### PR TITLE
fix(button): button with as link doesn t forward disabled property

### DIFF
--- a/src/components/Button/__stories__/index.stories.mdx
+++ b/src/components/Button/__stories__/index.stories.mdx
@@ -191,6 +191,19 @@ import Button, { buttonSizes, buttonVariants } from '..'
   </Story>
 </Canvas>
 
+<Description>
+  In case, you would like to disabled a link, this link will be transformed into
+  a button.
+</Description>
+
+<Canvas>
+  <Story name="Link delegation with disabled">
+    <Button to="https://scaleway.com" target="_blank" disabled>
+      Scaleway
+    </Button>
+  </Story>
+</Canvas>
+
 ## API
 
 <ArgsTable of={Button} />

--- a/src/components/Button/__tests__/__snapshots__/index.js.snap
+++ b/src/components/Button/__tests__/__snapshots__/index.js.snap
@@ -430,6 +430,99 @@ exports[`Button should render correctly when acting as Link 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Button should render correctly when acting as Link with disabled props 1`] = `
+<DocumentFragment>
+  .emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  border-radius: 4px;
+  border-width: 0;
+  cursor: pointer;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  outline: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-weight: 500;
+  -webkit-transition: color 150ms ease-in-out,background-color 150ms ease-in-out,border-color 150ms ease-in-out;
+  transition: color 150ms ease-in-out,background-color 150ms ease-in-out,border-color 150ms ease-in-out;
+  background-color: #4f0599;
+  color: #fff;
+  font-size: 16px;
+  line-height: 32px;
+  font-weight: 500;
+  padding: 8px 16px;
+  cursor: default;
+  pointer-events: none;
+  color: #d4dae7;
+  background-color: #fafafb;
+  border-color: #fafafb;
+  box-shadow: none;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  color: #fff;
+  background-color: #420480;
+}
+
+.emotion-1:focus {
+  box-shadow: 0 0 0 2px rgba(79,5,153,0.25);
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+<button
+    aria-disabled="true"
+    class="emotion-0 emotion-1"
+    disabled=""
+    to="/"
+    type="button"
+  >
+    <div
+      class="emotion-2 emotion-3"
+    >
+      Hello
+    </div>
+  </button>
+</DocumentFragment>
+`;
+
 exports[`Button should render correctly when acting as dom link 1`] = `
 <DocumentFragment>
   .emotion-1 {

--- a/src/components/Button/__tests__/index.js
+++ b/src/components/Button/__tests__/index.js
@@ -34,6 +34,13 @@ describe('Button', () => {
   test(`should render correctly when acting as Link`, () =>
     shouldMatchEmotionSnapshot(<Button to="/">Hello</Button>))
 
+  test(`should render correctly when acting as Link with disabled props`, () =>
+    shouldMatchEmotionSnapshot(
+      <Button to="/" disabled>
+        Hello
+      </Button>,
+    ))
+
   test(`should render correctly when acting as dom link`, () =>
     shouldMatchEmotionSnapshot(<Button href="/">Hello</Button>))
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -276,11 +276,12 @@ function FwdButton({
   ...props
 }) {
   const as = useMemo(() => {
+    if (disabled) return 'button'
     if (to) return UniversalLink
     if (href || download) return 'a'
 
     return 'button'
-  }, [to, href, download])
+  }, [disabled, to, href, download])
 
   const displayProgressOnly = !children
 

--- a/src/components/Modal/__stories__/index.stories.mdx
+++ b/src/components/Modal/__stories__/index.stories.mdx
@@ -6,7 +6,7 @@ import {
   Meta,
   Story,
 } from '@storybook/addon-docs/blocks'
-import { Box, Button, Modal } from '../..'
+import { Box, Button, Modal, Switch } from '../..'
 import { MODAL_ANIMATION, MODAL_PLACEMENT, MODAL_WIDTH } from '../index'
 
 <Meta title="Components/Modal" component={Modal} />
@@ -22,6 +22,20 @@ import { MODAL_ANIMATION, MODAL_PLACEMENT, MODAL_WIDTH } from '../index'
 <Canvas>
   <Story name="Basic">
     <Modal disclosure={() => <Button>Open Modal</Button>}>
+      <Box p={4}>Content should be present in center of the modal</Box>
+    </Modal>
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="switch">
+    <Modal
+      disclosure={() => (
+        <Box>
+          <Switch>Open Modal</Switch>
+        </Box>
+      )}
+    >
       <Box p={4}>Content should be present in center of the modal</Box>
     </Modal>
   </Story>


### PR DESCRIPTION
…rrectly

## Summary

## Type

- Bug

### Summarise concisely:
#### What is expected?

Disabled button with as=Link,a doesn't work

#### The following changes where made:

Checking if component is disabled before forward as property

## Relevant logs and/or screenshots

In this case, Button is disabled.
<img width="222" alt="Capture d’écran 2021-06-07 à 18 14 52" src="https://user-images.githubusercontent.com/14060273/121054089-4c21e180-c7bc-11eb-9f7c-f94bfc3c4431.png">




