### PR TITLE
fix(DateInput): correct colors

### DIFF
--- a/src/components/DateInput/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/DateInput/__tests__/__snapshots__/index.test.js.snap
@@ -28,11 +28,11 @@ exports[`DateInput renders correctly currentLocale 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -55,7 +55,7 @@ exports[`DateInput renders correctly currentLocale 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -73,29 +73,29 @@ exports[`DateInput renders correctly currentLocale 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -342,11 +342,11 @@ exports[`DateInput renders correctly disabled 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -369,7 +369,7 @@ exports[`DateInput renders correctly disabled 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -387,29 +387,29 @@ exports[`DateInput renders correctly disabled 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -665,11 +665,11 @@ exports[`DateInput renders correctly error 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -692,7 +692,7 @@ exports[`DateInput renders correctly error 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -710,29 +710,29 @@ exports[`DateInput renders correctly error 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -1018,11 +1018,11 @@ exports[`DateInput renders correctly error disabled 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -1045,7 +1045,7 @@ exports[`DateInput renders correctly error disabled 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -1063,29 +1063,29 @@ exports[`DateInput renders correctly error disabled 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -1380,11 +1380,11 @@ exports[`DateInput renders correctly error disabled required 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -1407,7 +1407,7 @@ exports[`DateInput renders correctly error disabled required 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -1425,29 +1425,29 @@ exports[`DateInput renders correctly error disabled required 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -1762,11 +1762,11 @@ exports[`DateInput renders correctly min-max 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -1789,7 +1789,7 @@ exports[`DateInput renders correctly min-max 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -1807,29 +1807,29 @@ exports[`DateInput renders correctly min-max 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -2076,11 +2076,11 @@ exports[`DateInput renders correctly required 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -2103,7 +2103,7 @@ exports[`DateInput renders correctly required 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -2121,29 +2121,29 @@ exports[`DateInput renders correctly required 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 
@@ -2410,11 +2410,11 @@ exports[`DateInput renders correctly with default props 1`] = `
 
 .emotion-0 .calendar {
   font-family: 'Asap';
-  border-color: #eeeeff;
+  border-color: #dce1eb;
 }
 
 .emotion-0 .calendar .react-datepicker__header {
-  color: #151a2d;
+  color: #4a4f62;
   background-color: #fff;
   border-bottom: none;
   text-align: inherit;
@@ -2437,7 +2437,7 @@ exports[`DateInput renders correctly with default props 1`] = `
 
 .emotion-0 .calendar .react-datepicker__day-name {
   font-family: 'Asap';
-  color: #151a2d;
+  color: #4a4f62;
   font-weight: 500;
   font-size: 14px;
   line-height: 24px;
@@ -2455,29 +2455,29 @@ exports[`DateInput renders correctly with default props 1`] = `
 }
 
 .emotion-0 .calendar .react-datepicker__day--selected {
-  color: #a365f6;
+  color: #eeeeff;
   background-color: #4f0599;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day--keyboard-selected {
   color: #4f0599;
-  background-color: #e4edff;
+  background-color: #eeeeff;
   border-radius: 50%;
 }
 
 .emotion-0 .calendar .react-datepicker__day:hover {
   color: #4f0599;
   border-radius: 50%;
-  background-color: #e4edff;
+  background-color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled {
-  color: #f6f5f7;
+  color: #eeeeff;
 }
 
 .emotion-0 .calendar .react-datepicker__day--disabled:hover {
-  color: #f6f5f7;
+  color: #eeeeff;
   background-color: transparent;
 }
 

--- a/src/components/DateInput/index.js
+++ b/src/components/DateInput/index.js
@@ -34,10 +34,10 @@ const StyledWrapper = styled.div`
   }
   .calendar {
     font-family: 'Asap';
-    border-color: ${({ theme: { colors } }) => colors.gray200};
+    border-color: ${({ theme: { colors } }) => colors.gray300};
 
     ${PREFIX}__header {
-      color: ${({ theme: { colors } }) => colors.gray950};
+      color: ${({ theme: { colors } }) => colors.gray700};
       background-color: ${({ theme: { colors } }) => colors.white};
       border-bottom: none;
       text-align: inherit;
@@ -59,7 +59,7 @@ const StyledWrapper = styled.div`
 
     ${PREFIX}__day-name {
       font-family: 'Asap';
-      color: ${({ theme: { colors } }) => colors.gray950};
+      color: ${({ theme: { colors } }) => colors.gray700};
       font-weight: 500;
       font-size: 14px;
       line-height: 24px;
@@ -77,28 +77,28 @@ const StyledWrapper = styled.div`
     }
 
     ${PREFIX}__day--selected {
-      color: ${({ theme: { colors } }) => colors.lightViolet};
+      color: ${({ theme: { colors } }) => colors.gray200};
       background-color: ${({ theme: { colors } }) => colors.primary};
       border-radius: 50%;
     }
     ${PREFIX}__day--keyboard-selected {
       color: ${({ theme: { colors } }) => colors.primary};
-      background-color: ${({ theme: { colors } }) => colors.zumthor};
+      background-color: ${({ theme: { colors } }) => colors.gray200};
       border-radius: 50%;
     }
 
     ${PREFIX}__day: hover {
       color: ${({ theme: { colors } }) => colors.primary};
       border-radius: 50%;
-      background-color: ${({ theme: { colors } }) => colors.zumthor};
+      background-color: ${({ theme: { colors } }) => colors.gray200};
     }
 
     ${PREFIX}__day--disabled {
-      color: ${({ theme: { colors } }) => colors.gray100};
+      color: ${({ theme: { colors } }) => colors.gray200};
     }
 
     ${PREFIX}__day--disabled: hover {
-      color: ${({ theme: { colors } }) => colors.gray100};
+      color: ${({ theme: { colors } }) => colors.gray200};
       background-color: ${({ theme: { colors } }) => colors.transparent};
     }
   }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Little discrepancy between here and console

## Relevant logs and/or screenshots

Page | Before | After
:-   |  :-:   | -:
/?path=/docs/components-dateinput--controlled | <img width="325" alt="Screenshot 2021-04-12 at 14 43 42" src="https://user-images.githubusercontent.com/2802867/114396170-8779a880-9b9d-11eb-992e-301bf937a03d.png"> | <img width="353" alt="Screenshot 2021-04-12 at 14 43 15" src="https://user-images.githubusercontent.com/2802867/114396162-86487b80-9b9d-11eb-9c9e-65dd349d71ec.png">




