### PR TITLE
fix(tooltip): using unstable portal and set it to false

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -99,7 +99,7 @@ const Tooltip = ({
   variant = 'black',
   baseId,
   zIndex,
-  unstable_portal = false,
+  unstable_portal = true,
   ...props
 }: TooltipProps): JSX.Element => {
   const tooltip = useTooltipState({

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -86,6 +86,7 @@ export type TooltipProps = {
   text?: ReactNode
   variant?: keyof typeof variants
   visible?: boolean
+  unstable_portal?: boolean
   zIndex?: number
 }
 
@@ -98,6 +99,7 @@ const Tooltip = ({
   variant = 'black',
   baseId,
   zIndex,
+  unstable_portal = false,
   ...props
 }: TooltipProps): JSX.Element => {
   const tooltip = useTooltipState({
@@ -106,6 +108,7 @@ const Tooltip = ({
     placement,
     visible,
   })
+
   const { setVisible } = tooltip
   useEffect(() => setVisible(visible), [setVisible, visible])
 
@@ -120,7 +123,11 @@ const Tooltip = ({
           ? referenceProps => children(referenceProps) as JSX.Element
           : children}
       </TooltipReference>
-      <ReakitTooltip {...tooltip} style={{ zIndex }}>
+      <ReakitTooltip
+        {...tooltip}
+        style={{ zIndex }}
+        unstable_portal={unstable_portal}
+      >
         <StyledTooltip variant={variant} {...props}>
           <TooltipArrow {...tooltip} />
           {text}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Uses unstable_portal from Reakit Tooltip to avoid portal into modal and have tooltips working inside modals too.

#### The following changes where made:

1. Pass unstable_portal props to Reakit Tooltip
2. Defaulting to true so it doesn't change current behaviour



