### PR TITLE
fix: children is not mandatory for button component

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -354,7 +354,7 @@ const StyledButton = styled(Box, {
 `
 
 export type ButtonProps = Omit<StyledButtonProps, 'variant' | 'size'> & {
-  children: ReactNode
+  children?: ReactNode
   variant?: ButtonVariant
   innerRef: Ref<Element>
   size?: ButtonSize


### PR DESCRIPTION
## Summary

## Type

- Bug



