### PR TITLE
fix: radioborderedbox add xstyledprops

### DIFF
--- a/src/components/RadioBorderedBox/index.tsx
+++ b/src/components/RadioBorderedBox/index.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React, { FunctionComponent, InputHTMLAttributes } from 'react'
 import Badge, { badgeSizes, badgeVariants } from '../Badge'
 import type { Sizes, Variants } from '../Badge'
-import Box from '../Box'
+import Box, { XStyledProps } from '../Box'
 import Radio from '../Radio'
 
 const StyledBox = styled(Box)<{ disabled: boolean; checked: boolean }>`
@@ -38,7 +38,8 @@ type RadioBorderedBoxProps = {
   name: string
   size?: number
   value: string | number
-} & InputHTMLAttributes<HTMLInputElement>
+} & InputHTMLAttributes<HTMLInputElement> &
+  XStyledProps
 
 const RadioBorderedBox: FunctionComponent<RadioBorderedBoxProps> = ({
   label,

--- a/src/components/RadioBorderedBox/index.tsx
+++ b/src/components/RadioBorderedBox/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { transparentize } from 'polished'
 import PropTypes from 'prop-types'
-import React, { FunctionComponent, InputHTMLAttributes } from 'react'
+import React, { FunctionComponent, InputHTMLAttributes, ReactNode } from 'react'
 import Badge, { badgeSizes, badgeVariants } from '../Badge'
 import type { Sizes, Variants } from '../Badge'
 import Box, { XStyledProps } from '../Box'
@@ -32,8 +32,8 @@ type RadioBorderedBoxProps = {
   badgeSize?: Sizes
   badgeText?: string
   badgeVariant?: Variants
-  children: React.ReactNode
-  label: string
+  children: ReactNode
+  label: ReactNode
   labelDescription?: string
   name: string
   size?: number
@@ -111,9 +111,9 @@ RadioBorderedBox.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   /**
-   * Label next to the radio button
+   * Label next to the radio button, can be a string or a more complex child
    */
-  label: PropTypes.string.isRequired,
+  label: PropTypes.node.isRequired,
   /**
    * Description next to the label
    */


### PR DESCRIPTION
Just added XStyledProps to radioBorderedBox.

Edit: also changed `label` prop to accept not only string but any other complex children.
