### PR TITLE
fix(flexbox): fixed proptypes spreading to accept xstyled props

### DIFF
--- a/src/components/Container/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Container/__tests__/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ exports[`Container renders correctly 1`] = `
   margin-top: 40px;
 }
 
-.cache-sfdutq {
+.cache-f3u9y9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -74,7 +74,7 @@ exports[`Container renders correctly 1`] = `
     class="elb23zt1 cache-9ic6y5 e7ah3bn0"
   >
     <div
-      class="e1l6meh00 cache-sfdutq e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-f3u9y9 e7ah3bn0"
     >
       <div
         class="cache-102bhvz e7ah3bn0"
@@ -100,7 +100,7 @@ exports[`Container renders correctly on edition mode 1`] = `
   margin-top: 40px;
 }
 
-.cache-sfdutq {
+.cache-f3u9y9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -168,7 +168,7 @@ exports[`Container renders correctly on edition mode 1`] = `
     class="elb23zt1 cache-9ic6y5 e7ah3bn0"
   >
     <div
-      class="e1l6meh00 cache-sfdutq e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-f3u9y9 e7ah3bn0"
     >
       <div
         class="cache-102bhvz e7ah3bn0"
@@ -194,7 +194,7 @@ exports[`Container renders correctly when disabled 1`] = `
   margin-top: 40px;
 }
 
-.cache-sfdutq {
+.cache-f3u9y9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -262,7 +262,7 @@ exports[`Container renders correctly when disabled 1`] = `
     class="elb23zt1 cache-9ic6y5 e7ah3bn0"
   >
     <div
-      class="e1l6meh00 cache-sfdutq e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-f3u9y9 e7ah3bn0"
     >
       <div
         class="cache-102bhvz e7ah3bn0"
@@ -289,7 +289,7 @@ exports[`Container renders correctly with small variant 1`] = `
   margin-top: 40px;
 }
 
-.cache-sfdutq {
+.cache-f3u9y9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -357,7 +357,7 @@ exports[`Container renders correctly with small variant 1`] = `
     class="elb23zt1 cache-9ic6y5 e7ah3bn0"
   >
     <div
-      class="e1l6meh00 cache-sfdutq e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-f3u9y9 e7ah3bn0"
     >
       <div
         class="cache-102bhvz e7ah3bn0"

--- a/src/components/DotSteps/__tests__/__snapshots__/index.js.snap
+++ b/src/components/DotSteps/__tests__/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DotSteps renders correctly 1`] = `
 <DocumentFragment>
-  .cache-16zi2u0 {
+  .cache-1hu6ghd {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,14 +13,14 @@ exports[`DotSteps renders correctly 1`] = `
   justify-content: center;
 }
 
-.cache-16zi2u0 .e1cog6k71:nth-of-type(2)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-1hu6ghd .e1cog6k71:nth-of-type(2)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-0px);
   -moz-transform: translateX(-0px);
   -ms-transform: translateX(-0px);
   transform: translateX(-0px);
 }
 
-.cache-16zi2u0 .e1cog6k71:nth-of-type(1)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-1hu6ghd .e1cog6k71:nth-of-type(1)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-26px);
   -moz-transform: translateX(-26px);
   -ms-transform: translateX(-26px);
@@ -76,7 +76,7 @@ exports[`DotSteps renders correctly 1`] = `
 }
 
 <div
-    class="e1cog6k70 e1l6meh00 cache-16zi2u0 e1l6meh01"
+    class="e1cog6k70 e1l6meh00 e1l6meh01 cache-1hu6ghd e7ah3bn0"
   >
     <div
       aria-selected="true"
@@ -92,7 +92,7 @@ exports[`DotSteps renders correctly 1`] = `
 
 exports[`DotSteps renders correctly useState function 1`] = `
 <DocumentFragment>
-  .cache-14geho4 {
+  .cache-15szogd {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -103,70 +103,70 @@ exports[`DotSteps renders correctly useState function 1`] = `
   justify-content: center;
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(10)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(10)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-0px);
   -moz-transform: translateX(-0px);
   -ms-transform: translateX(-0px);
   transform: translateX(-0px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(9)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(9)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-26px);
   -moz-transform: translateX(-26px);
   -ms-transform: translateX(-26px);
   transform: translateX(-26px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(8)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(8)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-52px);
   -moz-transform: translateX(-52px);
   -ms-transform: translateX(-52px);
   transform: translateX(-52px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(7)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(7)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-78px);
   -moz-transform: translateX(-78px);
   -ms-transform: translateX(-78px);
   transform: translateX(-78px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(6)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(6)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-104px);
   -moz-transform: translateX(-104px);
   -ms-transform: translateX(-104px);
   transform: translateX(-104px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(5)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(5)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-130px);
   -moz-transform: translateX(-130px);
   -ms-transform: translateX(-130px);
   transform: translateX(-130px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(4)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(4)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-156px);
   -moz-transform: translateX(-156px);
   -ms-transform: translateX(-156px);
   transform: translateX(-156px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(3)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(3)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-182px);
   -moz-transform: translateX(-182px);
   -ms-transform: translateX(-182px);
   transform: translateX(-182px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(2)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(2)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-208px);
   -moz-transform: translateX(-208px);
   -ms-transform: translateX(-208px);
   transform: translateX(-208px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(1)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(1)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-234px);
   -moz-transform: translateX(-234px);
   -ms-transform: translateX(-234px);
@@ -222,7 +222,7 @@ exports[`DotSteps renders correctly useState function 1`] = `
 }
 
 <div
-    class="e1cog6k70 e1l6meh00 cache-14geho4 e1l6meh01"
+    class="e1cog6k70 e1l6meh00 e1l6meh01 cache-15szogd e7ah3bn0"
   >
     <div
       aria-selected="false"
@@ -270,7 +270,7 @@ exports[`DotSteps renders correctly useState function 1`] = `
 
 exports[`DotSteps renders correctly wit 10 steps, default step=4 1`] = `
 <DocumentFragment>
-  .cache-14geho4 {
+  .cache-15szogd {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -281,70 +281,70 @@ exports[`DotSteps renders correctly wit 10 steps, default step=4 1`] = `
   justify-content: center;
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(10)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(10)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-0px);
   -moz-transform: translateX(-0px);
   -ms-transform: translateX(-0px);
   transform: translateX(-0px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(9)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(9)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-26px);
   -moz-transform: translateX(-26px);
   -ms-transform: translateX(-26px);
   transform: translateX(-26px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(8)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(8)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-52px);
   -moz-transform: translateX(-52px);
   -ms-transform: translateX(-52px);
   transform: translateX(-52px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(7)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(7)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-78px);
   -moz-transform: translateX(-78px);
   -ms-transform: translateX(-78px);
   transform: translateX(-78px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(6)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(6)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-104px);
   -moz-transform: translateX(-104px);
   -ms-transform: translateX(-104px);
   transform: translateX(-104px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(5)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(5)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-130px);
   -moz-transform: translateX(-130px);
   -ms-transform: translateX(-130px);
   transform: translateX(-130px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(4)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(4)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-156px);
   -moz-transform: translateX(-156px);
   -ms-transform: translateX(-156px);
   transform: translateX(-156px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(3)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(3)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-182px);
   -moz-transform: translateX(-182px);
   -ms-transform: translateX(-182px);
   transform: translateX(-182px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(2)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(2)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-208px);
   -moz-transform: translateX(-208px);
   -ms-transform: translateX(-208px);
   transform: translateX(-208px);
 }
 
-.cache-14geho4 .e1cog6k71:nth-of-type(1)[aria-selected='true']~.e1cog6k71:last-child:after {
+.cache-15szogd .e1cog6k71:nth-of-type(1)[aria-selected='true']~.e1cog6k71:last-child:after {
   -webkit-transform: translateX(-234px);
   -moz-transform: translateX(-234px);
   -ms-transform: translateX(-234px);
@@ -400,7 +400,7 @@ exports[`DotSteps renders correctly wit 10 steps, default step=4 1`] = `
 }
 
 <div
-    class="e1cog6k70 e1l6meh00 cache-14geho4 e1l6meh01"
+    class="e1cog6k70 e1l6meh00 e1l6meh01 cache-15szogd e7ah3bn0"
   >
     <div
       aria-selected="false"

--- a/src/components/FlexBox/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/FlexBox/__tests__/__snapshots__/index.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`FlexBox Child renders correctly with alignSelf 1`] = `
 <DocumentFragment>
-  .cache-1tts2hr {
+  .cache-meptv9 {
   -webkit-align-self: flex-end;
   -ms-flex-item-align: flex-end;
   align-self: flex-end;
 }
 
 <div
-    class="cache-1tts2hr e1l6meh01"
+    class="e1l6meh01 cache-meptv9 e7ah3bn0"
   >
     Sample FlexBox.Child
   </div>
@@ -19,7 +19,7 @@ exports[`FlexBox Child renders correctly with alignSelf 1`] = `
 exports[`FlexBox Child renders correctly with default values 1`] = `
 <DocumentFragment>
   <div
-    class="cache-yue654 e1l6meh01"
+    class="e1l6meh01 cache-1c7ex61 e7ah3bn0"
   >
     This should act as a regular div
   </div>
@@ -28,7 +28,7 @@ exports[`FlexBox Child renders correctly with default values 1`] = `
 
 exports[`FlexBox Child renders correctly with explicit basis, grow and shrink 1`] = `
 <DocumentFragment>
-  .cache-1c3tqqh {
+  .cache-4aswx8 {
   -webkit-flex-basis: 1;
   -ms-flex-preferred-size: 1;
   flex-basis: 1;
@@ -42,7 +42,7 @@ exports[`FlexBox Child renders correctly with explicit basis, grow and shrink 1`
 }
 
 <div
-    class="cache-1c3tqqh e1l6meh01"
+    class="e1l6meh01 cache-4aswx8 e7ah3bn0"
   >
     Sample FlexBox.Child
   </div>
@@ -51,14 +51,14 @@ exports[`FlexBox Child renders correctly with explicit basis, grow and shrink 1`
 
 exports[`FlexBox Child renders correctly with flex as a number 1`] = `
 <DocumentFragment>
-  .cache-jacheq {
+  .cache-fhbzyg {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
 }
 
 <div
-    class="cache-jacheq e1l6meh01"
+    class="e1l6meh01 cache-fhbzyg e7ah3bn0"
   >
     Sample FlexBox.Child
   </div>
@@ -67,14 +67,14 @@ exports[`FlexBox Child renders correctly with flex as a number 1`] = `
 
 exports[`FlexBox Child renders correctly with flex as string 1`] = `
 <DocumentFragment>
-  .cache-17tgpt1 {
+  .cache-swent9 {
   -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
   flex: 0 1 auto;
 }
 
 <div
-    class="cache-17tgpt1 e1l6meh01"
+    class="e1l6meh01 cache-swent9 e7ah3bn0"
   >
     Sample FlexBox.Child
   </div>
@@ -83,14 +83,14 @@ exports[`FlexBox Child renders correctly with flex as string 1`] = `
 
 exports[`FlexBox Child renders correctly with order 1`] = `
 <DocumentFragment>
-  .cache-19dl89p {
+  .cache-1h50qcu {
   -webkit-order: 6;
   -ms-flex-order: 6;
   order: 6;
 }
 
 <div
-    class="cache-19dl89p e1l6meh01"
+    class="e1l6meh01 cache-1h50qcu e7ah3bn0"
   >
     Sample FlexBox.Child
   </div>
@@ -99,7 +99,7 @@ exports[`FlexBox Child renders correctly with order 1`] = `
 
 exports[`FlexBox Parent renders correctly with align properties 1`] = `
 <DocumentFragment>
-  .cache-bhrqkk {
+  .cache-1iiq4c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -114,7 +114,7 @@ exports[`FlexBox Parent renders correctly with align properties 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-bhrqkk e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-1iiq4c2 e7ah3bn0"
   >
     Sample FlexBox
   </div>
@@ -123,7 +123,7 @@ exports[`FlexBox Parent renders correctly with align properties 1`] = `
 
 exports[`FlexBox Parent renders correctly with children properties 1`] = `
 <DocumentFragment>
-  .cache-1wqcvwa {
+  .cache-1lbwzv0 {
   -webkit-flex-basis: 0;
   -ms-flex-preferred-size: 0;
   flex-basis: 0;
@@ -137,7 +137,7 @@ exports[`FlexBox Parent renders correctly with children properties 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-1wqcvwa e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-1lbwzv0 e7ah3bn0"
   >
     Sample FlexBox
   </div>
@@ -146,7 +146,7 @@ exports[`FlexBox Parent renders correctly with children properties 1`] = `
 
 exports[`FlexBox Parent renders correctly with custom direction 1`] = `
 <DocumentFragment>
-  .cache-e6infm {
+  .cache-id5yjj {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -157,7 +157,7 @@ exports[`FlexBox Parent renders correctly with custom direction 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-e6infm e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-id5yjj e7ah3bn0"
   >
     Sample FlexBox
   </div>
@@ -166,7 +166,7 @@ exports[`FlexBox Parent renders correctly with custom direction 1`] = `
 
 exports[`FlexBox Parent renders correctly with custom wrap 1`] = `
 <DocumentFragment>
-  .cache-pvzshq {
+  .cache-31i89 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -178,7 +178,7 @@ exports[`FlexBox Parent renders correctly with custom wrap 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-pvzshq e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-31i89 e7ah3bn0"
   >
     Sample FlexBox
   </div>
@@ -187,7 +187,7 @@ exports[`FlexBox Parent renders correctly with custom wrap 1`] = `
 
 exports[`FlexBox Parent renders correctly with default values 1`] = `
 <DocumentFragment>
-  .cache-10tjcsc {
+  .cache-1aacvce {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -195,7 +195,7 @@ exports[`FlexBox Parent renders correctly with default values 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-10tjcsc e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-1aacvce e7ah3bn0"
   >
     Sample FlexBox
   </div>
@@ -204,7 +204,7 @@ exports[`FlexBox Parent renders correctly with default values 1`] = `
 
 exports[`FlexBox Parent renders correctly with inline flex 1`] = `
 <DocumentFragment>
-  .cache-hqudw {
+  .cache-f9k8f1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -212,7 +212,7 @@ exports[`FlexBox Parent renders correctly with inline flex 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-hqudw e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-f9k8f1 e7ah3bn0"
   >
     Sample FlexBox
   </div>
@@ -221,7 +221,7 @@ exports[`FlexBox Parent renders correctly with inline flex 1`] = `
 
 exports[`FlexBox Parent renders correctly with justifyContent 1`] = `
 <DocumentFragment>
-  .cache-zvjxz1 {
+  .cache-zchic9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -233,7 +233,7 @@ exports[`FlexBox Parent renders correctly with justifyContent 1`] = `
 }
 
 <div
-    class="e1l6meh00 cache-zvjxz1 e1l6meh01"
+    class="e1l6meh00 e1l6meh01 cache-zchic9 e7ah3bn0"
   >
     Sample FlexBox
   </div>

--- a/src/components/FlexBox/index.tsx
+++ b/src/components/FlexBox/index.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled'
 import PropTypes from 'prop-types'
 import React, { FunctionComponent } from 'react'
+import Box, { XStyledProps } from '../Box'
 
-const StyledChild = styled('div', {
+const StyledChild = styled(Box, {
   shouldForwardProp: prop =>
     !['alignSelf', 'basis', 'grow', 'shrink', 'flex', 'order'].includes(
       prop.toString(),
@@ -91,7 +92,8 @@ type FlexBoxProps = {
     | 'space-around'
     | 'space-between'
   wrap?: 'nowrap' | 'wrap-reverse' | 'wrap'
-} & ChildProps
+} & ChildProps &
+  XStyledProps
 
 type FlexBoxType = FunctionComponent<FlexBoxProps> & {
   Child: typeof Child

--- a/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -1931,7 +1931,7 @@ exports[`List should render correctly multiselect and with click 1`] = `
   font-weight: 500;
 }
 
-.cache-yinhqs {
+.cache-1bkooe {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -2515,7 +2515,7 @@ exports[`List should render correctly multiselect and with click 1`] = `
         items selected
       </div>
       <div
-        class="e1l6meh00 cache-yinhqs e1l6meh01"
+        class="e1l6meh00 e1l6meh01 cache-1bkooe e7ah3bn0"
       >
         Test SelectBar
       </div>
@@ -2947,7 +2947,7 @@ exports[`List should render correctly multiselect and with click and not functio
   font-weight: 500;
 }
 
-.cache-yinhqs {
+.cache-1bkooe {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -3531,7 +3531,7 @@ exports[`List should render correctly multiselect and with click and not functio
         items selected
       </div>
       <div
-        class="e1l6meh00 cache-yinhqs e1l6meh01"
+        class="e1l6meh00 e1l6meh01 cache-1bkooe e7ah3bn0"
       >
         Test SelectBar
       </div>
@@ -9080,7 +9080,7 @@ exports[`List should render correctly multiselect, explorer variant and with cli
   font-weight: 500;
 }
 
-.cache-yinhqs {
+.cache-1bkooe {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -9585,7 +9585,7 @@ exports[`List should render correctly multiselect, explorer variant and with cli
         items selected
       </div>
       <div
-        class="e1l6meh00 cache-yinhqs e1l6meh01"
+        class="e1l6meh00 e1l6meh01 cache-1bkooe e7ah3bn0"
       >
         Test SelectBar
       </div>
@@ -10761,7 +10761,7 @@ exports[`List should render correctly multiselect, table variant and with click 
   font-weight: 500;
 }
 
-.cache-yinhqs {
+.cache-1bkooe {
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
@@ -11266,7 +11266,7 @@ exports[`List should render correctly multiselect, table variant and with click 
         items selected
       </div>
       <div
-        class="e1l6meh00 cache-yinhqs e1l6meh01"
+        class="e1l6meh00 e1l6meh01 cache-1bkooe e7ah3bn0"
       >
         Test SelectBar
       </div>

--- a/src/components/TagsPoplist/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/TagsPoplist/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TagsPoplist renders correctly 1`] = `
 <DocumentFragment>
-  .cache-10tjcsc {
+  .cache-1aacvce {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -115,7 +115,7 @@ exports[`TagsPoplist renders correctly 1`] = `
 
 <div>
     <div
-      class="e1l6meh00 cache-10tjcsc e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-1aacvce e7ah3bn0"
     >
       <div
         class="cache-1ufuj7x e7ah3bn0"
@@ -154,7 +154,7 @@ exports[`TagsPoplist renders correctly 1`] = `
 
 exports[`TagsPoplist renders correctly with custom threshold 1`] = `
 <DocumentFragment>
-  .cache-10tjcsc {
+  .cache-1aacvce {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -231,7 +231,7 @@ exports[`TagsPoplist renders correctly with custom threshold 1`] = `
 
 <div>
     <div
-      class="e1l6meh00 cache-10tjcsc e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-1aacvce e7ah3bn0"
     >
       <div
         class="cache-1ufuj7x e7ah3bn0"
@@ -264,7 +264,7 @@ exports[`TagsPoplist renders correctly with custom threshold 1`] = `
 
 exports[`TagsPoplist renders correctly with custom threshold and extra tags 1`] = `
 <DocumentFragment>
-  .cache-10tjcsc {
+  .cache-1aacvce {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -397,7 +397,7 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags 1`] 
 
 <div>
     <div
-      class="e1l6meh00 cache-10tjcsc e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-1aacvce e7ah3bn0"
     >
       <div
         class="cache-1ufuj7x e7ah3bn0"
@@ -445,7 +445,7 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags 1`] 
 
 exports[`TagsPoplist renders correctly with custom threshold and extra tags and maxLength inferior to the combined size of tags 1`] = `
 <DocumentFragment>
-  .cache-10tjcsc {
+  .cache-1aacvce {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -558,7 +558,7 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags and 
 
 <div>
     <div
-      class="e1l6meh00 cache-10tjcsc e1l6meh01"
+      class="e1l6meh00 e1l6meh01 cache-1aacvce e7ah3bn0"
     >
       <div
         class="cache-1ufuj7x e7ah3bn0"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### The following changes where made:

`Flexbox` was not applying xstyled props such as `m={}`, `p={}`, etc. like `Box` component does.

This is because `Flexbox` style is a div so I changed it to a `Box`.




