### PR TITLE
feat: correct es module tree shaking by preserving modules on output

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,11 @@
   },
   "size-limit": [
     {
-      "path": "dist/index.js",
-      "import": "{ Box }",
+      "path": "dist/**/*.js",
+      "limit": "220 kB",
       "webpack": false,
-      "limit": "200 kB"
+      "brotli": true,
+      "running": false
     }
   ],
   "jest": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "linux"
   ],
   "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "jsnext:main": "dist/index.js",
+  "main": "dist/src/index.js",
+  "module": "dist/src/index.js",
+  "jsnext:main": "dist/src/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rollup -c",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -32,8 +32,10 @@ export default [{
   external,
   input: './src/index.ts',
   output: {
-    file: 'dist/index.js',
+    dir: 'dist',
     format: 'es',
+    preserveModules: true,
+    preserveModulesRoot: 'node_modules'
   },
   plugins: [
     babel({


### PR DESCRIPTION
## Summary

Turns out webpack does not tree shake bundled esm modules (https://github.com/webpack/webpack/issues/9337#issuecomment-524966201)



## Type

- Enhancement

 Before | After
  :-:   | -:
 <img width="348" alt="Screenshot 2021-08-21 at 00 12 54" src="https://user-images.githubusercontent.com/2802867/130298338-a64e4505-84f3-46d1-b917-9a26fc67b429.png"> | <img width="354" alt="Screenshot 2021-08-21 at 00 11 12" src="https://user-images.githubusercontent.com/2802867/130298337-01942929-288d-42b7-b4be-d452610bed8b.png">