### PR TITLE
fix: textbox random disabled

### DIFF
--- a/src/components/TextBox/__stories__/index.stories.mdx
+++ b/src/components/TextBox/__stories__/index.stories.mdx
@@ -108,6 +108,13 @@ import UncontrolledTextBox from './UncontrolledTextBox'
           label="Label"
         />
       ))}
+      <UncontrolledTextBox
+        size="medium"
+        disabled
+        defaultValue="Default value"
+        label="Label"
+        random="textbox"
+      />
     </Boxer>
   </Story>
 </Canvas>

--- a/src/components/TextBox/index.js
+++ b/src/components/TextBox/index.js
@@ -341,6 +341,7 @@ const TextBox = React.forwardRef(
           <Touchable
             onClick={handleRandomizeClick}
             onKeyDown={handleRandomizeKeyDown}
+            disabled={disabled}
             title="Randomize"
           >
             <Icon name="auto-fix" />


### PR DESCRIPTION
Minor changes to fix random touchable icon on a TextBox.

Before:
<img width="974" alt="Screenshot 2021-02-25 at 17 03 43" src="https://user-images.githubusercontent.com/15812968/109180900-a954d280-778b-11eb-802e-9f720238d3b0.png">

After:
<img width="977" alt="Screenshot 2021-02-25 at 17 04 00" src="https://user-images.githubusercontent.com/15812968/109180917-ad80f000-778b-11eb-9c95-9a20b761d36d.png">
