### PR TITLE
fix: richselect option

### DIFF
--- a/src/components/RichSelect/index.js
+++ b/src/components/RichSelect/index.js
@@ -631,7 +631,7 @@ const RichSelectWithRef = React.forwardRef((props, ref) => (
   <RichSelect innerRef={ref} {...props} />
 ))
 
-RichSelectWithRef.Option = {}
+RichSelectWithRef.Option = () => null
 
 RichSelectWithRef.defaultProps = {
   animation: 'pulse',


### PR DESCRIPTION
## Type

- Bug

### Summarise concisely:

#### What is expected?

RichSelect Option : no warning on render because it's an object

#### The following changes where made:

1. Fix RichSelect.Option component


