### PR TITLE
fix: add orange as text color in information

### DIFF
--- a/src/components/Typography/index.js
+++ b/src/components/Typography/index.js
@@ -135,6 +135,7 @@ const variantTags = {
 const textColors = {
   inherit: 'inherit',
   alert: colors.orange,
+  orange: colors.orange,
   white: colors.white,
   darkBlack: colors.gray950,
   lightBlack: colors.gray700,


### PR DESCRIPTION
As icon doesn't recognise `alert` as a color I added `orange` color in information component.