### PR TITLE
fix(richselect): fixed noTopLabel

### DIFF
--- a/src/components/RichSelect/__stories__/index.stories.mdx
+++ b/src/components/RichSelect/__stories__/index.stories.mdx
@@ -76,12 +76,38 @@ import * as animations from '../../../utils/animations'
   </Story>
 </Canvas>
 
+### No Label
+
+<Canvas>
+  <Story name="No Label" height="175px">
+    <Box m={2}>
+      <RichSelect name="label" noTopLabel>
+        <RichSelect.Option value="a">Option A</RichSelect.Option>
+        <RichSelect.Option value="b">Option B</RichSelect.Option>
+      </RichSelect>
+    </Box>
+  </Story>
+</Canvas>
+
+### Required
+
+<Canvas>
+  <Story name="Required" height="175px">
+    <Box m={2}>
+      <RichSelect name="required" required>
+        <RichSelect.Option value="a">Option A</RichSelect.Option>
+        <RichSelect.Option value="b">Option B</RichSelect.Option>
+      </RichSelect>
+    </Box>
+  </Story>
+</Canvas>
+
 ### Disabled
 
 <Canvas>
   <Story name="Disabled" height="100px">
     <Box m={2}>
-      <RichSelect name="disabled" disabled>
+      <RichSelect name="disabled" disabled value="a">
         <RichSelect.Option value="a">Option A</RichSelect.Option>
         <RichSelect.Option value="b">Option B</RichSelect.Option>
       </RichSelect>
@@ -94,24 +120,11 @@ import * as animations from '../../../utils/animations'
 <Canvas>
   <Story name="Option Disabled" height="175px">
     <Box m={2}>
-      <RichSelect name="disabled">
+      <RichSelect name="option-disabled">
         <RichSelect.Option value="a">Option A</RichSelect.Option>
         <RichSelect.Option value="b" disabled>
           Option B
         </RichSelect.Option>
-      </RichSelect>
-    </Box>
-  </Story>
-</Canvas>
-
-### Required
-
-<Canvas>
-  <Story name="Required" height="175px">
-    <Box m={2}>
-      <RichSelect name="required" required>
-        <RichSelect.Option value="11">11:00</RichSelect.Option>
-        <RichSelect.Option value="12">12:00</RichSelect.Option>
       </RichSelect>
     </Box>
   </Story>
@@ -250,7 +263,7 @@ of RichSelect with an external way (check example with button).
   </Story>
 </Canvas>
 
-### Exemple
+### Example
 
 <Canvas>
   <Story name="Exemple with custom LoadingIndicator" height="175px">

--- a/src/components/RichSelect/index.js
+++ b/src/components/RichSelect/index.js
@@ -86,7 +86,13 @@ const getOptionColor = state => {
   return { backgroundColor, color }
 }
 
-const getSelectStyles = (error, customStyle, animation, animationDuration) => ({
+const getSelectStyles = (
+  error,
+  customStyle,
+  animation,
+  animationDuration,
+  noTopLabel,
+) => ({
   control: (provided, state) => ({
     ...provided,
     transition: 'border-color 200ms ease, box-shadow 200ms ease',
@@ -144,7 +150,7 @@ const getSelectStyles = (error, customStyle, animation, animationDuration) => ({
   }),
   singleValue: (provided, state) => ({
     ...provided,
-    marginTop: !state.hasValue || state.isDisabled ? 0 : '8px',
+    marginTop: !state.hasValue || state.isDisabled || noTopLabel ? 0 : '8px',
     marginLeft: state.hasValue && 0,
     marginRight: state.hasValue && 0,
     paddingLeft: state.hasValue && 0,
@@ -578,6 +584,7 @@ function RichSelect({
         customStyle,
         isAnimated && animation,
         animationDuration,
+        noTopLabel,
       )}
       options={
         options ||


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

When prop `noTopLabel` is added there is a margin top on the value. I added a condition to check if this prop is on and so not to add that margin like for `isMulti` prop.

#### The following changes where made:

1. Added `noTopLabel` inside of style and a condition to check if margin should be added or not

## Relevant logs and/or screenshots

Page | Before | After
:-   |  :-:   | -:
RichSelect |<img width="1041" alt="Screenshot 2021-03-26 at 14 44 16" src="https://user-images.githubusercontent.com/15812968/112640614-c7245e80-8e41-11eb-907a-4ae9b8e2903c.png">|<img width="1046" alt="Screenshot 2021-03-26 at 14 39 41" src="https://user-images.githubusercontent.com/15812968/112640294-7ca2e200-8e41-11eb-8b57-d052d1aad687.png">




