### PR TITLE
docs: add e and g documentation

### DIFF
--- a/src/components/Expandable/__stories__/index.stories.mdx
+++ b/src/components/Expandable/__stories__/index.stories.mdx
@@ -1,39 +1,101 @@
-import { Canvas, Description, Meta, Story } from '@storybook/addon-docs'
+import {
+  ArgsTable,
+  Canvas,
+  Description,
+  Meta,
+  Story,
+} from '@storybook/addon-docs'
 import { useState } from 'react'
 import Expandable from '..'
-import { Icon, Touchable, Typography } from '../..'
+import Button from '../../Button'
 
 <Meta title="Components/Expandable" component={Expandable} />
 
 # Expandable
 
-<Description>Expandable container.</Description>
-
-# Basic
-
 <Description>
-  Expand using `opened`. Set `height` with the approximate height of the
-  container to have a beautiful animation.
+  An Expandable is a container that can hide or show its content
 </Description>
 
 <Canvas>
-  <Story name="basic">
+  <Story name="Basic">
     {() => {
       const [toggled, onToggle] = useState(false)
       const toggle = () => onToggle(state => !state)
       return (
         <>
-          <Touchable onClick={toggle}>
-            <Typography variant="lead-block" my={0}>
-              Add Some Advanced Options?
-              <Icon name={toggled ? 'minus-box-outline' : 'plus-box-outline'} />
-            </Typography>
-          </Touchable>
+          <Button
+            icon={toggled ? 'minus-box-outline' : 'plus-box-outline'}
+            onClick={toggle}
+          >
+            Click me
+          </Button>
           <Expandable height={24} opened={toggled}>
-            Advanced options
+            I&lsquo;m an Expandable content
           </Expandable>
         </>
       )
     }}
   </Story>
 </Canvas>
+
+## Opened
+
+<Description>
+  Set `opened` prop to show or hide the content of an Expandable.
+</Description>
+
+<Canvas>
+  <Story name="Opened">
+    {() => {
+      const [toggled, onToggle] = useState(false)
+      const toggle = () => onToggle(state => !state)
+      return (
+        <>
+          <Button
+            icon={toggled ? 'minus-box-outline' : 'plus-box-outline'}
+            onClick={toggle}
+          >
+            Click me to {toggled ? 'hide' : 'show'} content
+          </Button>
+          <Expandable opened={toggled}>
+            I&lsquo;m a visible Expandable content
+          </Expandable>
+        </>
+      )
+    }}
+  </Story>
+</Canvas>
+
+## Height
+
+<Description>
+  Set `height` prop to have a beautiful animation when opening and closing. Put
+  something near your content height.
+</Description>
+
+<Canvas>
+  <Story name="Height">
+    {() => {
+      const [toggled, onToggle] = useState(false)
+      const toggle = () => onToggle(state => !state)
+      return (
+        <>
+          <Button
+            icon={toggled ? 'minus-box-outline' : 'plus-box-outline'}
+            onClick={toggle}
+          >
+            Click me to {toggled ? 'hide' : 'show'} content
+          </Button>
+          <Expandable height={500} opened={toggled}>
+            I&lsquo;m an Expandable content with a beautiful animation
+          </Expandable>
+        </>
+      )
+    }}
+  </Story>
+</Canvas>
+
+## API
+
+<ArgsTable of={Expandable} />

--- a/src/components/Expandable/index.js
+++ b/src/components/Expandable/index.js
@@ -28,8 +28,17 @@ const Expandable = ({ opened, height, children, ...props }) => (
 )
 
 Expandable.propTypes = {
+  /**
+   * The content to display
+   */
   children: PropTypes.node.isRequired,
+  /**
+   * The maxHeight of the content to make the opening and closing animation
+   */
   height: PropTypes.number,
+  /**
+   * To display or not the content
+   */
   opened: PropTypes.bool,
 }
 

--- a/src/components/ExtendedReminder/__stories__/index.stories.mdx
+++ b/src/components/ExtendedReminder/__stories__/index.stories.mdx
@@ -1,132 +1,128 @@
-import { Canvas, Description, Meta, Story } from '@storybook/addon-docs'
+import {
+  ArgsTable,
+  Canvas,
+  Description,
+  Meta,
+  Story,
+} from '@storybook/addon-docs'
 import ExtendedReminder from '..'
 
 <Meta title="Components/ExtendedReminder" component={ExtendedReminder} />
 
 # ExtendedReminder
 
-<Description>ExtendedReminder //TODO:</Description>
+<Description>
+  ExtendedReminder is a component to display multiple information in a single
+  container. To make it work you need to pass `title`, `badgeText` and `text`
+  props at least.
+</Description>
 
-# Basic
-
-<Canvas isColumn>
-  <Story name="warning">
+<Canvas>
+  <Story name="Basic">
     <ExtendedReminder
-      variant="warning"
-      icon="alert"
       badgeText="10 days remaining"
-      to="/"
-      mb={4}
       title="Verify your credit card"
       text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-  <Story name="error">
-    <ExtendedReminder
-      variant="error"
-      icon="lock"
-      badgeText="10 days remaining"
-      to="/"
-      mb={4}
-      title="Verify your credit card"
-      text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-  <Story name="info">
-    <ExtendedReminder
-      variant="info"
-      icon="check"
-      badgeText="10 days remaining"
-      to="/"
-      mb={4}
-      title="Verify your credit card"
-      text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-  <Story name="success">
-    <ExtendedReminder
-      variant="success"
-      icon="checkbox-marked-circle-outline"
-      badgeText="SUCCESS"
-      to="/"
-      title="Your ID have been verified"
-      text="You now have a Build level account. The Build level allows you to order any type of resources and scale your project as it grows."
-      linkText="Learn more about Build Level"
     />
   </Story>
 </Canvas>
 
-# With onClick
-
-<Canvas isColumn>
-  <Story name="on-click-warning">
-    <ExtendedReminder
-      variant="warning"
-      icon="alert"
-      badgeText="10 days remaining"
-      onClick={() => console.log('clicked')}
-      mb={4}
-      title="Verify your credit card"
-      text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-  <Story name="on-click-error">
-    <ExtendedReminder
-      variant="error"
-      icon="lock"
-      badgeText="10 days remaining"
-      onClick={() => console.log('clicked')}
-      mb={4}
-      title="Verify your credit card"
-      text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-  <Story name="on-click-info">
-    <ExtendedReminder
-      variant="info"
-      icon="check"
-      badgeText="10 days remaining"
-      onClick={() => console.log('clicked')}
-      mb={4}
-      title="Verify your credit card"
-      text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-  <Story name="on-click-success">
-    <ExtendedReminder
-      variant="success"
-      icon="check"
-      badgeText="10 days remaining"
-      onClick={() => console.log('clicked')}
-      title="Verify your credit card"
-      text="Enter the code we send to your bank account to validate your payment method."
-      linkText="Verify my credit card"
-    />
-  </Story>
-</Canvas>
-
-# Without link
+## Variants
 
 <Description>
-  If you don&apos;t pass a `linkText` props there will be no link at the end of
-  the block
+  By using `variant` prop you can cusomize the component.
 </Description>
 
 <Canvas isColumn>
-  <Story name="without link">
+  <Story name="Variants">
     <ExtendedReminder
       variant="warning"
       icon="alert"
-      badgeText="10 days remaining"
+      badgeText="warning variant"
       mb={4}
+      title="Verify your credit card"
+      text="Enter the code we send to your bank account to validate your payment method."
+    />
+    <ExtendedReminder
+      variant="error"
+      icon="lock"
+      badgeText="error variant"
+      mb={4}
+      title="Verify your credit card"
+      text="Enter the code we send to your bank account to validate your payment method."
+    />
+    <ExtendedReminder
+      variant="info"
+      icon="check"
+      badgeText="info variant"
+      mb={4}
+      title="Verify your credit card"
+      text="Enter the code we send to your bank account to validate your payment method."
+    />
+    <ExtendedReminder
+      variant="success"
+      icon="checkbox-marked-circle-outline"
+      badgeText="success variant"
+      title="Your ID have been verified"
+      text="You now have a Build level account. The Build level allows you to order any type of resources and scale your project as it grows."
+    />
+  </Story>
+</Canvas>
+
+## OnClick
+
+<Description>
+  By using `onClick` prop you can add an event listener when the user click on
+  the component
+</Description>
+
+<Canvas isColumn>
+  <Story name="OnClick">
+    <ExtendedReminder
+      badgeText="onClick (toggle your console)"
+      onClick={() => console.log('clicked')}
       title="Verify your credit card"
       text="Enter the code we send to your bank account to validate your payment method."
     />
   </Story>
 </Canvas>
+
+## Icon
+
+<Description>By using `icon` prop you set the icon to use</Description>
+
+<Canvas isColumn>
+  <Story name="Icon">
+    <ExtendedReminder
+      icon="alert"
+      badgeText="Custom icon on my left"
+      title="Verify your credit card"
+      text="Enter the code we send to your bank account to validate your payment method."
+    />
+  </Story>
+</Canvas>
+
+## Link
+
+<Description>
+  If you pass a `linkText` props there will be a link at the end of the block
+  that redirect to the link set in `to` prop.
+</Description>
+
+<Canvas isColumn>
+  <Story name="Link">
+    <ExtendedReminder
+      variant="warning"
+      icon="alert"
+      badgeText="10 days remaining"
+      title="Verify your credit card"
+      text="Enter the code we send to your bank account to validate your payment method."
+      linkText="Verify my credit card"
+      to="/"
+    />
+  </Story>
+</Canvas>
+
+## API
+
+<ArgsTable of={ExtendedReminder} />

--- a/src/components/ExtendedReminder/index.js
+++ b/src/components/ExtendedReminder/index.js
@@ -117,12 +117,27 @@ const ExtendedReminder = ({
 }
 
 ExtendedReminder.propTypes = {
+  /**
+   * The text to be placed in the top badge
+   */
   badgeText: PropTypes.string.isRequired,
+  /**
+   * The icon to use in the badge
+   */
   icon: PropTypes.string.isRequired,
+  /**
+   * The link text to display at the end
+   */
   linkText: PropTypes.string,
+  /**
+   * MouseEvent listener on the component
+   */
   onClick: PropTypes.func,
   text: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
+  /**
+   * The link that linkText prop need to redirect to.
+   */
   to: PropTypes.string,
   variant: PropTypes.oneOf(Object.keys(variants)),
 }

--- a/src/components/Grid/Col.js
+++ b/src/components/Grid/Col.js
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { screens, space } from '../../theme'
 import { up } from '../../utils'
 import Box from '../Box'
@@ -10,7 +11,7 @@ const getSizeWidth = (size, nbColumns) =>
   `${Math.round((size / nbColumns) * 10 ** 6) / 10 ** 4}%`
 const query = (brk, style) => (screens[brk] === 0 ? style : up(brk, style))
 
-const Col = styled(Box, {
+const StyledCol = styled(Box, {
   shouldForwardProp: prop =>
     ![...Object.keys(screens), 'gutter'].includes(prop),
 })`
@@ -64,6 +65,8 @@ const Col = styled(Box, {
         )
       })}
 `
+
+const Col = props => <StyledCol {...props} />
 
 const PropTypesBreakpoint = PropTypes.oneOfType([
   PropTypes.bool,

--- a/src/components/Grid/Grid.js
+++ b/src/components/Grid/Grid.js
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { screens, space } from '../../theme'
 import { up } from '../../utils'
 import Box from '../Box'
@@ -13,7 +14,7 @@ const gridMaxWidths = {
 
 const query = (brk, style) => (screens[brk] === 0 ? style : up(brk, style))
 
-const Grid = styled(Box, {
+const StyledGrid = styled(Box, {
   shouldForwardProp: prop => !['gutter', 'fluid'].includes(prop),
 })`
   width: 100%;
@@ -31,6 +32,8 @@ const Grid = styled(Box, {
         )}
 `
 
+const Grid = props => <StyledGrid {...props} />
+
 Grid.defaultProps = {
   fluid: false,
   gutter: 1,
@@ -38,7 +41,13 @@ Grid.defaultProps = {
 
 Grid.propTypes = {
   children: PropTypes.node.isRequired,
+  /**
+   * If true, take all the parent width
+   */
   fluid: PropTypes.bool,
+  /**
+   * padding left and right space
+   */
   gutter: PropTypes.oneOf(Object.keys(space).map(Number)),
 }
 

--- a/src/components/Grid/Row.js
+++ b/src/components/Grid/Row.js
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
+import React from 'react'
 import { space } from '../../theme'
 import Box from '../Box'
 
-const Row = styled(Box, {
+const StyledRow = styled(Box, {
   shouldForwardProp: prop => !['gutter'].includes(prop),
 })`
   box-sizing: border-box;
@@ -14,7 +15,10 @@ const Row = styled(Box, {
   margin-right: ${({ gutter }) => `-${space[gutter]}`};
 `
 
+const Row = props => <StyledRow {...props} />
+
 Row.defaultProps = {
+  children: null,
   gutter: 1,
 }
 

--- a/src/components/Grid/__stories__/index.stories.mdx
+++ b/src/components/Grid/__stories__/index.stories.mdx
@@ -12,19 +12,16 @@ import ColWithBackground from './ColWithBackground'
 
 <Meta title="Components/Grid" component={Grid} />
 
-# Grid
+# Grid, Row, Col
 
-<Description>
-  `Grid`, `Row` and `Col` behaves the same as the one from Smooth UI. [original
-  ref](https://smooth-ui-v10.smooth-code.com/docs-basics-grid)
-</Description>
+These three component are built to organize your content
 
-<Description>Resize the window to see the responsive properties</Description>
-
-## Simple usage
+- `Grid` allow you to create a container with some padding.
+- `Row` is a flex container that allow you to create a row with some margin left and right.
+- `Col` allow you to create a col where you can place your content.
 
 <Canvas>
-  <Story name="simple">
+  <Story name="Basic">
     <Grid>
       <Row>
         <ColWithBackground>One</ColWithBackground>
@@ -35,7 +32,7 @@ import ColWithBackground from './ColWithBackground'
   </Story>
 </Canvas>
 
-## fixed vs fluid width
+## Fluid
 
 <Description>
   If you pass the `fluid` prop the grid will take the full width of its
@@ -43,19 +40,7 @@ import ColWithBackground from './ColWithBackground'
 </Description>
 
 <Canvas>
-  <Story name="fixed width">
-    <Grid>
-      <Row>
-        <ColWithBackground>One</ColWithBackground>
-        <ColWithBackground>Two</ColWithBackground>
-        <ColWithBackground>Three</ColWithBackground>
-      </Row>
-    </Grid>
-  </Story>
-</Canvas>
-
-<Canvas>
-  <Story name="fluid width">
+  <Story name="Fluid">
     <Grid fluid>
       <Row>
         <ColWithBackground>One</ColWithBackground>
@@ -66,10 +51,38 @@ import ColWithBackground from './ColWithBackground'
   </Story>
 </Canvas>
 
+## Gutter
+
+<Description>
+  If you pass the `gutter` prop the component will have more padding and margin
+</Description>
+
+<Canvas>
+  <Story name="Gutter">
+    <Grid fluid gutter={2}>
+      <Row>
+        <ColWithBackground>One</ColWithBackground>
+        <ColWithBackground>Two</ColWithBackground>
+        <ColWithBackground>Three</ColWithBackground>
+      </Row>
+      <Row gutter={2}>
+        <ColWithBackground>One</ColWithBackground>
+        <ColWithBackground>Two</ColWithBackground>
+        <ColWithBackground>Three</ColWithBackground>
+      </Row>
+      <Row>
+        <ColWithBackground gutter={2}>One</ColWithBackground>
+        <ColWithBackground>Two</ColWithBackground>
+        <ColWithBackground>Three</ColWithBackground>
+      </Row>
+    </Grid>
+  </Story>
+</Canvas>
+
 ## Complex responsive example
 
 <Canvas>
-  <Story name="complex responsive">
+  <Story name="Complex responsive">
     <Grid>
       <Row>
         <ColWithBackground
@@ -100,6 +113,16 @@ import ColWithBackground from './ColWithBackground'
   </Story>
 </Canvas>
 
+## API
+
+### Grid
+
 <ArgsTable of={Grid} />
-<ArgsTable of={Col} />
+
+### Row
+
 <ArgsTable of={Row} />
+
+### Col
+
+<ArgsTable of={Col} />


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Documentation on E and G components

#### The following changes where made:

1. Add documentation on proptypes

2. Update stories


## Relevant logs and/or screenshots
<img width="268" alt="Capture d’écran 2021-06-22 à 13 52 22" src="https://user-images.githubusercontent.com/24531136/122919915-1571cc80-d361-11eb-9ebc-53089bc93d8a.png">
<img width="684" alt="Capture d’écran 2021-06-22 à 13 52 59" src="https://user-images.githubusercontent.com/24531136/122919993-29b5c980-d361-11eb-8b66-c84b4e89427b.png">
<img width="257" alt="Capture d’écran 2021-06-22 à 13 53 18" src="https://user-images.githubusercontent.com/24531136/122920035-3508f500-d361-11eb-9353-e56fbdafdfa7.png">




