### PR TITLE
fix(theme): allow theme constants inspection in typescript

### DIFF
--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -69,7 +69,7 @@ const colors = {
   warning,
   white,
   zumthor,
-}
+} as const
 
 export type Color = keyof typeof colors
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -21,7 +21,7 @@ const space = {
   7: '56px',
   8: '64px',
   9: '72px',
-}
+} as const
 export type Spaces = keyof typeof space
 
 const screens = {
@@ -30,13 +30,13 @@ const screens = {
   medium: 768,
   large: 992,
   xlarge: 1200,
-}
+} as const
 export type ScreenSize = keyof typeof screens
 
 const fonts = {
   monospace: "'Lucida Console', Monaco, 'Courier New', Courier, monospace",
   sansSerif: 'Asap, System, sans-serif',
-}
+} as const
 
 const theme = {
   colors,


### PR DESCRIPTION
## Summary

Allow theme constants inspection in typescript

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Export theme values in typescript types

#### The following changes where made:

1. added [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html) in theme definition

## Relevant logs and/or screenshots

![image](https://user-images.githubusercontent.com/62407/132310542-5a8855a7-ffdd-48e9-93dc-75c084fdce46.png)




