### PR TITLE
ci: correct deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Build
         uses: docker/build-push-action@v2
         env:


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

Apparently the GITHUB_TOKEN way of authenticating to GCR is not yet stable 
So back to using a PAT for now

https://github.community/t/403-error-on-container-registry-push-from-github-action/173071/10


Still won't work for dependabot PR but it's a start to have easier reviews