### PR TITLE
fix(radio-bordered-box): avoid using multiple label

### DIFF
--- a/src/components/RadioBorderedBox/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/RadioBorderedBox/__tests__/__snapshots__/index.tsx.snap
@@ -100,7 +100,7 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   margin-right: 8px;
 }
 
-<label
+<div
     class="e13z6rra0 cache-1l5bs5y e7ah3bn0"
   >
     <div
@@ -140,7 +140,7 @@ exports[`RadioBorderedBox renders correctly 1`] = `
     <div>
       Choice description
     </div>
-  </label>
+  </div>
 </DocumentFragment>
 `;
 
@@ -246,7 +246,7 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   margin-right: 8px;
 }
 
-<label
+<div
     class="e13z6rra0 cache-my9iyn e7ah3bn0"
   >
     <div
@@ -287,7 +287,7 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
     <div>
       Choice description
     </div>
-  </label>
+  </div>
 </DocumentFragment>
 `;
 
@@ -384,7 +384,7 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   margin-right: 8px;
 }
 
-<label
+<div
     class="e13z6rra0 cache-2w7h54 e7ah3bn0"
     disabled=""
   >
@@ -428,7 +428,7 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
     <div>
       Choice description
     </div>
-  </label>
+  </div>
 </DocumentFragment>
 `;
 
@@ -551,7 +551,7 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   height: 24px;
 }
 
-<label
+<div
     class="e13z6rra0 cache-2w7h54 e7ah3bn0"
     disabled=""
   >
@@ -602,6 +602,6 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
     <div>
       Choice description
     </div>
-  </label>
+  </div>
 </DocumentFragment>
 `;

--- a/src/components/RadioBorderedBox/__tests__/index.tsx
+++ b/src/components/RadioBorderedBox/__tests__/index.tsx
@@ -82,6 +82,6 @@ describe('RadioBorderedBox', () => {
     )
     const box = document.getElementById('radiotest')
     userEvent.click(box as Element)
-    await waitFor(() => expect(choice).toBe('choice1'))
+    await waitFor(() => expect(choice).not.toBe('choice1'))
   })
 })

--- a/src/components/RadioBorderedBox/index.tsx
+++ b/src/components/RadioBorderedBox/index.tsx
@@ -60,7 +60,6 @@ const RadioBorderedBox: FunctionComponent<RadioBorderedBoxProps> = ({
 }) => (
   <StyledBox
     bordered
-    as="label"
     display="block"
     disabled={disabled}
     checked={checked}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarizse concisely:

When using a Label wrapping another radio/label you will have side effect bubble event if you are using an other input inside your radio button.

This example show us the side effect (Firefox / Chrome ) 
You can try here https://stackoverflow.com/questions/24501497/why-the-onclick-element-will-trigger-twice-for-label-element 



#### What is expected?

#### The following changes where made:

1. Remove Wrapped label of RadioBorderedBox
2. You can only click on the label of the radio and not all the BorderedBox.
3. What can possibly done, is using only css https://codepen.io/chriscoyier/pen/eYOqrZR but you will also have side effect like no text selection for a user ( copy / paste )

