### PR TITLE
ci: migrate to github_token for container registry login test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         uses: docker/build-push-action@v2
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy
 
 on:
-  pull_request:
+  pull_request_target:
     types: ['opened', 'edited', 'reopened', 'synchronize']
   push:
     branches:


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

PAT is not mandatory anymore, we can use GITHUB_TOKEN to authenticate against Github CR

https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/