### PR TITLE
fix: remove invalid css

### DIFF
--- a/src/components/GlobalStyle/index.js
+++ b/src/components/GlobalStyle/index.js
@@ -102,16 +102,6 @@ const globalStyles = css`
   p {
     margin: 0;
   }
-
-  input[type='number']::-webkit-outer-spin-button,
-  input[type='number']::-webkit-inner-spin-button {
-    variant: none;
-    margin: 0;
-  }
-
-  input[type='number'] {
-    variant: textfield;
-  }
 `
 export const GlobalStyle = ({ additionalStyles }) => (
   <Global styles={[globalStyles, ...additionalStyles]} />


### PR DESCRIPTION
Fixes CNS-3671

Invalid CSS code to be removed. This was causing input of type number to have an invalid `variant` css prop