### PR TITLE
feat(textbox): reduce padding & add `inputProps`

### DIFF
--- a/src/components/TextBox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/TextBox/__tests__/__snapshots__/index.test.tsx.snap
@@ -1411,7 +1411,7 @@ exports[`TextBox should render correctly required true 1`] = `
   position: relative;
 }
 
-.cache-ik4go1 {
+.cache-13ncup3 {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -1437,52 +1437,52 @@ exports[`TextBox should render correctly required true 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: 32px;
+  padding-right: 22px;
 }
 
-.cache-ik4go1::-webkit-input-placeholder {
+.cache-13ncup3::-webkit-input-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-ik4go1::-moz-placeholder {
+.cache-13ncup3::-moz-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-ik4go1:-ms-input-placeholder {
+.cache-13ncup3:-ms-input-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-ik4go1::placeholder {
+.cache-13ncup3::placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-ik4go1:hover,
-.cache-ik4go1:focus {
+.cache-13ncup3:hover,
+.cache-13ncup3:focus {
   border-color: #dbdbdf;
 }
 
-.cache-ik4go1:focus {
+.cache-13ncup3:focus {
   box-shadow: 0 0 0 2px rgba(79,5,153,0.25);
   border-color: #4f0599;
 }
 
-.cache-ik4go1::-webkit-input-placeholder {
+.cache-13ncup3::-webkit-input-placeholder {
   opacity: 1;
 }
 
-.cache-ik4go1::-moz-placeholder {
+.cache-13ncup3::-moz-placeholder {
   opacity: 1;
 }
 
-.cache-ik4go1:-ms-input-placeholder {
+.cache-13ncup3:-ms-input-placeholder {
   opacity: 1;
 }
 
-.cache-ik4go1::placeholder {
+.cache-13ncup3::placeholder {
   opacity: 1;
 }
 
@@ -1582,7 +1582,7 @@ exports[`TextBox should render correctly required true 1`] = `
     >
       <input
         autocomplete="on"
-        class="cache-ik4go1 e18bmnpq0"
+        class="cache-13ncup3 e18bmnpq0"
         type="text"
         value="test"
       />
@@ -3450,7 +3450,7 @@ exports[`TextBox should render correctly with unit is px and required 1`] = `
   position: relative;
 }
 
-.cache-mmsc9t {
+.cache-ue76ck {
   -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
   transition: border-color 0.2s ease,box-shadow 0.2s ease;
   -webkit-appearance: none;
@@ -3476,35 +3476,35 @@ exports[`TextBox should render correctly with unit is px and required 1`] = `
   padding-left: 8px;
   padding-right: 20px;
   padding-top: 14px;
-  padding-right: 32px;
+  padding-right: 22px;
 }
 
-.cache-mmsc9t::-webkit-input-placeholder {
+.cache-ue76ck::-webkit-input-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-mmsc9t::-moz-placeholder {
+.cache-ue76ck::-moz-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-mmsc9t:-ms-input-placeholder {
+.cache-ue76ck:-ms-input-placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-mmsc9t::placeholder {
+.cache-ue76ck::placeholder {
   color: #b2b6c3;
   opacity: 0;
 }
 
-.cache-mmsc9t:hover,
-.cache-mmsc9t:focus {
+.cache-ue76ck:hover,
+.cache-ue76ck:focus {
   border-color: #dbdbdf;
 }
 
-.cache-mmsc9t:focus {
+.cache-ue76ck:focus {
   box-shadow: 0 0 0 2px rgba(79,5,153,0.25);
   border-color: #4f0599;
 }
@@ -3645,7 +3645,7 @@ exports[`TextBox should render correctly with unit is px and required 1`] = `
     >
       <input
         autocomplete="on"
-        class="cache-mmsc9t e18bmnpq0"
+        class="cache-ue76ck e18bmnpq0"
         name="test"
         type="text"
         value=""

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -480,13 +480,10 @@ const TextBox = forwardRef<
     const hasRightElement =
       valid || required || isPassToggleable || random || unit
 
-    const getRightElementPadding = () => {
-      if (required && hasRightElement) {
-        return 22
-      }
-
-      return undefined
-    }
+    // Set the right padding to 22px when the TextBox is required. 22px allows
+    // keeping the required star icon centered, since it is smaller than valid or
+    // unit icons which have a right padding of 32px.
+    const rightElementPadding = required ? 22 : undefined
 
     const getType = () => {
       if (isPassToggleable) {
@@ -567,7 +564,7 @@ const TextBox = forwardRef<
             fillAvailable={fillAvailable}
             hasLabel={hasLabel}
             hasRightElement={!!hasRightElement}
-            rightElementPadding={getRightElementPadding()}
+            rightElementPadding={rightElementPadding}
             id={id}
             inputSize={inputSize}
             isPlaceholderVisible={isPlaceholderVisible}

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -187,6 +187,11 @@ type StyledInputProps = {
   | TextareaHTMLAttributes<HTMLTextAreaElement>
 )
 
+type InputProps = Omit<
+  Exclude<StyledInputProps, TextareaHTMLAttributes<HTMLTextAreaElement>>,
+  'inputSize'
+>
+
 const StyledInput = styled('input', {
   shouldForwardProp: props =>
     ![
@@ -334,6 +339,7 @@ type TextBoxProps = {
   valid?: boolean
   value?: string | number
   wrap?: string
+  inputProps?: InputProps
 } & (
   | InputHTMLAttributes<HTMLInputElement>
   | TextareaHTMLAttributes<HTMLTextAreaElement>
@@ -380,6 +386,7 @@ const TextBox = forwardRef<
       valid,
       value,
       wrap,
+      inputProps,
       ...props
     },
     ref,
@@ -579,6 +586,7 @@ const TextBox = forwardRef<
             type={getType()}
             value={value}
             wrap={wrap}
+            {...inputProps}
           />
           {hasLabel && (
             <StyledLabel
@@ -629,6 +637,7 @@ TextBox.propTypes = {
   generated: PropTypes.bool,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   id: PropTypes.string,
+  inputProps: PropTypes.objectOf(PropTypes.any),
   label: PropTypes.string,
   multiline: PropTypes.bool,
   name: PropTypes.string,

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -177,6 +177,7 @@ type StyledInputProps = {
   fillAvailable?: boolean
   hasLabel?: boolean
   hasRightElement?: boolean
+  rightElementPadding?: number
   isPlaceholderVisible?: boolean
   multiline?: boolean
   resizable?: boolean
@@ -198,6 +199,7 @@ const StyledInput = styled('input', {
       'multiline',
       'resizable',
       'inputSize',
+      'rightElementPadding',
     ].includes(props.toString()),
 })<StyledInputProps>`
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -288,10 +290,10 @@ const StyledInput = styled('input', {
     padding-top: 8px;
   `}
 
-  ${({ hasRightElement }) =>
+  ${({ hasRightElement, rightElementPadding }) =>
     hasRightElement &&
     `
-    padding-right: 32px;
+    padding-right: ${rightElementPadding || 32}px;
   `}
 `
 type TextBoxProps = {
@@ -471,6 +473,14 @@ const TextBox = forwardRef<
     const hasRightElement =
       valid || required || isPassToggleable || random || unit
 
+    const getRightElementPadding = () => {
+      if (required && hasRightElement) {
+        return 22
+      }
+
+      return undefined
+    }
+
     const getType = () => {
       if (isPassToggleable) {
         return passwordVisible || generated ? 'text' : 'password'
@@ -550,6 +560,7 @@ const TextBox = forwardRef<
             fillAvailable={fillAvailable}
             hasLabel={hasLabel}
             hasRightElement={!!hasRightElement}
+            rightElementPadding={getRightElementPadding()}
             id={id}
             inputSize={inputSize}
             isPlaceholderVisible={isPlaceholderVisible}


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

The padding-right has been reduced to `required` TextBox, and this PR adds an `inputProps` prop to TextBox which are forwarded to the input element.

## Relevant logs and/or screenshots

Page | Before | After
:-   |  :-:   | -:
-- | <img width="186" alt="Screenshot 2021-09-16 at 15 14 34" src="https://user-images.githubusercontent.com/43268759/133618831-25b93957-edd5-4171-a7a3-54ba44dd1c64.png"> | <img width="98" alt="Screenshot 2021-09-16 at 15 15 00" src="https://user-images.githubusercontent.com/43268759/133618851-4ba19b61-61ed-4ea9-8fd6-2664719949c9.png">



