### PR TITLE
fix(Slider): correct drag image object

### DIFF
--- a/src/components/Slider/index.js
+++ b/src/components/Slider/index.js
@@ -3,10 +3,6 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
 import Box from '../Box'
 
-const blankImg = {}
-blankImg.src =
-  'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
-
 const StyledWrapper = styled(Box)`
   position: relative;
   margin-left: -100px;
@@ -134,6 +130,10 @@ const Slider = ({ children, ...props }) => {
           setDragStartX(e.pageX)
         }}
         onDragStart={e => {
+          const blankImg = new Image()
+          blankImg.src =
+            'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=='
+
           e.dataTransfer.setDragImage(blankImg, 0, 0)
           setDragStartX(e.clientX)
         }}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

We currently have some exception thrown in the console because the setDragImage need an `img` element as first argument

## Relevant logs and/or screenshots

To reproduce try to scroll via dragging the slider in the master deployment and there should be an error, there should be none in this branch