### PR TITLE
fix(tooltip): fixed prop spreading

### DIFF
--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -55,7 +55,7 @@ const StyledTooltip = styled(Box, {
 const Tooltip = ({
   animated,
   children,
-  text = '',
+  text,
   placement,
   visible,
   variant,
@@ -106,8 +106,8 @@ const Tooltip = ({
       <TooltipReference {...tooltip} ref={children.ref}>
         {finalChildren}
       </TooltipReference>
-      <ReakitTooltip {...tooltip}>
-        <StyledTooltip variant={variant} {...props}>
+      <ReakitTooltip {...tooltip} {...props}>
+        <StyledTooltip variant={variant}>
           <TooltipArrow {...tooltip} />
           {text}
         </StyledTooltip>

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -60,6 +60,7 @@ const Tooltip = ({
   visible,
   variant,
   baseId,
+  zIndex,
   ...props
 }) => {
   const tooltip = useTooltipState({ animated, placement, visible, baseId })
@@ -106,8 +107,8 @@ const Tooltip = ({
       <TooltipReference {...tooltip} ref={children.ref}>
         {finalChildren}
       </TooltipReference>
-      <ReakitTooltip {...tooltip} {...props}>
-        <StyledTooltip variant={variant}>
+      <ReakitTooltip {...tooltip} style={{ zIndex }}>
+        <StyledTooltip variant={variant} {...props}>
           <TooltipArrow {...tooltip} />
           {text}
         </StyledTooltip>
@@ -128,6 +129,7 @@ Tooltip.propTypes = {
     PropTypes.node,
     PropTypes.func,
   ]),
+  zIndex: PropTypes.number,
 }
 
 Tooltip.defaultProps = {
@@ -138,6 +140,7 @@ Tooltip.defaultProps = {
   text: '',
   baseId: undefined,
   children: null,
+  zIndex: undefined,
 }
 
 export default Tooltip

--- a/src/components/TooltipIcon/__tests__/__snapshots__/index.js.snap
+++ b/src/components/TooltipIcon/__tests__/__snapshots__/index.js.snap
@@ -50,6 +50,12 @@ exports[`TooltipIcon renders with default props 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
+.emotion-1.emotion-1 {
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+}
+
 [data-enter] .emotion-1 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
@@ -66,7 +72,6 @@ exports[`TooltipIcon renders with default props 1`] = `
       id="test"
       role="tooltip"
       style="display: none; position: fixed; left: 100%; top: 100%; pointer-events: none;"
-      width="max-content"
     >
       <div
         class="emotion-0 emotion-1"

--- a/src/components/TooltipIcon/__tests__/__snapshots__/index.js.snap
+++ b/src/components/TooltipIcon/__tests__/__snapshots__/index.js.snap
@@ -50,12 +50,6 @@ exports[`TooltipIcon renders with default props 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.emotion-1.emotion-1 {
-  width: -webkit-max-content;
-  width: -moz-max-content;
-  width: max-content;
-}
-
 [data-enter] .emotion-1 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
@@ -72,6 +66,7 @@ exports[`TooltipIcon renders with default props 1`] = `
       id="test"
       role="tooltip"
       style="display: none; position: fixed; left: 100%; top: 100%; pointer-events: none;"
+      width="max-content"
     >
       <div
         class="emotion-0 emotion-1"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

We should spread props on ReakitTooltip not in his children. This can allow us to define a zIndex and so to be able to show a tooltip inside of a modal.



