### PR TITLE
fix(modal): onBeforeClose & ExtendReminder CustomLink

### DIFF
--- a/src/components/ExtendedReminder/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/ExtendedReminder/__tests__/__snapshots__/index.tsx.snap
@@ -1,5 +1,136 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ExtendedReminder renders correctly with custom link 1`] = `
+<DocumentFragment>
+  .cache-ca5rh {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 4px;
+  position: relative;
+  padding: 16px;
+  background-color: #ffefe6;
+}
+
+.cache-1c2oc0x {
+  position: absolute;
+  top: -12px;
+  left: 16px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.cache-12kyav8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  white-space: nowrap;
+  border-radius: 16px;
+  padding: 0 16px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  background-color: #ff8c69;
+  color: #fff;
+  font-size: 12px;
+  line-height: 24px;
+  height: 24px;
+}
+
+.cache-16gvrqr {
+  fill: #fff;
+  height: 16px;
+  width: 16px;
+  min-width: 16px;
+  min-height: 16px;
+}
+
+.cache-16gvrqr.cache-16gvrqr {
+  vertical-align: middle;
+  margin-right: 4px;
+}
+
+.cache-c2d62p {
+  color: #4a4f62;
+  font-weight: 400;
+  margin-bottom: 0;
+  margin-top: 0;
+  color: #4a4f62;
+  font-size: 14px;
+  line-height: 22px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #ff8c69;
+}
+
+.cache-c2d62p.cache-c2d62p {
+  margin-bottom: 8px;
+}
+
+.cache-aixvht {
+  color: #4a4f62;
+  font-weight: 400;
+  margin-bottom: 0;
+  margin-top: 0;
+  color: #4a4f62;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.cache-aixvht.cache-aixvht {
+  margin-bottom: 8px;
+}
+
+<div
+    class="edgwu7l3 cache-ca5rh e7ah3bn0"
+  >
+    <div
+      class="edgwu7l2 cache-1c2oc0x e7ah3bn0"
+    >
+      <span
+        class="egvl2gp0 cache-12kyav8 e7ah3bn0"
+      >
+        <svg
+          class="sc-ui-icon etwatq50 cache-16gvrqr e7ah3bn0"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z"
+          />
+        </svg>
+        10 days remaining
+      </span>
+    </div>
+    <p
+      class="edgwu7l1 e1g1zfwd0 cache-c2d62p e7ah3bn0"
+    >
+      Verify your credit card
+    </p>
+    <p
+      class="e1g1zfwd0 cache-aixvht e7ah3bn0"
+    >
+      Enter the code we send to your bank account to validate your payment method.
+    </p>
+    <div>
+      Custom Link
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`ExtendedReminder renders correctly with default values 1`] = `
 <DocumentFragment>
   .cache-11ukj9a {

--- a/src/components/ExtendedReminder/__tests__/index.tsx
+++ b/src/components/ExtendedReminder/__tests__/index.tsx
@@ -38,4 +38,16 @@ describe('ExtendedReminder', () => {
         text="Enter the code we send to your bank account to validate your payment method."
       />,
     ))
+
+  test('renders correctly with custom link', () =>
+    shouldMatchEmotionSnapshot(
+      <ExtendedReminder
+        variant="warning"
+        icon="alert"
+        badgeText="10 days remaining"
+        title="Verify your credit card"
+        text="Enter the code we send to your bank account to validate your payment method."
+        CustomLink={<div>Custom Link</div>}
+      />,
+    ))
 })

--- a/src/components/ExtendedReminder/index.tsx
+++ b/src/components/ExtendedReminder/index.tsx
@@ -1,7 +1,7 @@
 import { Theme, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
-import React, { FunctionComponent, MouseEventHandler } from 'react'
+import React, { FunctionComponent, MouseEventHandler, ReactNode } from 'react'
 import Badge from '../Badge'
 import Box from '../Box'
 import Button from '../Button'
@@ -94,6 +94,10 @@ type Props = {
    */
   to?: string
   variant?: Variants
+  /**
+   * Custom link component
+   */
+  CustomLink?: ReactNode
 }
 
 const ExtendedReminder: FunctionComponent<Props> = ({
@@ -105,6 +109,7 @@ const ExtendedReminder: FunctionComponent<Props> = ({
   title,
   to,
   variant = 'info',
+  CustomLink,
   ...props
 }) => {
   const theme = useTheme()
@@ -129,23 +134,25 @@ const ExtendedReminder: FunctionComponent<Props> = ({
       <Typography mb={1} variant="bodyD">
         {text}
       </Typography>
-      {linkText && (
-        <StyledButtonLink
-          variant="link"
-          to={to}
-          onClick={onClick}
-          size="xsmall"
-          icon="east"
-        >
-          {linkText}
-        </StyledButtonLink>
-      )}
+      {CustomLink ||
+        (linkText && (
+          <StyledButtonLink
+            variant="link"
+            to={to}
+            onClick={onClick}
+            size="xsmall"
+            icon="east"
+          >
+            {linkText}
+          </StyledButtonLink>
+        ))}
     </StyledContainer>
   )
 }
 
 ExtendedReminder.propTypes = {
   badgeText: PropTypes.string.isRequired,
+  CustomLink: PropTypes.node,
   icon: PropTypes.oneOf(icons).isRequired,
   linkText: PropTypes.string,
   onClick: PropTypes.func,

--- a/src/components/ExtendedReminder/index.tsx
+++ b/src/components/ExtendedReminder/index.tsx
@@ -135,7 +135,7 @@ const ExtendedReminder: FunctionComponent<Props> = ({
         {text}
       </Typography>
       {CustomLink ||
-        (linkText && (
+        (linkText ? (
           <StyledButtonLink
             variant="link"
             to={to}
@@ -145,7 +145,7 @@ const ExtendedReminder: FunctionComponent<Props> = ({
           >
             {linkText}
           </StyledButtonLink>
-        ))}
+        ) : null)}
     </StyledContainer>
   )
 }

--- a/src/components/Modal/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index.tsx.snap
@@ -547,18 +547,16 @@ exports[`Modal renders with disclosure and onBeforeClose 1`] = `
     <div
       class="cache-5vl9c-Modal e1x6rvve2"
       data-dialog-ref="modal-test"
-      hidden=""
-      style="display: none;"
+      style=""
     >
       <div
         aria-label="modal-test"
         aria-modal="true"
         class="cache-wh6zpw-Modal e1x6rvve1"
         data-dialog="true"
-        hidden=""
         id="modal-test"
         role="dialog"
-        style="display: none;"
+        style=""
         tabindex="-1"
       >
         <div
@@ -578,6 +576,9 @@ exports[`Modal renders with disclosure and onBeforeClose 1`] = `
               />
             </svg>
           </button>
+        </div>
+        <div>
+          modal
         </div>
       </div>
     </div>

--- a/src/components/Modal/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index.tsx.snap
@@ -438,6 +438,153 @@ exports[`Modal renders with disclosure 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Modal renders with disclosure and onBeforeClose 1`] = `
+<DocumentFragment>
+  <button
+    aria-controls="modal-test"
+    aria-expanded="false"
+    aria-haspopup="dialog"
+    type="button"
+  >
+    Test
+  </button>
+  .cache-5vl9c-Modal {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: fixed;
+  overflow: auto;
+  padding: 16px;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 999;
+  opacity: 1;
+  background-color: rgba(74,79,98,0.2);
+}
+
+.cache-wh6zpw-Modal {
+  background-color: #fff;
+  position: relative;
+  border-radius: 4px;
+  border: 0;
+  padding: 32px;
+  margin: auto;
+  width: 616px;
+  min-height: initial;
+  box-shadow: 0 0 12px 18px rgba(165,165,205,0.2);
+  opacity: 1;
+}
+
+.cache-wh6zpw-Modal::before {
+  content: '';
+  height: 100%;
+  width: 100%;
+}
+
+.cache-et21s3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  left: 16px;
+}
+
+.cache-1x1qiw9 {
+  border: 0;
+  transition-property: opacity;
+  transition-duration: 0.15s;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.cache-1x1qiw9.cache-1x1qiw9 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  margin-bottom: 0;
+}
+
+.cache-byq9xb {
+  fill: #b2b6c3;
+  height: 20px;
+  width: 20px;
+  min-width: 20px;
+  min-height: 20px;
+}
+
+.cache-byq9xb.cache-byq9xb {
+  vertical-align: middle;
+}
+
+<div
+    class="__reakit-portal"
+  >
+    <div
+      class="cache-5vl9c-Modal e1x6rvve2"
+      data-dialog-ref="modal-test"
+      hidden=""
+      style="display: none;"
+    >
+      <div
+        aria-label="modal-test"
+        aria-modal="true"
+        class="cache-wh6zpw-Modal e1x6rvve1"
+        data-dialog="true"
+        hidden=""
+        id="modal-test"
+        role="dialog"
+        style="display: none;"
+        tabindex="-1"
+      >
+        <div
+          class="cache-et21s3 e1x6rvve0"
+        >
+          <button
+            class="cache-1x1qiw9 e7ah3bn0"
+            title="close"
+            type="button"
+          >
+            <svg
+              class="sc-ui-icon etwatq50 cache-byq9xb e7ah3bn0"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Modal renders with opened={true} 1`] = `
 <DocumentFragment>
   <div

--- a/src/components/Modal/__tests__/index.tsx
+++ b/src/components/Modal/__tests__/index.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import Modal from '..'
 import shouldMatchEmotionSnapshotWithPortal from '../../../helpers/shouldMatchEmotionSnapshotWithPortal'
@@ -47,22 +48,35 @@ describe('Modal', () => {
       </Modal>,
     ))
 
-  test(`renders with disclosure and onBeforeClose`, () =>
-    shouldMatchEmotionSnapshotWithPortal(
+  test(`renders with disclosure and onBeforeClose`, () => {
+    let count = 0
+
+    return shouldMatchEmotionSnapshotWithPortal(
       <Modal
         ariaLabel="modal-test"
         baseId="modal-test"
         disclosure={() => <button type="button">Test</button>}
-        onBeforeClose={() => console.log('onBeforeClose triggered')}
+        /* eslint-disable-next-line @typescript-eslint/require-await */
+        onBeforeClose={async () => {
+          count += 1
+        }}
       >
         <div>modal</div>
       </Modal>,
-    ))
+      {
+        transform: node => {
+          const closeButton = node.getByTitle('close')
+          userEvent.click(closeButton)
+          expect(count).toBe(1)
+        },
+      },
+    )
+  })
 
   test(`renders with portal node (modal=false)`, () =>
     shouldMatchEmotionSnapshotWithPortal(
       <Modal ariaLabel="modal-test" baseId="modal-test" modal={false}>
-        <div> test </div>
+        <div> test</div>
       </Modal>,
     ))
 })

--- a/src/components/Modal/__tests__/index.tsx
+++ b/src/components/Modal/__tests__/index.tsx
@@ -46,6 +46,19 @@ describe('Modal', () => {
         <div>modal</div>
       </Modal>,
     ))
+
+  test(`renders with disclosure and onBeforeClose`, () =>
+    shouldMatchEmotionSnapshotWithPortal(
+      <Modal
+        ariaLabel="modal-test"
+        baseId="modal-test"
+        disclosure={() => <button type="button">Test</button>}
+        onBeforeClose={() => console.log('onBeforeClose triggered')}
+      >
+        <div>modal</div>
+      </Modal>,
+    ))
+
   test(`renders with portal node (modal=false)`, () =>
     shouldMatchEmotionSnapshotWithPortal(
       <Modal ariaLabel="modal-test" baseId="modal-test" modal={false}>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -305,13 +305,25 @@ const Modal: FunctionComponent<ModalProps> = ({
           hideOnEsc={hideOnEsc}
           preventBodyScroll={preventBodyScroll}
           {...dialog}
-          hide={onClose || (() => onBeforeClose?.() && dialog.toggle)}
+          hide={
+            onClose ||
+            (() => {
+              onBeforeClose?.()
+              dialog.toggle()
+            })
+          }
         >
           <>
             <StyledContainer>
               {isClosable && (
                 <Touchable
-                  onClick={onClose || dialog.toggle}
+                  onClick={
+                    onClose ||
+                    (() => {
+                      onBeforeClose?.()
+                      dialog.toggle()
+                    })
+                  }
                   alignSelf="center"
                   title="close"
                   mb={0}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactElement,
   VoidFunctionComponent,
   memo,
+  useCallback,
   useEffect,
   useRef,
 } from 'react'
@@ -288,6 +289,11 @@ const Modal: FunctionComponent<ModalProps> = ({
   const { setVisible } = dialog
   useEffect(() => setVisible(opened), [setVisible, opened])
 
+  const onCloseCallBack = useCallback(async () => {
+    await onBeforeClose?.()
+    dialog.toggle()
+  }, [dialog, onBeforeClose])
+
   return (
     <>
       {disclosure && <MemoDisclosure dialog={dialog} disclosure={disclosure} />}
@@ -305,25 +311,13 @@ const Modal: FunctionComponent<ModalProps> = ({
           hideOnEsc={hideOnEsc}
           preventBodyScroll={preventBodyScroll}
           {...dialog}
-          hide={
-            onClose ||
-            (async () => {
-              await onBeforeClose?.()
-              dialog.toggle()
-            })
-          }
+          hide={onClose || onCloseCallBack}
         >
           <>
             <StyledContainer>
               {isClosable && (
                 <Touchable
-                  onClick={
-                    onClose ||
-                    (async () => {
-                      await onBeforeClose?.()
-                      dialog.toggle()
-                    })
-                  }
+                  onClick={onClose || onCloseCallBack}
                   alignSelf="center"
                   title="close"
                   mb={0}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -250,6 +250,7 @@ type ModalProps = Partial<DialogProps> &
     isClosable?: boolean
     modal?: boolean
     onClose?: () => void
+    onBeforeClose?: () => void
     opened?: boolean
     placement?: ModalPlacement
     width?: ModalWidth
@@ -271,6 +272,7 @@ const Modal: FunctionComponent<ModalProps> = ({
   isClosable = true,
   modal = true,
   onClose,
+  onBeforeClose,
   opened = false,
   placement = 'center',
   preventBodyScroll = true,
@@ -303,7 +305,7 @@ const Modal: FunctionComponent<ModalProps> = ({
           hideOnEsc={hideOnEsc}
           preventBodyScroll={preventBodyScroll}
           {...dialog}
-          hide={onClose || dialog.toggle}
+          hide={onClose || (() => onBeforeClose?.() && dialog.toggle)}
         >
           <>
             <StyledContainer>
@@ -342,6 +344,7 @@ Modal.propTypes = {
   hideOnEsc: PropTypes.bool,
   isClosable: PropTypes.bool,
   modal: PropTypes.bool,
+  onBeforeClose: PropTypes.func,
   onClose: PropTypes.func,
   opened: PropTypes.bool,
   placement: PropTypes.oneOf(Object.keys(MODAL_PLACEMENT) as ModalPlacement[]),

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -250,7 +250,7 @@ type ModalProps = Partial<DialogProps> &
     isClosable?: boolean
     modal?: boolean
     onClose?: () => void
-    onBeforeClose?: () => void
+    onBeforeClose?: () => Promise<unknown>
     opened?: boolean
     placement?: ModalPlacement
     width?: ModalWidth
@@ -307,8 +307,8 @@ const Modal: FunctionComponent<ModalProps> = ({
           {...dialog}
           hide={
             onClose ||
-            (() => {
-              onBeforeClose?.()
+            (async () => {
+              await onBeforeClose?.()
               dialog.toggle()
             })
           }
@@ -319,8 +319,8 @@ const Modal: FunctionComponent<ModalProps> = ({
                 <Touchable
                   onClick={
                     onClose ||
-                    (() => {
-                      onBeforeClose?.()
+                    (async () => {
+                      await onBeforeClose?.()
                       dialog.toggle()
                     })
                   }


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

**Modals**: added `onBeforeClose` prop that will be triggered before the modal is closed. This is useful when using disclosure and not onClose prop.

**ExtendedReminder**: added `CustomLink` prop that can take a node value. This is useful when wanting to put a modal with disclosure inside of ExtendedReminder without using default link and onClick prop.



