### PR TITLE
feat(a11y): add tabs arrow navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,18 @@ $ yarn global add yalc # Make sure to have the yalc binary
 
 ```bash
 $ cd scaleway-ui
-$ yarn run build # Build the package
-$ yalc publish
+$ yarn build && yalc publish
 $ # Now it's ready to install in your project
 $ cd ../project-something
 $ yalc add @scaleway/ui --yarn
+$ cd ../scaleway-ui
 $ # If you do some changes into your package
-$ cd scaleway-ui
-$ yarn run build
-$ yalc publish --push # --push will automatically update the package on projects where it have been added
+$ yarn build && yalc publish --push --sig # --push will automatically update the package on projects where it have been added, --sig updates the signature hash to trigger webpack update
 ```
 
-> :warning: `yalc` create a `yalc.lock` and updates the `package.json` in the target project. Make sure to not commit these changes
+> :warning: since [1.0.0.pre.51 (2021-04-23)](https://github.com/wclr/yalc/blob/master/CHANGELOG.md#100pre51-2021-04-23), `yalc publish` needs the `--sig` option to trigger webpack module actual update.
+
+> :warning: `yalc` create a `yalc.lock` and updates the `package.json` in the target project. **Make sure to not commit these changes**
 
 ---
 

--- a/src/components/TabGroup/Tab.js
+++ b/src/components/TabGroup/Tab.js
@@ -14,16 +14,20 @@ export const StyledTab = styled.span`
   color: ${({ theme: { colors } }) => colors.gray550};
   font-weight: 500;
   text-decoration: none;
-  outline: none;
   user-select: none;
   touch-action: manipulation;
-
   transition: color 0.2s;
+
   &:hover,
   &:active,
   &:focus {
     color: ${({ theme: { colors } }) => colors.primary};
     text-decoration: none;
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: auto;
   }
 
   &[aria-selected='true'] {
@@ -67,7 +71,7 @@ const Tab = ({
       aria-label={name}
       ref={ref}
       role="tab"
-      tabIndex={0}
+      tabIndex={isSelected ? 0 : -1}
       onKeyDown={event => {
         if (['Enter', 'Space'].includes(event.code) && onClick) {
           onClick(event)

--- a/src/components/TabGroup/__tests__/TabGroup.test.js
+++ b/src/components/TabGroup/__tests__/TabGroup.test.js
@@ -1,6 +1,9 @@
+import { ThemeProvider } from '@emotion/react'
+import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import TabGroup from '..'
 import shouldMatchEmotionSnapshot from '../../../helpers/shouldMatchEmotionSnapshot'
+import theme from '../../../theme'
 import Box from '../../Box'
 
 describe('TabGroup', () => {
@@ -48,4 +51,26 @@ describe('TabGroup', () => {
         </TabGroup.Tab>
       </TabGroup>,
     ))
+  test('allows arrow navigation', () => {
+    const { getByRole, getByText } = render(
+      <ThemeProvider theme={theme}>
+        <TabGroup>
+          <TabGroup.Tab>First</TabGroup.Tab>
+          <TabGroup.Tab>Second</TabGroup.Tab>
+          <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
+        </TabGroup>
+      </ThemeProvider>,
+    )
+    const tablist = getByRole('tablist')
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(getByText('First')).toBe(document.activeElement)
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(getByText('Second')).toBe(document.activeElement)
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' }) // skip disabled tab & cycle
+    expect(getByText('First')).toBe(document.activeElement)
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' }) // cycle && skip disabled tab
+    expect(getByText('Second')).toBe(document.activeElement)
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    expect(getByText('First')).toBe(document.activeElement)
+  })
 })

--- a/src/components/TabGroup/__tests__/TabGroup.test.js
+++ b/src/components/TabGroup/__tests__/TabGroup.test.js
@@ -1,9 +1,8 @@
-import { ThemeProvider } from '@emotion/react'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import React from 'react'
 import TabGroup from '..'
+import renderWithTheme from '../../../helpers/renderWithTheme'
 import shouldMatchEmotionSnapshot from '../../../helpers/shouldMatchEmotionSnapshot'
-import theme from '../../../theme'
 import Box from '../../Box'
 
 describe('TabGroup', () => {
@@ -55,14 +54,12 @@ describe('TabGroup', () => {
   test('updates tab index on click', () => {
     const onChange = jest.fn()
     const onFirstTabClick = jest.fn()
-    const { getByText } = render(
-      <ThemeProvider theme={theme}>
-        <TabGroup onChange={onChange}>
-          <TabGroup.Tab onClick={onFirstTabClick}>First</TabGroup.Tab>
-          <TabGroup.Tab>Second</TabGroup.Tab>
-          <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
-        </TabGroup>
-      </ThemeProvider>,
+    const { getByText } = renderWithTheme(
+      <TabGroup onChange={onChange}>
+        <TabGroup.Tab onClick={onFirstTabClick}>First</TabGroup.Tab>
+        <TabGroup.Tab>Second</TabGroup.Tab>
+        <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
+      </TabGroup>,
     )
     fireEvent.click(getByText('First'))
     expect(onChange).toHaveBeenLastCalledWith(0)
@@ -77,16 +74,14 @@ describe('TabGroup', () => {
   test('updates tab name on click', () => {
     const onChange = jest.fn()
     const onFirstTabClick = jest.fn()
-    const { getByText } = render(
-      <ThemeProvider theme={theme}>
-        <TabGroup onChange={onChange}>
-          <TabGroup.Tab name="first" onClick={onFirstTabClick}>
-            First
-          </TabGroup.Tab>
-          <TabGroup.Tab name="second">Second</TabGroup.Tab>
-          <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
-        </TabGroup>
-      </ThemeProvider>,
+    const { getByText } = renderWithTheme(
+      <TabGroup onChange={onChange}>
+        <TabGroup.Tab name="first" onClick={onFirstTabClick}>
+          First
+        </TabGroup.Tab>
+        <TabGroup.Tab name="second">Second</TabGroup.Tab>
+        <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
+      </TabGroup>,
     )
     fireEvent.click(getByText('First'))
     expect(onChange).toHaveBeenLastCalledWith('first')
@@ -100,14 +95,12 @@ describe('TabGroup', () => {
 
   test('allows arrow navigation', () => {
     const onChange = jest.fn()
-    const { getByRole, getByText } = render(
-      <ThemeProvider theme={theme}>
-        <TabGroup onChange={onChange}>
-          <TabGroup.Tab>First</TabGroup.Tab>
-          <TabGroup.Tab>Second</TabGroup.Tab>
-          <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
-        </TabGroup>
-      </ThemeProvider>,
+    const { getByRole, getByText } = renderWithTheme(
+      <TabGroup onChange={onChange}>
+        <TabGroup.Tab>First</TabGroup.Tab>
+        <TabGroup.Tab>Second</TabGroup.Tab>
+        <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
+      </TabGroup>,
     )
     const tablist = getByRole('tablist')
     fireEvent.keyDown(tablist, { code: 'ArrowRight' })

--- a/src/components/TabGroup/__tests__/TabGroup.test.js
+++ b/src/components/TabGroup/__tests__/TabGroup.test.js
@@ -51,10 +51,58 @@ describe('TabGroup', () => {
         </TabGroup.Tab>
       </TabGroup>,
     ))
+
+  test('updates tab index on click', () => {
+    const onChange = jest.fn()
+    const onFirstTabClick = jest.fn()
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <TabGroup onChange={onChange}>
+          <TabGroup.Tab onClick={onFirstTabClick}>First</TabGroup.Tab>
+          <TabGroup.Tab>Second</TabGroup.Tab>
+          <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
+        </TabGroup>
+      </ThemeProvider>,
+    )
+    fireEvent.click(getByText('First'))
+    expect(onChange).toHaveBeenLastCalledWith(0)
+    fireEvent.click(getByText('Second'))
+    expect(onChange).toHaveBeenLastCalledWith(1)
+    onChange.mockReset()
+    fireEvent.click(getByText('Disabled'))
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onFirstTabClick).toHaveBeenCalledTimes(1)
+  })
+
+  test('updates tab name on click', () => {
+    const onChange = jest.fn()
+    const onFirstTabClick = jest.fn()
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <TabGroup onChange={onChange}>
+          <TabGroup.Tab name="first" onClick={onFirstTabClick}>
+            First
+          </TabGroup.Tab>
+          <TabGroup.Tab name="second">Second</TabGroup.Tab>
+          <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
+        </TabGroup>
+      </ThemeProvider>,
+    )
+    fireEvent.click(getByText('First'))
+    expect(onChange).toHaveBeenLastCalledWith('first')
+    fireEvent.click(getByText('Second'))
+    expect(onChange).toHaveBeenLastCalledWith('second')
+    onChange.mockReset()
+    fireEvent.click(getByText('Disabled'))
+    expect(onChange).not.toHaveBeenCalled()
+    expect(onFirstTabClick).toHaveBeenCalledTimes(1)
+  })
+
   test('allows arrow navigation', () => {
+    const onChange = jest.fn()
     const { getByRole, getByText } = render(
       <ThemeProvider theme={theme}>
-        <TabGroup>
+        <TabGroup onChange={onChange}>
           <TabGroup.Tab>First</TabGroup.Tab>
           <TabGroup.Tab>Second</TabGroup.Tab>
           <TabGroup.Tab disabled>Disabled</TabGroup.Tab>
@@ -62,15 +110,19 @@ describe('TabGroup', () => {
       </ThemeProvider>,
     )
     const tablist = getByRole('tablist')
-    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    fireEvent.keyDown(tablist, { code: 'ArrowRight' })
     expect(getByText('First')).toBe(document.activeElement)
-    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    fireEvent.keyDown(tablist, { code: 'ArrowRight' })
     expect(getByText('Second')).toBe(document.activeElement)
-    fireEvent.keyDown(tablist, { key: 'ArrowRight' }) // skip disabled tab & cycle
+    fireEvent.keyDown(tablist, { code: 'ArrowRight' }) // skip disabled tab & cycle
     expect(getByText('First')).toBe(document.activeElement)
-    fireEvent.keyDown(tablist, { key: 'ArrowLeft' }) // cycle && skip disabled tab
+    fireEvent.keyDown(tablist, { code: 'ArrowLeft' }) // cycle && skip disabled tab
     expect(getByText('Second')).toBe(document.activeElement)
-    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    fireEvent.keyDown(getByText('Second'), { code: 'Space' })
+    expect(onChange).toHaveBeenLastCalledWith(1)
+    fireEvent.keyDown(tablist, { code: 'ArrowLeft' })
     expect(getByText('First')).toBe(document.activeElement)
+    fireEvent.keyDown(getByText('First'), { code: 'Enter' })
+    expect(onChange).toHaveBeenLastCalledWith(0)
   })
 })

--- a/src/components/TabGroup/__tests__/__snapshots__/Tab.test.js.snap
+++ b/src/components/TabGroup/__tests__/__snapshots__/Tab.test.js.snap
@@ -26,7 +26,6 @@ exports[`Tab renders correctly 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -42,6 +41,11 @@ exports[`Tab renders correctly 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-0:focus-visible {
+  outline: auto;
 }
 
 .emotion-0[aria-selected='true'] {
@@ -63,7 +67,7 @@ exports[`Tab renders correctly 1`] = `
     aria-selected="false"
     class="emotion-0 emotion-1"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Test tab
   </span>
@@ -96,7 +100,6 @@ exports[`Tab renders correctly when as component 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -112,6 +115,11 @@ exports[`Tab renders correctly when as component 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-0:focus-visible {
+  outline: auto;
 }
 
 .emotion-0[aria-selected='true'] {
@@ -134,7 +142,7 @@ exports[`Tab renders correctly when as component 1`] = `
     aria-selected="false"
     class="emotion-0 emotion-1"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Test tab
   </a>
@@ -167,7 +175,6 @@ exports[`Tab renders correctly when disabled 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -183,6 +190,11 @@ exports[`Tab renders correctly when disabled 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-0:focus-visible {
+  outline: auto;
 }
 
 .emotion-0[aria-selected='true'] {
@@ -205,7 +217,7 @@ exports[`Tab renders correctly when disabled 1`] = `
     aria-selected="false"
     class="emotion-0 emotion-1"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Test tab
   </span>
@@ -238,7 +250,6 @@ exports[`Tab renders correctly when selected 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -254,6 +265,11 @@ exports[`Tab renders correctly when selected 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-0:focus-visible {
+  outline: auto;
 }
 
 .emotion-0[aria-selected='true'] {
@@ -309,7 +325,6 @@ exports[`Tab renders correctly with variant default 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -325,6 +340,11 @@ exports[`Tab renders correctly with variant default 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-0:focus-visible {
+  outline: auto;
 }
 
 .emotion-0[aria-selected='true'] {
@@ -347,7 +367,7 @@ exports[`Tab renders correctly with variant default 1`] = `
     aria-selected="false"
     class="emotion-0 emotion-1"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Test tab
   </span>
@@ -380,7 +400,6 @@ exports[`Tab renders correctly with variant primary 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -396,6 +415,11 @@ exports[`Tab renders correctly with variant primary 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-0:focus-visible {
+  outline: auto;
 }
 
 .emotion-0[aria-selected='true'] {
@@ -418,7 +442,7 @@ exports[`Tab renders correctly with variant primary 1`] = `
     aria-selected="false"
     class="emotion-0 emotion-1"
     role="tab"
-    tabindex="0"
+    tabindex="-1"
   >
     Test tab
   </span>

--- a/src/components/TabGroup/__tests__/__snapshots__/TabGroup.test.js.snap
+++ b/src/components/TabGroup/__tests__/__snapshots__/TabGroup.test.js.snap
@@ -93,7 +93,6 @@ exports[`TabGroup renders correctly with Tabs and last disabled 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -109,6 +108,11 @@ exports[`TabGroup renders correctly with Tabs and last disabled 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-4:focus-visible {
+  outline: auto;
 }
 
 .emotion-4[aria-selected='true'] {
@@ -147,7 +151,7 @@ exports[`TabGroup renders correctly with Tabs and last disabled 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         First
       </span>
@@ -156,7 +160,7 @@ exports[`TabGroup renders correctly with Tabs and last disabled 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         Second
       </span>
@@ -224,7 +228,6 @@ exports[`TabGroup renders correctly with Tabs name 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -240,6 +243,11 @@ exports[`TabGroup renders correctly with Tabs name 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-4:focus-visible {
+  outline: auto;
 }
 
 .emotion-4[aria-selected='true'] {
@@ -279,7 +287,7 @@ exports[`TabGroup renders correctly with Tabs name 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         First
       </span>
@@ -299,7 +307,7 @@ exports[`TabGroup renders correctly with Tabs name 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         Very long tab name
       </span>
@@ -358,7 +366,6 @@ exports[`TabGroup renders correctly with Tabs with prop 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -374,6 +381,11 @@ exports[`TabGroup renders correctly with Tabs with prop 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-4:focus-visible {
+  outline: auto;
 }
 
 .emotion-4[aria-selected='true'] {
@@ -421,7 +433,7 @@ exports[`TabGroup renders correctly with Tabs with prop 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         Second
       </span>
@@ -430,7 +442,7 @@ exports[`TabGroup renders correctly with Tabs with prop 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         Very long tab name
       </span>
@@ -489,7 +501,6 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -505,6 +516,11 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-4:focus-visible {
+  outline: auto;
 }
 
 .emotion-4[aria-selected='true'] {
@@ -545,7 +561,6 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
   font-weight: 500;
   -webkit-text-decoration: none;
   text-decoration: none;
-  outline: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -561,6 +576,11 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
   color: #4f0599;
   -webkit-text-decoration: none;
   text-decoration: none;
+  outline: none;
+}
+
+.emotion-9:focus-visible {
+  outline: auto;
 }
 
 .emotion-9[aria-selected='true'] {
@@ -599,7 +619,7 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         First
       </div>
@@ -608,7 +628,7 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
         aria-selected="false"
         class="emotion-4 emotion-5"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         Second
       </a>
@@ -617,7 +637,7 @@ exports[`TabGroup renders correctly with custom Tabs component 1`] = `
         aria-selected="false"
         class="emotion-5 emotion-9 emotion-1"
         role="tab"
-        tabindex="0"
+        tabindex="-1"
       >
         Very long tab name
       </div>

--- a/src/components/TabGroup/index.js
+++ b/src/components/TabGroup/index.js
@@ -66,9 +66,29 @@ const TabGroup = ({ children, selected, onChange, className, ...props }) => {
 
   const [width, left] = computeBarProperties(tabsWidth, currentTabIndex)
 
+  const navigateWithArrow = ({ currentTarget, key }) => {
+    const activeTab = '[role="tab"]:focus'
+    const enabledTab = '[role="tab"]:not([aria-disabled="true"]'
+    if (key === 'ArrowLeft') {
+      const previousTab =
+        currentTarget.querySelector(activeTab)?.previousElementSibling ||
+        [...currentTarget.querySelectorAll(enabledTab)].pop()
+      previousTab?.focus()
+    } else if (key === 'ArrowRight') {
+      const nextTab =
+        currentTarget.querySelector(`${activeTab} ~ ${enabledTab}`) ||
+        currentTarget.querySelector(enabledTab)
+      nextTab?.focus()
+    }
+  }
+
   return (
     <Box {...props} position="relative">
-      <StyledTabs role="tablist" className={className}>
+      <StyledTabs
+        role="tablist"
+        className={className}
+        onKeyDown={navigateWithArrow}
+      >
         {flattenedChildren.map((child, index) => {
           const isSelected = child.props.name
             ? child.props.name === selected

--- a/src/components/TabGroup/index.js
+++ b/src/components/TabGroup/index.js
@@ -66,15 +66,15 @@ const TabGroup = ({ children, selected, onChange, className, ...props }) => {
 
   const [width, left] = computeBarProperties(tabsWidth, currentTabIndex)
 
-  const navigateWithArrow = ({ currentTarget, key }) => {
+  const navigateWithArrow = ({ currentTarget, code }) => {
     const activeTab = '[role="tab"]:focus'
     const enabledTab = '[role="tab"]:not([aria-disabled="true"]'
-    if (key === 'ArrowLeft') {
+    if (code === 'ArrowLeft') {
       const previousTab =
         currentTarget.querySelector(activeTab)?.previousElementSibling ||
         [...currentTarget.querySelectorAll(enabledTab)].pop()
       previousTab?.focus()
-    } else if (key === 'ArrowRight') {
+    } else if (code === 'ArrowRight') {
       const nextTab =
         currentTarget.querySelector(`${activeTab} ~ ${enabledTab}`) ||
         currentTarget.querySelector(enabledTab)


### PR DESCRIPTION
## Summary

Allow tabs keyboard navigation with `←` / `→` arrows. 

**Linked PR**
Same fix applied to [scaleway-lib README](https://github.com/scaleway/scaleway-lib/pull/306).

## Type

Enhancement

#### What is expected?

`Tab` key no longer allow navigation between tabs, only the selected tab can be navigated to with `Tab` key navigation.
Then to switch tabs, user can navigate with keyboard  using `←` / `→` arrows to rotate through tabs. 
The current focused tab (when using keyboard navigation) is outlined.

## Relevant screenshots

Page | Before | After
:-   |  :-:   | -:
https://console.scaleway.com/organization | ![image](https://user-images.githubusercontent.com/62407/128012819-3d9be55f-5da8-4fbc-b3d0-25f5cabab36c.png) | ![image](https://user-images.githubusercontent.com/62407/128012968-c0429d7f-e325-4f3b-a32e-7da377956b2a.png)







