### PR TITLE
fix: textbox can have number and text as value

### DIFF
--- a/src/components/TextBox/index.js
+++ b/src/components/TextBox/index.js
@@ -483,7 +483,7 @@ TextBox.propTypes = {
   unit: PropTypes.string,
   unitAlignment: PropTypes.oneOf(['center', 'flex-end', 'flex-start']),
   valid: PropTypes.bool,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   wrap: PropTypes.string,
 }
 


### PR DESCRIPTION
Textbox can have a number as much as a text as value in case we want to show an input with numbers.