### PR TITLE
fix(menu): item font-weight

### DIFF
--- a/src/components/Menu/Item.js
+++ b/src/components/Menu/Item.js
@@ -38,6 +38,7 @@ const styles = {
     display: block;
     font-size: 14px;
     line-height: 22px;
+    font-weight: inherit;
     padding: 4px 8px;
     color: ${theme.colors.gray700};
     border: 0;

--- a/src/components/Menu/__tests__/__snapshots__/index.js.snap
+++ b/src/components/Menu/__tests__/__snapshots__/index.js.snap
@@ -40,6 +40,7 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -129,6 +130,7 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -235,6 +237,7 @@ exports[`Menu Menu.Item render with default props 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -323,6 +326,7 @@ exports[`Menu Menu.Item render with default props 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -428,6 +432,7 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -529,6 +534,7 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -647,6 +653,7 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -741,6 +748,7 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -852,6 +860,7 @@ exports[`Menu Menu.Item render with variant nav 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -953,6 +962,7 @@ exports[`Menu Menu.Item render with variant nav 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -1154,6 +1164,7 @@ exports[`Menu placement render bottom 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -1317,6 +1328,7 @@ exports[`Menu placement render bottom 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -1523,6 +1535,7 @@ exports[`Menu placement render bottom-end 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -1687,6 +1700,7 @@ exports[`Menu placement render bottom-end 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -1893,6 +1907,7 @@ exports[`Menu placement render bottom-start 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -2057,6 +2072,7 @@ exports[`Menu placement render bottom-start 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -2262,6 +2278,7 @@ exports[`Menu placement render top 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -2425,6 +2442,7 @@ exports[`Menu placement render top 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -2631,6 +2649,7 @@ exports[`Menu placement render top-end 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -2795,6 +2814,7 @@ exports[`Menu placement render top-end 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3001,6 +3021,7 @@ exports[`Menu placement render top-start 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3165,6 +3186,7 @@ exports[`Menu placement render top-start 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3370,6 +3392,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3533,6 +3556,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3738,6 +3762,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3839,6 +3864,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -3999,6 +4025,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -4100,6 +4127,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -4326,6 +4354,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -4489,6 +4518,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -4694,6 +4724,7 @@ exports[`Menu renders with modal={false} 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;
@@ -4857,6 +4888,7 @@ exports[`Menu renders with modal={false} 1`] = `
   display: block;
   font-size: 14px;
   line-height: 22px;
+  font-weight: inherit;
   padding: 4px 8px;
   color: #4a4f62;
   border: 0;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

The font weight was herited from Button component with a font-weight: 500

Before:

<img width="204" alt="Capture d’écran 2021-06-16 à 17 13 40" src="https://user-images.githubusercontent.com/14060273/122245701-3dc37c00-cec6-11eb-9614-e142fd650a50.png">


After:
<img width="164" alt="Capture d’écran 2021-06-16 à 17 13 30" src="https://user-images.githubusercontent.com/14060273/122245720-42883000-cec6-11eb-994c-7174e649fca6.png">





