### PR TITLE
fix: colors not const

### DIFF
--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -69,7 +69,7 @@ const colors = {
   warning,
   white,
   zumthor,
-} as const
+}
 
 export type Color = keyof typeof colors
 

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -37,7 +37,7 @@ const info = blue
 
 const transparent = 'transparent'
 
-const colors = {
+const baseColors = {
   beta,
   black,
   blue,
@@ -71,6 +71,8 @@ const colors = {
   zumthor,
 }
 
-export type Color = keyof typeof colors
+export type Color = keyof typeof baseColors
+
+const colors: Record<Color, string> = baseColors
 
 export default colors


### PR DESCRIPTION
Removes const for colors so typescript works when overwriting base colors.