### PR TITLE
fix: avoid to declare emotion Theme typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ const App = () => (
 );
 ```
 
+N.B. To allow typescript theme typings with `@emotion/styled` components,
+you'll have to define the `@emotion/react` module `Theme` interface in your project.
+
+Example, in a `global.d.ts` file:
+
+- Declaration to use the default Scaleway theme
+```ts
+declare module '@emotion/react' {
+  import type { SCWUITheme } from '@scaleway/ui'
+  // https://emotion.sh/docs/typescript#define-a-theme
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends SCWUITheme {}
+}
+
+```
+-  Declaration to use your custom theme
+```ts
+import type { MyTheme } from './src/theme'
+
+declare module '@emotion/react' {
+  // https://emotion.sh/docs/typescript#define-a-theme
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends MyTheme {}
+}
+
+```
+
 ## Development
 
 ### Storybook

--- a/emotion.d.ts
+++ b/emotion.d.ts
@@ -1,0 +1,7 @@
+import { SCWUITheme } from './src'
+
+declare module '@emotion/react' {
+  // https://emotion.sh/docs/typescript#define-a-theme
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends SCWUITheme {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components'
 export { default as theme } from './theme'
+export type { SCWUITheme } from './theme'
 export * from './utils'

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -46,16 +46,10 @@ const theme = {
   radii,
 }
 
-export type SCWUITheme = typeof theme & {
+type SCWUITheme = typeof theme & {
   linkComponent?: unknown
-}
-
-declare module '@emotion/react' {
-  // https://emotion.sh/docs/typescript#define-a-theme
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  export interface Theme extends SCWUITheme {}
 }
 
 export default theme
 
-export { colors, space, radii, fonts, screens }
+export { colors, space, radii, fonts, screens, SCWUITheme }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "**/*.tsx",
     "**/*.js",
     "**/*.jsx",
+    "emotion.d.ts",
+    "global.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Allows projects to define custom Theme typings

#### The following changes where made:
1. removed extended emotion Theme typings from exported typings
2. forces to localy extends emotion Theme
3. exports SCWUITheme for convenience




