### PR TITLE
fix(container): some props was forward to the DOM

### DIFF
--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -10,7 +10,9 @@ const StyledContainer = styled(Box)`
   margin-top: 40px;
 `
 
-const StyledBox = styled(Box)<{
+const StyledBox = styled(Box, {
+  shouldForwardProp: props => !['small', 'edition'].includes(props.toString()),
+})<{
   small?: boolean
   edition?: boolean
   disabled?: boolean


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

<img width="882" alt="Capture d’écran 2021-08-18 à 12 29 58" src="https://user-images.githubusercontent.com/14060273/129883241-21e231d5-1c22-48d9-9ba8-a45b505f0e40.png">
<img width="868" alt="Capture d’écran 2021-08-18 à 12 29 47" src="https://user-images.githubusercontent.com/14060273/129883243-c5744107-74d8-4df6-bc70-e70d389169c9.png">

#### What is expected?

This props should not be forward to the DOM as value



