### PR TITLE
fix(menu): allow toggle props

### DIFF
--- a/src/components/Alert/__stories__/index.stories.mdx
+++ b/src/components/Alert/__stories__/index.stories.mdx
@@ -4,7 +4,7 @@ import {
   Description,
   Meta,
   Story,
-} from '@storybook/addon-docs/blocks'
+} from '@storybook/addon-docs'
 import Alert, { alertTypes, alertVariants } from '..'
 import { Box } from '../..'
 

--- a/src/components/Menu/Item.js
+++ b/src/components/Menu/Item.js
@@ -8,13 +8,13 @@ const styles = {
     border: 0;
   `,
   danger: theme => css`
-    color: ${theme.colors.red};
     display: inline-block;
+    color: ${theme.colors.red};
     &:hover,
     &:focus {
-      color: ${theme.colors.darkRed};
+      color: ${theme.colors.crimson};
       svg {
-        fill: ${theme.colors.darkRed};
+        fill: ${theme.colors.crimson};
       }
     }
     svg {

--- a/src/components/Menu/__stories__/index.stories.mdx
+++ b/src/components/Menu/__stories__/index.stories.mdx
@@ -47,7 +47,7 @@ import { Box, Button, Icon, Modal, Touchable } from '../..'
 </Description>
 
 <Canvas>
-  <Story name="Variant" height="300px">
+  <Story name="Variant" height="350px">
     <Menu
       disclosure={() => (
         <Touchable title="menu" name="menu" ml={8}>
@@ -63,8 +63,22 @@ import { Box, Button, Icon, Modal, Touchable } from '../..'
       <Menu.Item variant="danger" to="/?path=/docs/components-menu--basic">
         Link Danger
       </Menu.Item>
+      <Menu.Item
+        variant="danger"
+        to="/?path=/docs/components-menu--basic"
+        disabled
+      >
+        Link Danger Disabled
+      </Menu.Item>
       <Menu.Item variant="nav" to="/?path=/docs/components-menu--basic">
         Link Nav
+      </Menu.Item>
+      <Menu.Item
+        variant="nav"
+        to="/?path=/docs/components-menu--basic"
+        disabled
+      >
+        Link Nav disabled
       </Menu.Item>
     </Menu>
   </Story>
@@ -110,6 +124,48 @@ import { Box, Button, Icon, Modal, Touchable } from '../..'
       >
         Link Nav
       </Menu.Item>
+    </Menu>
+  </Story>
+</Canvas>
+
+## Children Props
+
+<Description>
+  Use children props : - `toggle` to toggle menu with action
+</Description>
+
+<Canvas>
+  <Story name="Children Props" height="250px">
+    <Menu
+      disclosure={() => (
+        <Touchable title="menu" name="menu" ml={8}>
+          <Icon name="dots-horizontal" color="gray550" size={24} />
+        </Touchable>
+      )}
+    >
+      {({ toggle }) => (
+        <>
+          <Menu.Item>default</Menu.Item>
+          <Menu.Item onClick={toggle} variant="danger">
+            Danger
+          </Menu.Item>
+          <Menu.Item onClick={toggle} variant="nav">
+            Nav
+          </Menu.Item>
+          <Menu.Item onClick={toggle} variant="nav" disabled>
+            Nav disabled
+          </Menu.Item>
+          <Menu.Item onClick={toggle} variant="nav" disabled borderless>
+            Nav disabled borderless
+          </Menu.Item>
+          <Menu.Item
+            to="/?path=/docs/components-menu--disclosure"
+            onClick={toggle}
+          >
+            Menu Item Link
+          </Menu.Item>
+        </>
+      )}
     </Menu>
   </Story>
 </Canvas>
@@ -182,7 +238,3 @@ import { Box, Button, Icon, Modal, Touchable } from '../..'
 ## Menu.Item
 
 <ArgsTable of={Menu.Item} />
-
-## Menu.ItemLink
-
-<ArgsTable of={Menu.ItemLink} />

--- a/src/components/Menu/__tests__/__snapshots__/index.js.snap
+++ b/src/components/Menu/__tests__/__snapshots__/index.js.snap
@@ -676,8 +676,8 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
   transition: color 300ms;
   min-width: 110px;
   background-color: transparent;
-  color: #ef5774;
   display: inline-block;
+  color: #ef5774;
 }
 
 .emotion-1:hover,
@@ -701,6 +701,16 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
 .emotion-1:last-child {
   border-bottom: 0;
   border-radius: 0 0 4px 4px;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  color: #cf0f34;
+}
+
+.emotion-1:hover svg,
+.emotion-1:focus svg {
+  fill: #cf0f34;
 }
 
 .emotion-1 svg {
@@ -771,8 +781,8 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
   transition: color 300ms;
   min-width: 110px;
   background-color: transparent;
-  color: #ef5774;
   display: inline-block;
+  color: #ef5774;
 }
 
 .emotion-1:hover,
@@ -796,6 +806,16 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
 .emotion-1:last-child {
   border-bottom: 0;
   border-radius: 0 0 4px 4px;
+}
+
+.emotion-1:hover,
+.emotion-1:focus {
+  color: #cf0f34;
+}
+
+.emotion-1:hover svg,
+.emotion-1:focus svg {
+  fill: #cf0f34;
 }
 
 .emotion-1 svg {

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -147,7 +147,7 @@ const Menu = ({
     name={name}
     placement={placement}
   >
-    {({ placement: localPlacement }) => (
+    {({ placement: localPlacement, toggle }) => (
       <div
         role="menu"
         css={[
@@ -156,7 +156,9 @@ const Menu = ({
           styles.align(align),
         ]}
       >
-        {children}
+        {typeof children === 'function'
+          ? children({ placement: localPlacement, toggle })
+          : children}
       </div>
     )}
   </Popper>
@@ -179,7 +181,7 @@ Menu.propTypes = {
   }),
   ariaLabel: PropTypes.string,
   baseId: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   disclosure: PropTypes.func.isRequired,
   hasArrow: PropTypes.bool,
   modal: PropTypes.bool,


### PR DESCRIPTION
## Summary

## Type

- Feature
Allow Menu to forward toggle props as children, it's useful in case you would like to close menu on click 

```js
{({ toggle }) => (
        <>
          <Menu.Item>default</Menu.Item>
          <Menu.Item onClick={toggle} variant="danger">
            Danger
          </Menu.Item>
```

Fix:
Hover on Danger variant  use wrong color from our palette



