### PR TITLE
fix(action): add forwardRef to button

### DIFF
--- a/src/components/Action/index.js
+++ b/src/components/Action/index.js
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { forwardRef } from 'react'
 import Button, { buttonVariants } from '../Button'
 import Icon, { icons } from '../Icon'
 import Tooltip from '../Tooltip'
@@ -17,22 +17,24 @@ const action = rounded => css`
   ${rounded && `border-radius: 16px;`}
 `
 
-const Action = ({ name, size, children, tooltip, rounded, ...props }) => {
-  if (!name && !children) {
-    throw new Error(
-      'Action component need to have either children (as string) or a name prop',
-    )
-  }
+const Action = forwardRef(
+  ({ name, size, children, tooltip, rounded, ...props }, ref) => {
+    if (!name && !children) {
+      throw new Error(
+        'Action component need to have either children (as string) or a name prop',
+      )
+    }
 
-  return (
-    <Tooltip text={tooltip}>
-      <Button css={action(rounded)} {...props}>
-        {name && <Icon size={size} name={name} />}
-        {children}
-      </Button>
-    </Tooltip>
-  )
-}
+    return (
+      <Tooltip text={tooltip}>
+        <Button ref={ref} css={action(rounded)} {...props}>
+          {name && <Icon size={size} name={name} />}
+          {children}
+        </Button>
+      </Tooltip>
+    )
+  },
+)
 
 Action.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

When you use Action component as disclosure on modal, you will have an error on ref. Tooltip cannot forward ref if's not render.

<img width="820" alt="Capture d’écran 2021-05-28 à 12 08 51" src="https://user-images.githubusercontent.com/14060273/119969330-b661a780-bfae-11eb-8353-4f56876bda25.png">

#### The following changes where made:

1. Add ForwardRef to button





