### PR TITLE
fix(switch-button): add missing BoxProps

### DIFF
--- a/src/components/SwitchButton/index.tsx
+++ b/src/components/SwitchButton/index.tsx
@@ -10,7 +10,7 @@ import React, {
   ReactNode,
 } from 'react'
 import { Radio } from 'reakit'
-import Box from '../Box'
+import Box, { BoxProps } from '../Box'
 import Tooltip from '../Tooltip'
 
 const variants = {
@@ -87,7 +87,8 @@ type StyledSwitchProps = {
   checked?: boolean
   disabled?: boolean
   variant?: Variants
-} & LabelHTMLAttributes<HTMLLabelElement>
+} & BoxProps &
+  LabelHTMLAttributes<HTMLLabelElement>
 
 const StyledSwitch = styled(Box, {
   shouldForwardProp: prop => !['variant'].includes(prop.toString()),


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### The following changes where made:

Add missing `BoxProps` type to `SwitchButton`