### PR TITLE
refactor(a11y): activity-indicator

### DIFF
--- a/src/components/ActivityIndicator/__stories__/index.stories.tsx
+++ b/src/components/ActivityIndicator/__stories__/index.stories.tsx
@@ -29,6 +29,7 @@ Percentages.decorators = [
           <ActivityIndicator
             key={`percent-${percentage}`}
             percentage={percentage}
+            label="Loading example"
           />
         </div>
       ))}
@@ -48,7 +49,12 @@ Sizes.decorators = [
     <>
       {[8, 16, 24, 32, 40, 100].map(size => (
         <div style={{ display: 'inline-flex', marginRight: 8 }}>
-          <ActivityIndicator key={`size-${size}`} percentage={75} size={size} />
+          <ActivityIndicator
+            key={`size-${size}`}
+            percentage={75}
+            size={size}
+            label="Loading example"
+          />
         </div>
       ))}
     </>
@@ -71,6 +77,7 @@ Colors.decorators = [
             key={`color-${color}`}
             color={color}
             percentage={75}
+            label="Loading example"
           />
         </div>
       ))}
@@ -95,6 +102,7 @@ TrailColor.decorators = [
               key={`trailColor-${color}`}
               trailColor={color}
               percentage={75}
+              label="Loading example"
             />
           </div>
         ),
@@ -119,6 +127,7 @@ StrokeWidth.decorators = [
             key={`strokeWidth-${size}`}
             percentage={75}
             strokeWidth={size}
+            label="Loading example"
           />
         </div>
       ))}
@@ -142,6 +151,7 @@ Text.decorators = [
             key={`text-${percentage}`}
             percentage={percentage}
             text={`${percentage}%`}
+            label="Loading example"
           />
         </div>
       ))}
@@ -161,7 +171,12 @@ Active.decorators = [
     <>
       {[10, 20, 30, 40, 50, 100].map(size => (
         <div style={{ display: 'inline-flex', marginRight: 8 }}>
-          <ActivityIndicator key={`active-${size}`} size={size} active />
+          <ActivityIndicator
+            key={`active-${size}`}
+            size={size}
+            active
+            label="Loading example"
+          />
         </div>
       ))}
     </>

--- a/src/components/ActivityIndicator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/ActivityIndicator/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,36 +25,65 @@ exports[`ActivityIndicator renders active with custom percentage 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
-<svg
-    class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-2b664bf96e3e0a8435cca796484fca52"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-2b664bf96e3e0a8435cca796484fca52"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -83,36 +112,65 @@ exports[`ActivityIndicator renders active with default percentage 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
-<svg
-    class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-371352a55f664e7f76321769a2ef2202"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-371352a55f664e7f76321769a2ef2202"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -123,36 +181,65 @@ exports[`ActivityIndicator renders default props 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-60023a5b76f6ba653e014b7ae5876e75"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-60023a5b76f6ba653e014b7ae5876e75"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -163,36 +250,65 @@ exports[`ActivityIndicator renders with color beta 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #ff8c69; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #ff8c69; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-7063bfb50c82f7eb2cae00e16a4360ef"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-7063bfb50c82f7eb2cae00e16a4360ef"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -203,36 +319,65 @@ exports[`ActivityIndicator renders with color black 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-2289b383c71cf9ec0b1bf694b97f1782"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-2289b383c71cf9ec0b1bf694b97f1782"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -243,36 +388,65 @@ exports[`ActivityIndicator renders with color blue 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #3f6ed8; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #3f6ed8; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-bd7936ab51bceabdc1043cbd2f1a4f63"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-bd7936ab51bceabdc1043cbd2f1a4f63"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -283,36 +457,65 @@ exports[`ActivityIndicator renders with color chartGreen 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #33BBB3; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #33BBB3; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-24d8f40acc6915f289d4b94b41881455"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-24d8f40acc6915f289d4b94b41881455"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -323,36 +526,65 @@ exports[`ActivityIndicator renders with color chartNegativeRed 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #ef5774; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #ef5774; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-d8ad7e13a96eb9c16f9869fdb95aaf4b"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-d8ad7e13a96eb9c16f9869fdb95aaf4b"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -363,36 +595,65 @@ exports[`ActivityIndicator renders with custom size 1`] = `
   width: 100px;
 }
 
-<svg
-    class="CircularProgressbar  cache-13skzuh e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-13skzuh e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-c77f6669ee653ed34c0afaa29e3ec0bb"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-c77f6669ee653ed34c0afaa29e3ec0bb"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -403,36 +664,65 @@ exports[`ActivityIndicator renders with inlined color 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #ff0000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #ff0000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-1a4523b695a458718e019c5fa7c65458"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-1a4523b695a458718e019c5fa7c65458"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -443,36 +733,65 @@ exports[`ActivityIndicator renders with inlined trailColor 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #ff0000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #ff0000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-46bbfc4f073177c65ac6baf1dca453db"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-46bbfc4f073177c65ac6baf1dca453db"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -501,36 +820,65 @@ exports[`ActivityIndicator renders with percentage 75 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
-<svg
-    class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 65.97344572538566px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 65.97344572538566px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-a801327c057962085b74b75552d2c7be"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="75"
+      aria-valuetext="75%"
+      id="activityIndicator-a801327c057962085b74b75552d2c7be"
+      max="100"
+      value="75"
+    >
+      75%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -541,36 +889,65 @@ exports[`ActivityIndicator renders with strokeWidth 25 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-37.5
       a 37.5,37.5 0 1 1 0,75
       a 37.5,37.5 0 1 1 0,-75
     "
-      fill-opacity="0"
-      stroke-width="25"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 235.61944901923448px 235.61944901923448px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="25"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 235.61944901923448px 235.61944901923448px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-37.5
       a 37.5,37.5 0 1 1 0,75
       a 37.5,37.5 0 1 1 0,-75
     "
-      fill-opacity="0"
-      stroke-width="25"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 235.61944901923448px 235.61944901923448px; stroke-dashoffset: 188.4955592153876px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="25"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 235.61944901923448px 235.61944901923448px; stroke-dashoffset: 188.4955592153876px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-4da1aea1b7761cfcdd27e4f2299d5eb4"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-4da1aea1b7761cfcdd27e4f2299d5eb4"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -581,44 +958,73 @@ exports[`ActivityIndicator renders with text 100% 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
-      M 50,50
-      m 0,-42
-      a 42,42 0 1 1 0,84
-      a 42,42 0 1 1 0,-84
-    "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
-      M 50,50
-      m 0,-42
-      a 42,42 0 1 1 0,84
-      a 42,42 0 1 1 0,-84
-    "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-    <text
-      class="CircularProgressbar-text"
-      style="dominant-baseline: middle; fill: #4f0599; font-size: 26px; text-anchor: middle;"
-      x="50"
-      y="50"
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
     >
-      100%
-    </text>
-  </svg>
+      <path
+        class="CircularProgressbar-trail"
+        d="
+      M 50,50
+      m 0,-42
+      a 42,42 0 1 1 0,84
+      a 42,42 0 1 1 0,-84
+    "
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
+      M 50,50
+      m 0,-42
+      a 42,42 0 1 1 0,84
+      a 42,42 0 1 1 0,-84
+    "
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+      <text
+        class="CircularProgressbar-text"
+        style="dominant-baseline: middle; fill: #4f0599; font-size: 26px; text-anchor: middle;"
+        x="50"
+        y="50"
+      >
+        100%
+      </text>
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-4fed84b1f49cceb27916e3da7c3ef25c"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-4fed84b1f49cceb27916e3da7c3ef25c"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -629,36 +1035,65 @@ exports[`ActivityIndicator renders with trailColor beta 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #ff8c69; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #ff8c69; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-a855c09db91872e92cad9c536828a7da"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-a855c09db91872e92cad9c536828a7da"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -669,36 +1104,65 @@ exports[`ActivityIndicator renders with trailColor black 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #000; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-aa5c64d7edcddbf9dbdd7d786cd91aca"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-aa5c64d7edcddbf9dbdd7d786cd91aca"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -709,36 +1173,65 @@ exports[`ActivityIndicator renders with trailColor blue 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #3f6ed8; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #3f6ed8; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-184ca3585f51e54c3a9f0743c9d670ac"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-184ca3585f51e54c3a9f0743c9d670ac"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -749,36 +1242,65 @@ exports[`ActivityIndicator renders with trailColor chartGreen 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #33BBB3; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #33BBB3; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-061fba5deeb511c8136946b5ea14d82c"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-061fba5deeb511c8136946b5ea14d82c"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;
 
@@ -789,35 +1311,64 @@ exports[`ActivityIndicator renders with trailColor chartNegativeRed 1`] = `
   width: 40px;
 }
 
-<svg
-    class="CircularProgressbar  cache-5i4mj9 e7dhm9i0"
-    data-test-id="CircularProgressbar"
-    viewBox="0 0 100 100"
+<div
+    aria-hidden="true"
   >
-    <path
-      class="CircularProgressbar-trail"
-      d="
+    <svg
+      class="CircularProgressbar  cache-5i4mj9 e7dhm9i1"
+      data-test-id="CircularProgressbar"
+      viewBox="0 0 100 100"
+    >
+      <path
+        class="CircularProgressbar-trail"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #ef5774; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-    />
-    <path
-      class="CircularProgressbar-path"
-      d="
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #ef5774; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+      />
+      <path
+        class="CircularProgressbar-path"
+        d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-      fill-opacity="0"
-      stroke-width="16"
-      style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-    />
-  </svg>
+        fill-opacity="0"
+        stroke-width="16"
+        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+      />
+    </svg>
+  </div>
+  .cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
+<div
+    class="cache-546l7a e7dhm9i0"
+  >
+    <label
+      for="activityIndicator-5893e90e45cf8764fa0f9efbd47bb585"
+    >
+      Loading test
+    </label>
+    <progress
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="20"
+      aria-valuetext="20%"
+      id="activityIndicator-5893e90e45cf8764fa0f9efbd47bb585"
+      max="100"
+      value="20"
+    >
+      20%
+    </progress>
+  </div>
 </DocumentFragment>
 `;

--- a/src/components/ActivityIndicator/__tests__/index.test.tsx
+++ b/src/components/ActivityIndicator/__tests__/index.test.tsx
@@ -5,43 +5,63 @@ import { colors } from '../../../theme'
 
 describe('ActivityIndicator', () => {
   test(`renders default props`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator />))
+    shouldMatchEmotionSnapshot(<ActivityIndicator label="Loading test" />))
 
   test(`renders active with default percentage`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator active />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" active />,
+    ))
 
   test(`renders active with custom percentage`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator active />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" active />,
+    ))
 
   test(`renders with percentage 75`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator active percentage={75} />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" active percentage={75} />,
+    ))
 
   Object.keys(colors)
     .slice(0, 5)
     .forEach(color => {
       test(`renders with color ${color}`, () =>
-        shouldMatchEmotionSnapshot(<ActivityIndicator color={color} />))
+        shouldMatchEmotionSnapshot(
+          <ActivityIndicator label="Loading test" color={color} />,
+        ))
     })
 
   test(`renders with inlined color`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator color="#ff0000" />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" color="#ff0000" />,
+    ))
 
   Object.keys(colors)
     .slice(0, 5)
     .forEach(color => {
       test(`renders with trailColor ${color}`, () =>
-        shouldMatchEmotionSnapshot(<ActivityIndicator trailColor={color} />))
+        shouldMatchEmotionSnapshot(
+          <ActivityIndicator label="Loading test" trailColor={color} />,
+        ))
     })
 
   test(`renders with inlined trailColor`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator trailColor="#ff0000" />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" trailColor="#ff0000" />,
+    ))
 
   test(`renders with strokeWidth 25`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator strokeWidth={25} />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" strokeWidth={25} />,
+    ))
 
   test(`renders with text 100%`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator text="100%" />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" text="100%" />,
+    ))
 
   test(`renders with custom size`, () =>
-    shouldMatchEmotionSnapshot(<ActivityIndicator size="100px" />))
+    shouldMatchEmotionSnapshot(
+      <ActivityIndicator label="Loading test" size="100px" />,
+    ))
 })

--- a/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -87,6 +87,11 @@ exports[`Button should render correctly loading 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 .cache-115wth8 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -111,36 +116,60 @@ exports[`Button should render correctly loading 1`] = `
     <div
       class="cache-i7e9al em6gco82"
     >
-      <svg
-        class="CircularProgressbar  cache-1d2vwm0 e7dhm9i0"
-        data-test-id="CircularProgressbar"
-        viewBox="0 0 100 100"
+      <div
+        aria-hidden="true"
       >
-        <path
-          class="CircularProgressbar-trail"
-          d="
+        <svg
+          class="CircularProgressbar  cache-1d2vwm0 e7dhm9i1"
+          data-test-id="CircularProgressbar"
+          viewBox="0 0 100 100"
+        >
+          <path
+            class="CircularProgressbar-trail"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-        />
-        <path
-          class="CircularProgressbar-path"
-          d="
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+          />
+          <path
+            class="CircularProgressbar-path"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: currentColor; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-        />
-      </svg>
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: currentColor; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+          />
+        </svg>
+      </div>
+      <div
+        class="cache-546l7a e7dhm9i0"
+      >
+        <label
+          for="activityIndicator-51587355cebadc384a36ff852f15a1ec"
+        >
+          Loading
+        </label>
+        <progress
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          aria-valuetext="20%"
+          id="activityIndicator-51587355cebadc384a36ff852f15a1ec"
+          max="100"
+          value="20"
+        >
+          20%
+        </progress>
+      </div>
     </div>
     <div
       class="cache-115wth8 em6gco81"
@@ -238,6 +267,11 @@ exports[`Button should render correctly loading with an icon 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 .cache-115wth8 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -271,36 +305,60 @@ exports[`Button should render correctly loading with an icon 1`] = `
     <div
       class="cache-i7e9al em6gco82"
     >
-      <svg
-        class="CircularProgressbar  cache-1d2vwm0 e7dhm9i0"
-        data-test-id="CircularProgressbar"
-        viewBox="0 0 100 100"
+      <div
+        aria-hidden="true"
       >
-        <path
-          class="CircularProgressbar-trail"
-          d="
+        <svg
+          class="CircularProgressbar  cache-1d2vwm0 e7dhm9i1"
+          data-test-id="CircularProgressbar"
+          viewBox="0 0 100 100"
+        >
+          <path
+            class="CircularProgressbar-trail"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-        />
-        <path
-          class="CircularProgressbar-path"
-          d="
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+          />
+          <path
+            class="CircularProgressbar-path"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: currentColor; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-        />
-      </svg>
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: currentColor; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+          />
+        </svg>
+      </div>
+      <div
+        class="cache-546l7a e7dhm9i0"
+      >
+        <label
+          for="activityIndicator-7d62693ac589f2cf8a1e51c8141b47e7"
+        >
+          Loading
+        </label>
+        <progress
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          aria-valuetext="20%"
+          id="activityIndicator-7d62693ac589f2cf8a1e51c8141b47e7"
+          max="100"
+          value="20"
+        >
+          20%
+        </progress>
+      </div>
     </div>
     <div
       class="cache-115wth8 em6gco81"
@@ -310,36 +368,60 @@ exports[`Button should render correctly loading with an icon 1`] = `
     <div
       class="cache-14frhxz em6gco82"
     >
-      <svg
-        class="CircularProgressbar  cache-1d2vwm0 e7dhm9i0"
-        data-test-id="CircularProgressbar"
-        viewBox="0 0 100 100"
+      <div
+        aria-hidden="true"
       >
-        <path
-          class="CircularProgressbar-trail"
-          d="
+        <svg
+          class="CircularProgressbar  cache-1d2vwm0 e7dhm9i1"
+          data-test-id="CircularProgressbar"
+          viewBox="0 0 100 100"
+        >
+          <path
+            class="CircularProgressbar-trail"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-        />
-        <path
-          class="CircularProgressbar-path"
-          d="
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+          />
+          <path
+            class="CircularProgressbar-path"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: currentColor; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-        />
-      </svg>
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: currentColor; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+          />
+        </svg>
+      </div>
+      <div
+        class="cache-546l7a e7dhm9i0"
+      >
+        <label
+          for="activityIndicator-b866d0988f5b66fdfd6bbb499cd2d1c8"
+        >
+          Loading
+        </label>
+        <progress
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          aria-valuetext="20%"
+          id="activityIndicator-b866d0988f5b66fdfd6bbb499cd2d1c8"
+          max="100"
+          value="20"
+        >
+          20%
+        </progress>
+      </div>
     </div>
   </button>
 </DocumentFragment>

--- a/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
@@ -1008,6 +1008,11 @@ exports[`Checkbox renders correctly with progress 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 .cache-1w6vxon {
   -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
   transition: max-height 300ms ease-out,opacity 300ms ease-out;
@@ -1045,36 +1050,60 @@ exports[`Checkbox renders correctly with progress 1`] = `
       <div
         class="cache-1wr6k2n e7ah3bn0"
       >
-        <svg
-          class="CircularProgressbar  cache-8ng7tj e7dhm9i0"
-          data-test-id="CircularProgressbar"
-          viewBox="0 0 100 100"
+        <div
+          aria-hidden="true"
         >
-          <path
-            class="CircularProgressbar-trail"
-            d="
+          <svg
+            class="CircularProgressbar  cache-8ng7tj e7dhm9i1"
+            data-test-id="CircularProgressbar"
+            viewBox="0 0 100 100"
+          >
+            <path
+              class="CircularProgressbar-trail"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-          />
-          <path
-            class="CircularProgressbar-path"
-            d="
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+            />
+            <path
+              class="CircularProgressbar-path"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-          />
-        </svg>
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+            />
+          </svg>
+        </div>
+        <div
+          class="cache-546l7a e7dhm9i0"
+        >
+          <label
+            for="activityIndicator-b3f97bd2b6752a417dbda16fd7377f2a"
+          >
+            Loading
+          </label>
+          <progress
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="20"
+            aria-valuetext="20%"
+            id="activityIndicator-b3f97bd2b6752a417dbda16fd7377f2a"
+            max="100"
+            value="20"
+          >
+            20%
+          </progress>
+        </div>
       </div>
       <div
         class="cache-0 eu28k4m0"
@@ -1166,6 +1195,11 @@ exports[`Checkbox renders correctly with progress and no child 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 .cache-1w6vxon {
   -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
   transition: max-height 300ms ease-out,opacity 300ms ease-out;
@@ -1203,36 +1237,60 @@ exports[`Checkbox renders correctly with progress and no child 1`] = `
       <div
         class="cache-iyx5sv e7ah3bn0"
       >
-        <svg
-          class="CircularProgressbar  cache-8ng7tj e7dhm9i0"
-          data-test-id="CircularProgressbar"
-          viewBox="0 0 100 100"
+        <div
+          aria-hidden="true"
         >
-          <path
-            class="CircularProgressbar-trail"
-            d="
+          <svg
+            class="CircularProgressbar  cache-8ng7tj e7dhm9i1"
+            data-test-id="CircularProgressbar"
+            viewBox="0 0 100 100"
+          >
+            <path
+              class="CircularProgressbar-trail"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-          />
-          <path
-            class="CircularProgressbar-path"
-            d="
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+            />
+            <path
+              class="CircularProgressbar-path"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-          />
-        </svg>
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+            />
+          </svg>
+        </div>
+        <div
+          class="cache-546l7a e7dhm9i0"
+        >
+          <label
+            for="activityIndicator-a148b71605bcedb3a97b35d468fc9ca3"
+          >
+            Loading
+          </label>
+          <progress
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="20"
+            aria-valuetext="20%"
+            id="activityIndicator-a148b71605bcedb3a97b35d468fc9ca3"
+            max="100"
+            value="20"
+          >
+            20%
+          </progress>
+        </div>
       </div>
     </label>
     <div
@@ -1447,6 +1505,11 @@ exports[`Checkbox renders correctly with sizes 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 .cache-1w6vxon {
   -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
   transition: max-height 300ms ease-out,opacity 300ms ease-out;
@@ -1485,36 +1548,60 @@ exports[`Checkbox renders correctly with sizes 1`] = `
       <div
         class="cache-1wr6k2n e7ah3bn0"
       >
-        <svg
-          class="CircularProgressbar  cache-78jmh4 e7dhm9i0"
-          data-test-id="CircularProgressbar"
-          viewBox="0 0 100 100"
+        <div
+          aria-hidden="true"
         >
-          <path
-            class="CircularProgressbar-trail"
-            d="
+          <svg
+            class="CircularProgressbar  cache-78jmh4 e7dhm9i1"
+            data-test-id="CircularProgressbar"
+            viewBox="0 0 100 100"
+          >
+            <path
+              class="CircularProgressbar-trail"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-          />
-          <path
-            class="CircularProgressbar-path"
-            d="
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+            />
+            <path
+              class="CircularProgressbar-path"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-          />
-        </svg>
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+            />
+          </svg>
+        </div>
+        <div
+          class="cache-546l7a e7dhm9i0"
+        >
+          <label
+            for="activityIndicator-4974ff79917a335c9f765dee2bef5772"
+          >
+            Loading
+          </label>
+          <progress
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="20"
+            aria-valuetext="20%"
+            id="activityIndicator-4974ff79917a335c9f765dee2bef5772"
+            max="100"
+            value="20"
+          >
+            20%
+          </progress>
+        </div>
       </div>
       <div
         class="cache-0 eu28k4m0"

--- a/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -23628,6 +23628,11 @@ exports[`List should render correctly with isLoading 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <div
     class="cache-11djngs e7ah3bn0"
   >
@@ -23774,36 +23779,60 @@ exports[`List should render correctly with isLoading 1`] = `
     <div
       class="cache-1vsqel5 e7ah3bn0"
     >
-      <svg
-        class="CircularProgressbar  cache-1e51aj0 e7dhm9i0"
-        data-test-id="CircularProgressbar"
-        viewBox="0 0 100 100"
+      <div
+        aria-hidden="true"
       >
-        <path
-          class="CircularProgressbar-trail"
-          d="
+        <svg
+          class="CircularProgressbar  cache-1e51aj0 e7dhm9i1"
+          data-test-id="CircularProgressbar"
+          viewBox="0 0 100 100"
+        >
+          <path
+            class="CircularProgressbar-trail"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-        />
-        <path
-          class="CircularProgressbar-path"
-          d="
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+          />
+          <path
+            class="CircularProgressbar-path"
+            d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-          fill-opacity="0"
-          stroke-width="16"
-          style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-        />
-      </svg>
+            fill-opacity="0"
+            stroke-width="16"
+            style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+          />
+        </svg>
+      </div>
+      <div
+        class="cache-546l7a e7dhm9i0"
+      >
+        <label
+          for="activityIndicator-3fd4368386426e67e6578c9d8872c80d"
+        >
+          Loading
+        </label>
+        <progress
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="20"
+          aria-valuetext="20%"
+          id="activityIndicator-3fd4368386426e67e6578c9d8872c80d"
+          max="100"
+          value="20"
+        >
+          20%
+        </progress>
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/components/NavigationStepper/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/NavigationStepper/__tests__/__snapshots__/index.test.tsx.snap
@@ -301,6 +301,11 @@ exports[`NavigationStepper should render correctly with bad child 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <ul
     class="cache-q2a1ff eccy81h0"
   >
@@ -338,36 +343,60 @@ exports[`NavigationStepper should render correctly with bad child 1`] = `
         <span
           class="cache-8blmi3 eccy81h2"
         >
-          <svg
-            class="CircularProgressbar  cache-25qc29 e7dhm9i0"
-            data-test-id="CircularProgressbar"
-            viewBox="0 0 100 100"
+          <div
+            aria-hidden="true"
           >
-            <path
-              class="CircularProgressbar-trail"
-              d="
+            <svg
+              class="CircularProgressbar  cache-25qc29 e7dhm9i1"
+              data-test-id="CircularProgressbar"
+              viewBox="0 0 100 100"
+            >
+              <path
+                class="CircularProgressbar-trail"
+                d="
       M 50,50
       m 0,-46
       a 46,46 0 1 1 0,92
       a 46,46 0 1 1 0,-92
     "
-              fill-opacity="0"
-              stroke-width="8"
-              style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 0px;"
-            />
-            <path
-              class="CircularProgressbar-path"
-              d="
+                fill-opacity="0"
+                stroke-width="8"
+                style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 0px;"
+              />
+              <path
+                class="CircularProgressbar-path"
+                d="
       M 50,50
       m 0,-46
       a 46,46 0 1 1 0,92
       a 46,46 0 1 1 0,-92
     "
-              fill-opacity="0"
-              stroke-width="8"
-              style="stroke: #45d6b5; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 231.22121930420877px;"
-            />
-          </svg>
+                fill-opacity="0"
+                stroke-width="8"
+                style="stroke: #45d6b5; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 231.22121930420877px;"
+              />
+            </svg>
+          </div>
+          <div
+            class="cache-546l7a e7dhm9i0"
+          >
+            <label
+              for="activityIndicator-f53241bae03399e700f4285bceb99b26"
+            >
+              Loading
+            </label>
+            <progress
+              aria-valuemax="100"
+              aria-valuemin="0"
+              aria-valuenow="20"
+              aria-valuetext="20%"
+              id="activityIndicator-f53241bae03399e700f4285bceb99b26"
+              max="100"
+              value="20"
+            >
+              20%
+            </progress>
+          </div>
         </span>
         2
       </div>
@@ -1110,6 +1139,11 @@ exports[`NavigationStepper should render correctly with isLoading 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <ul
     class="cache-z9xsvn eccy81h0"
   >
@@ -1147,36 +1181,60 @@ exports[`NavigationStepper should render correctly with isLoading 1`] = `
         <span
           class="cache-8blmi3 eccy81h2"
         >
-          <svg
-            class="CircularProgressbar  cache-25qc29 e7dhm9i0"
-            data-test-id="CircularProgressbar"
-            viewBox="0 0 100 100"
+          <div
+            aria-hidden="true"
           >
-            <path
-              class="CircularProgressbar-trail"
-              d="
+            <svg
+              class="CircularProgressbar  cache-25qc29 e7dhm9i1"
+              data-test-id="CircularProgressbar"
+              viewBox="0 0 100 100"
+            >
+              <path
+                class="CircularProgressbar-trail"
+                d="
       M 50,50
       m 0,-46
       a 46,46 0 1 1 0,92
       a 46,46 0 1 1 0,-92
     "
-              fill-opacity="0"
-              stroke-width="8"
-              style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 0px;"
-            />
-            <path
-              class="CircularProgressbar-path"
-              d="
+                fill-opacity="0"
+                stroke-width="8"
+                style="stroke: transparent; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 0px;"
+              />
+              <path
+                class="CircularProgressbar-path"
+                d="
       M 50,50
       m 0,-46
       a 46,46 0 1 1 0,92
       a 46,46 0 1 1 0,-92
     "
-              fill-opacity="0"
-              stroke-width="8"
-              style="stroke: #45d6b5; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 231.22121930420877px;"
-            />
-          </svg>
+                fill-opacity="0"
+                stroke-width="8"
+                style="stroke: #45d6b5; stroke-linecap: round; stroke-dasharray: 289.02652413026095px 289.02652413026095px; stroke-dashoffset: 231.22121930420877px;"
+              />
+            </svg>
+          </div>
+          <div
+            class="cache-546l7a e7dhm9i0"
+          >
+            <label
+              for="activityIndicator-5dbceb5eb5419f8a92f422b3c4e4933a"
+            >
+              Loading
+            </label>
+            <progress
+              aria-valuemax="100"
+              aria-valuemin="0"
+              aria-valuenow="20"
+              aria-valuetext="20%"
+              id="activityIndicator-5dbceb5eb5419f8a92f422b3c4e4933a"
+              max="100"
+              value="20"
+            >
+              20%
+            </progress>
+          </div>
         </span>
         2
       </div>

--- a/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -2722,39 +2722,68 @@ exports[`Pagination should render correctly loadable with no data and initial pa
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <div
     class="cache-hpffz9 e7ah3bn0"
   >
-    <svg
-      class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-      data-test-id="CircularProgressbar"
-      viewBox="0 0 100 100"
+    <div
+      aria-hidden="true"
     >
-      <path
-        class="CircularProgressbar-trail"
-        d="
+      <svg
+        class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+        data-test-id="CircularProgressbar"
+        viewBox="0 0 100 100"
+      >
+        <path
+          class="CircularProgressbar-trail"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-      />
-      <path
-        class="CircularProgressbar-path"
-        d="
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+        />
+        <path
+          class="CircularProgressbar-path"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-      />
-    </svg>
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+        />
+      </svg>
+    </div>
+    <div
+      class="cache-546l7a e7dhm9i0"
+    >
+      <label
+        for="activityIndicator-617a70e29b56a0a4ba81d75c20481dcc"
+      >
+        Loading
+      </label>
+      <progress
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        aria-valuetext="20%"
+        id="activityIndicator-617a70e29b56a0a4ba81d75c20481dcc"
+        max="100"
+        value="20"
+      >
+        20%
+      </progress>
+    </div>
   </div>
   .cache-jbewx9 {
   display: grid;
@@ -3144,39 +3173,68 @@ exports[`Pagination should render correctly loadable with no data and initial pa
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <div
     class="cache-hpffz9 e7ah3bn0"
   >
-    <svg
-      class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-      data-test-id="CircularProgressbar"
-      viewBox="0 0 100 100"
+    <div
+      aria-hidden="true"
     >
-      <path
-        class="CircularProgressbar-trail"
-        d="
+      <svg
+        class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+        data-test-id="CircularProgressbar"
+        viewBox="0 0 100 100"
+      >
+        <path
+          class="CircularProgressbar-trail"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-      />
-      <path
-        class="CircularProgressbar-path"
-        d="
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+        />
+        <path
+          class="CircularProgressbar-path"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-      />
-    </svg>
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+        />
+      </svg>
+    </div>
+    <div
+      class="cache-546l7a e7dhm9i0"
+    >
+      <label
+        for="activityIndicator-c4de2f473cdb7e6927f53cc8013e2c99"
+      >
+        Loading
+      </label>
+      <progress
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        aria-valuetext="20%"
+        id="activityIndicator-c4de2f473cdb7e6927f53cc8013e2c99"
+        max="100"
+        value="20"
+      >
+        20%
+      </progress>
+    </div>
   </div>
   .cache-jbewx9 {
   display: grid;
@@ -8629,39 +8687,68 @@ exports[`Pagination should render correctly with pageClick and load and empty re
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <div
     class="cache-hpffz9 e7ah3bn0"
   >
-    <svg
-      class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-      data-test-id="CircularProgressbar"
-      viewBox="0 0 100 100"
+    <div
+      aria-hidden="true"
     >
-      <path
-        class="CircularProgressbar-trail"
-        d="
+      <svg
+        class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+        data-test-id="CircularProgressbar"
+        viewBox="0 0 100 100"
+      >
+        <path
+          class="CircularProgressbar-trail"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-      />
-      <path
-        class="CircularProgressbar-path"
-        d="
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+        />
+        <path
+          class="CircularProgressbar-path"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-      />
-    </svg>
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+        />
+      </svg>
+    </div>
+    <div
+      class="cache-546l7a e7dhm9i0"
+    >
+      <label
+        for="activityIndicator-cd5a55ad390f4a3f479111f33b58dce3"
+      >
+        Loading
+      </label>
+      <progress
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        aria-valuetext="20%"
+        id="activityIndicator-cd5a55ad390f4a3f479111f33b58dce3"
+        max="100"
+        value="20"
+      >
+        20%
+      </progress>
+    </div>
   </div>
   .cache-jbewx9 {
   display: grid;
@@ -9096,39 +9183,68 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <div
     class="cache-hpffz9 e7ah3bn0"
   >
-    <svg
-      class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-      data-test-id="CircularProgressbar"
-      viewBox="0 0 100 100"
+    <div
+      aria-hidden="true"
     >
-      <path
-        class="CircularProgressbar-trail"
-        d="
+      <svg
+        class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+        data-test-id="CircularProgressbar"
+        viewBox="0 0 100 100"
+      >
+        <path
+          class="CircularProgressbar-trail"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-      />
-      <path
-        class="CircularProgressbar-path"
-        d="
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+        />
+        <path
+          class="CircularProgressbar-path"
+          d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-        fill-opacity="0"
-        stroke-width="16"
-        style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-      />
-    </svg>
+          fill-opacity="0"
+          stroke-width="16"
+          style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+        />
+      </svg>
+    </div>
+    <div
+      class="cache-546l7a e7dhm9i0"
+    >
+      <label
+        for="activityIndicator-7e99f7b9d84aa07114e71abca34176fb"
+      >
+        Loading
+      </label>
+      <progress
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="20"
+        aria-valuetext="20%"
+        id="activityIndicator-7e99f7b9d84aa07114e71abca34176fb"
+        max="100"
+        value="20"
+      >
+        20%
+      </progress>
+    </div>
   </div>
   .cache-jbewx9 {
   display: grid;

--- a/src/components/Table/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/index.tsx.snap
@@ -248,6 +248,11 @@ exports[`Table renders correctly while loading 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 <table
     class="efhaznt5 cache-1pbu3dg e7ah3bn0"
   >
@@ -282,36 +287,60 @@ exports[`Table renders correctly while loading 1`] = `
           <div
             class="efhaznt0 cache-wywcx4 e7ah3bn0"
           >
-            <svg
-              class="CircularProgressbar  cache-82dnp8 e7dhm9i0"
-              data-test-id="CircularProgressbar"
-              viewBox="0 0 100 100"
+            <div
+              aria-hidden="true"
             >
-              <path
-                class="CircularProgressbar-trail"
-                d="
+              <svg
+                class="CircularProgressbar  cache-82dnp8 e7dhm9i1"
+                data-test-id="CircularProgressbar"
+                viewBox="0 0 100 100"
+              >
+                <path
+                  class="CircularProgressbar-trail"
+                  d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-                fill-opacity="0"
-                stroke-width="16"
-                style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-              />
-              <path
-                class="CircularProgressbar-path"
-                d="
+                  fill-opacity="0"
+                  stroke-width="16"
+                  style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+                />
+                <path
+                  class="CircularProgressbar-path"
+                  d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-                fill-opacity="0"
-                stroke-width="16"
-                style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-              />
-            </svg>
+                  fill-opacity="0"
+                  stroke-width="16"
+                  style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+                />
+              </svg>
+            </div>
+            <div
+              class="cache-546l7a e7dhm9i0"
+            >
+              <label
+                for="activityIndicator-3c9f012a14be18af372b16fb62bb78d6"
+              >
+                Loading
+              </label>
+              <progress
+                aria-valuemax="100"
+                aria-valuemin="0"
+                aria-valuenow="20"
+                aria-valuetext="20%"
+                id="activityIndicator-3c9f012a14be18af372b16fb62bb78d6"
+                max="100"
+                value="20"
+              >
+                20%
+              </progress>
+            </div>
           </div>
         </td>
       </tr>

--- a/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
@@ -1322,6 +1322,11 @@ exports[`Tags delete tag with error 1`] = `
   animation: animation-0 0.75s linear infinite;
 }
 
+.cache-546l7a {
+  visibility: hidden;
+  position: absolute;
+}
+
 .cache-1qk78jd {
   font-size: 16px;
   color: #4a4f62;
@@ -1387,36 +1392,60 @@ exports[`Tags delete tag with error 1`] = `
         class="e1vt8sjg0 e1kgqxfn0 cache-k15tc5 e7ah3bn0"
         type="button"
       >
-        <svg
-          class="CircularProgressbar  cache-1233ma1 e7dhm9i0"
-          data-test-id="CircularProgressbar"
-          viewBox="0 0 100 100"
+        <div
+          aria-hidden="true"
         >
-          <path
-            class="CircularProgressbar-trail"
-            d="
+          <svg
+            class="CircularProgressbar  cache-1233ma1 e7dhm9i1"
+            data-test-id="CircularProgressbar"
+            viewBox="0 0 100 100"
+          >
+            <path
+              class="CircularProgressbar-trail"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
-          />
-          <path
-            class="CircularProgressbar-path"
-            d="
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #d4dae7; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 0px;"
+            />
+            <path
+              class="CircularProgressbar-path"
+              d="
       M 50,50
       m 0,-42
       a 42,42 0 1 1 0,84
       a 42,42 0 1 1 0,-84
     "
-            fill-opacity="0"
-            stroke-width="16"
-            style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
-          />
-        </svg>
+              fill-opacity="0"
+              stroke-width="16"
+              style="stroke: #4f0599; stroke-linecap: round; stroke-dasharray: 263.89378290154264px 263.89378290154264px; stroke-dashoffset: 211.11502632123413px;"
+            />
+          </svg>
+        </div>
+        <div
+          class="cache-546l7a e7dhm9i0"
+        >
+          <label
+            for="activityIndicator-237d83c4cafd746eaf9d8ac2573512fe"
+          >
+            Loading
+          </label>
+          <progress
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="20"
+            aria-valuetext="20%"
+            id="activityIndicator-237d83c4cafd746eaf9d8ac2573512fe"
+            max="100"
+            value="20"
+          >
+            20%
+          </progress>
+        </div>
       </button>
     </div>
     <input


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Make activity indicator more accessible.

#### The following changes where made:

(Describe what you did)

1. Wrapped activityIndicator into a div and added `aria-hidden`. @iManu I don't know if it is the best way to do it but as `CircularProgressbar` do not spread props I had to do it that way.

2. Added a label and progress tag in an hidden div



