### PR TITLE
ci: safeguard deploy domain name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: Export custom variables
         run: |
-          SAFE_GITHUB_HEAD_REF_SLUG_URL=$(echo $GITHUB_HEAD_REF_SLUG_URL | rev | cut -c-38 | rev)
+          SAFE_GITHUB_HEAD_REF_SLUG_URL=$(echo $GITHUB_HEAD_REF_SLUG_URL | rev | cut -c-37 | rev)
           ([[ $REF == 'refs/heads/master' ]] && echo "BRANCH_SLUG=master" || echo "BRANCH_SLUG=$SAFE_GITHUB_HEAD_REF_SLUG_URL") >> $GITHUB_ENV
           ([[ $REF == 'refs/heads/master' ]] && echo "HOST=react.ui.scaleway.com" || echo "HOST=$SAFE_GITHUB_HEAD_REF_SLUG_URL.react.ui.scaleway.com") >> $GITHUB_ENV
 

--- a/.github/workflows/teardown_pull_request.yml
+++ b/.github/workflows/teardown_pull_request.yml
@@ -16,7 +16,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
       - name: Export custom variables
         run: |
-          SAFE_GITHUB_HEAD_REF_SLUG_URL=$(echo $GITHUB_HEAD_REF_SLUG_URL | rev | cut -c-38 | rev)
+          SAFE_GITHUB_HEAD_REF_SLUG_URL=$(echo $GITHUB_HEAD_REF_SLUG_URL | rev | cut -c-37 | rev)
           ([[ $REF == 'refs/heads/master' ]] && echo "BRANCH_SLUG=master" || echo "BRANCH_SLUG=$SAFE_GITHUB_HEAD_REF_SLUG_URL") >> $GITHUB_ENV
 
       - name: Set Docker context


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Common Name cannot be > 63 char by RFC, meaning we have a lot of error when we try to deploy and retrieve a certificate for it
This PR cap the deployed domain at 62 char