### PR TITLE
refactor(theme): renamed colors into deprecatedColors

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -85,7 +85,7 @@ const globalStyles = theme => css`
       local('Roboto-Bold'), local('DroidSans-Bold'), local('Tahoma Bold');
   }
   body {
-    background-color: ${theme.colors.white};
+    background-color: ${theme.colorsDeprecated.white};
     font-family: ${theme.fonts.sansSerif};
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;

--- a/src/__stories__/Customization.stories.mdx
+++ b/src/__stories__/Customization.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs'
 import Box from '../components/Box'
 import FlexBox from '../components/FlexBox'
-import { colors } from '../theme'
+import { colorsDeprecated } from '../theme'
 
 <Meta title="Theme" />
 
@@ -14,7 +14,7 @@ Scaleway UI is based on `@emotion/react` library. It allows you to customize the
 Here are all colors that we use in Scaleway UI. You can customize them in your custom theme.
 
 <div>
-  {Object.keys(colors).map(
+  {Object.keys(colorsDeprecated).map(
     color =>
       color !== 'colors' && (
         <FlexBox justifyContent="center" key={color}>
@@ -25,7 +25,7 @@ Here are all colors that we use in Scaleway UI. You can customize them in your c
             m={1}
             backgroundColor="black"
           >
-            <p style={{ color: colors[color] }}>{color}</p>
+            <p style={{ color: colorsDeprecated[color] }}>{color}</p>
           </Box>
           <Box
             textAlign="center"
@@ -34,7 +34,7 @@ Here are all colors that we use in Scaleway UI. You can customize them in your c
             m={1}
             backgroundColor="white"
           >
-            <p style={{ color: colors[color] }}>{color}</p>
+            <p style={{ color: colorsDeprecated[color] }}>{color}</p>
           </Box>
           <Box
             textAlign="center"

--- a/src/components/ActionBar/index.tsx
+++ b/src/components/ActionBar/index.tsx
@@ -8,12 +8,12 @@ const SPACING = 20
 
 const StyledDiv = styled.div<{ rank: number }>`
   align-items: center;
-  background: ${({ theme }) => theme.colors.white};
-  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  background: ${({ theme }) => theme.colorsDeprecated.white};
+  border: 1px solid ${({ theme }) => theme.colorsDeprecated.gray300};
   border-radius: 4px;
   bottom: ${({ rank }) => SPACING + rank * (HEIGHT + SPACING)}px;
   box-shadow: 0 2px 14px 8px
-    ${({ theme }) => transparentize(0.5, theme.colors.gray200)};
+    ${({ theme }) => transparentize(0.5, theme.colorsDeprecated.gray200)};
   display: flex;
   height: ${HEIGHT}px;
   left: 50%;

--- a/src/components/ActivityIndicator/__stories__/index.stories.tsx
+++ b/src/components/ActivityIndicator/__stories__/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 import ActivityIndicator, { ActivityIndicatorProps } from '..'
-import { colors } from '../../../theme'
+import { colorsDeprecated } from '../../../theme'
 
 export default {
   component: ActivityIndicator,
@@ -74,7 +74,7 @@ Colors.parameters = {
 Colors.decorators = [
   () => (
     <>
-      {Object.keys(colors).map(color => (
+      {Object.keys(colorsDeprecated).map(color => (
         <div key={color} style={{ display: 'inline-flex', marginRight: 8 }}>
           <ActivityIndicator
             key={`color-${color}`}

--- a/src/components/ActivityIndicator/__tests__/index.test.tsx
+++ b/src/components/ActivityIndicator/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ActivityIndicator from '..'
 import { shouldMatchEmotionSnapshot } from '../../../helpers/jestHelpers'
-import { colors } from '../../../theme'
+import { colorsDeprecated } from '../../../theme'
 
 describe('ActivityIndicator', () => {
   beforeAll(() => {
@@ -30,7 +30,7 @@ describe('ActivityIndicator', () => {
       <ActivityIndicator label="Loading test" active percentage={75} />,
     ))
 
-  Object.keys(colors)
+  Object.keys(colorsDeprecated)
     .slice(0, 5)
     .forEach(color => {
       test(`renders with color ${color}`, () =>
@@ -44,7 +44,7 @@ describe('ActivityIndicator', () => {
       <ActivityIndicator label="Loading test" color="#ff0000" />,
     ))
 
-  Object.keys(colors)
+  Object.keys(colorsDeprecated)
     .slice(0, 5)
     .forEach(color => {
       test(`renders with trailColor ${color}`, () =>

--- a/src/components/ActivityIndicator/index.tsx
+++ b/src/components/ActivityIndicator/index.tsx
@@ -80,18 +80,18 @@ const ActivityIndicator: FunctionComponent<ActivityIndicatorProps> = ({
           size={size}
           styles={{
             path: {
-              stroke: theme.colors[color as Color] || color,
+              stroke: theme.colorsDeprecated[color as Color] || color,
               strokeLinecap: 'round',
             },
             root: {},
             text: {
               dominantBaseline: 'middle',
-              fill: theme.colors.primary,
+              fill: theme.colorsDeprecated.primary,
               fontSize: '26px',
               textAnchor: 'middle',
             },
             trail: {
-              stroke: theme.colors[trailColor as Color] || trailColor,
+              stroke: theme.colorsDeprecated[trailColor as Color] || trailColor,
               strokeLinecap: 'round',
             },
           }}

--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -21,20 +21,20 @@ const typesColors = (
   theme: Theme,
 ): Record<AlertType, { primary: string; secondary: string }> => ({
   beta: {
-    primary: theme.colors.beta,
-    secondary: theme.colors.serenade,
+    primary: theme.colorsDeprecated.beta,
+    secondary: theme.colorsDeprecated.serenade,
   },
   info: {
-    primary: theme.colors.info,
-    secondary: theme.colors.zumthor,
+    primary: theme.colorsDeprecated.info,
+    secondary: theme.colorsDeprecated.zumthor,
   },
   success: {
-    primary: theme.colors.success,
-    secondary: theme.colors.foam,
+    primary: theme.colorsDeprecated.success,
+    secondary: theme.colorsDeprecated.foam,
   },
   warning: {
-    primary: theme.colors.warning,
-    secondary: theme.colors.pippin,
+    primary: theme.colorsDeprecated.warning,
+    secondary: theme.colorsDeprecated.pippin,
   },
 })
 
@@ -45,13 +45,15 @@ const variants = ({
   theme: Theme
   type: AlertType
 }): Record<AlertVariant, SerializedStyles> => {
-  const primary = typesColors(theme)[type]?.primary || theme.colors.warning
-  const secondary = typesColors(theme)[type]?.secondary || theme.colors.pippin
+  const primary =
+    typesColors(theme)[type]?.primary || theme.colorsDeprecated.warning
+  const secondary =
+    typesColors(theme)[type]?.secondary || theme.colorsDeprecated.pippin
 
   return {
     filled: css`
       background-color: ${primary};
-      color: ${theme.colors.white};
+      color: ${theme.colorsDeprecated.white};
     `,
     outlined: css`
       border: 1px solid ${primary};

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -29,11 +29,11 @@ const StyledDiv = styled.div<{
   align-items: center;
   background-color: ${({ lock, theme, textBgColor }) =>
     lock
-      ? theme.colors.gray50
-      : theme.colors[textBgColor as Color] || textBgColor};
+      ? theme.colorsDeprecated.gray50
+      : theme.colorsDeprecated[textBgColor as Color] || textBgColor};
   border-radius: 50%;
   color: ${({ theme, textColor }) =>
-    theme.colors[textColor as Color] || textColor};
+    theme.colorsDeprecated[textColor as Color] || textColor};
   font-size: ${({ textSize }) => textSize}px;
   display: flex;
   height: 100%;

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -5,57 +5,57 @@ import React, { FunctionComponent, useMemo } from 'react'
 import Box, { XStyledProps } from '../Box'
 
 const variants = {
-  beta: ({ theme: { colors } }: { theme: Theme }) => css`
-    background-color: ${colors.beta};
-    color: ${colors.white};
+  beta: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    background-color: ${colorsDeprecated.beta};
+    color: ${colorsDeprecated.white};
   `,
-  error: ({ theme: { colors } }: { theme: Theme }) => css`
-    background-color: ${colors.red};
-    color: ${colors.white};
+  error: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    background-color: ${colorsDeprecated.red};
+    color: ${colorsDeprecated.white};
   `,
-  info: ({ theme: { colors } }: { theme: Theme }) => css`
-    background-color: ${colors.info};
-    color: ${colors.white};
+  info: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    background-color: ${colorsDeprecated.info};
+    color: ${colorsDeprecated.white};
   `,
-  'light-beta': ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.beta};
-    background-color: ${colors.serenade};
+  'light-beta': ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.beta};
+    background-color: ${colorsDeprecated.serenade};
   `,
-  'light-error': ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.red};
-    background-color: ${colors.pippin};
+  'light-error': ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.red};
+    background-color: ${colorsDeprecated.pippin};
   `,
-  'light-info': ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.info};
-    background-color: ${colors.zumthor};
+  'light-info': ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.info};
+    background-color: ${colorsDeprecated.zumthor};
   `,
-  'light-neutral': ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.gray550};
-    background-color: ${colors.gray100};
+  'light-neutral': ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.gray550};
+    background-color: ${colorsDeprecated.gray100};
   `,
-  'light-primary': ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.primary};
-    background-color: ${colors.gray200};
+  'light-primary': ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.primary};
+    background-color: ${colorsDeprecated.gray200};
   `,
-  'light-success': ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.success};
-    background-color: ${colors.foam};
+  'light-success': ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.success};
+    background-color: ${colorsDeprecated.foam};
   `,
-  neutral: ({ theme: { colors } }: { theme: Theme }) => css`
-    color: ${colors.gray700};
-    background-color: ${colors.gray350};
+  neutral: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    color: ${colorsDeprecated.gray700};
+    background-color: ${colorsDeprecated.gray350};
   `,
-  primary: ({ theme: { colors } }: { theme: Theme }) => css`
-    background-color: ${colors.primary};
-    color: ${colors.white};
+  primary: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    background-color: ${colorsDeprecated.primary};
+    color: ${colorsDeprecated.white};
   `,
-  success: ({ theme: { colors } }: { theme: Theme }) => css`
-    background-color: ${colors.success};
-    color: ${colors.white};
+  success: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    background-color: ${colorsDeprecated.success};
+    color: ${colorsDeprecated.white};
   `,
-  warning: ({ theme: { colors } }: { theme: Theme }) => css`
-    background-color: ${colors.warning};
-    color: ${colors.white};
+  warning: ({ theme: { colorsDeprecated } }: { theme: Theme }) => css`
+    background-color: ${colorsDeprecated.warning};
+    color: ${colorsDeprecated.white};
   `,
 }
 

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -56,14 +56,14 @@ const BarChart: FunctionComponent<BarChartProps> = ({
     axis: {
       ticks: {
         line: {
-          stroke: theme.colors.gray300,
+          stroke: theme.colorsDeprecated.gray300,
           strokeWidth: 1,
         },
       },
     },
     fontFamily: theme.fonts.sansSerif,
     fontSize: 12,
-    textColor: theme.colors.gray550,
+    textColor: theme.colorsDeprecated.gray550,
   }
 
   const tooltip = useCallback(

--- a/src/components/BarStack/index.tsx
+++ b/src/components/BarStack/index.tsx
@@ -36,13 +36,13 @@ export interface BarStackProps {
 const StyledBarWrapper = styled.div`
   width: 0px;
   transition: width 500ms;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme }) => theme.colorsDeprecated.white};
 `
 
 const StyledBar = styled.div`
   height: 50px;
   font-weight: 600;
-  color: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colorsDeprecated.white};
   font-size: 14px;
   display: flex;
   align-items: center;
@@ -50,57 +50,64 @@ const StyledBar = styled.div`
   width: 100%;
   white-space: nowrap;
   overflow: hidden;
-  text-shadow: -1px 0 ${({ theme }) => transparentize(0.7, theme.colors.black)},
-    0 1px ${({ theme }) => transparentize(0.7, theme.colors.black)},
-    1px 0 ${({ theme }) => transparentize(0.7, theme.colors.black)},
-    0 -1px ${({ theme }) => transparentize(0.7, theme.colors.black)};
+  text-shadow: -1px 0
+      ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)},
+    0 1px ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)},
+    1px 0 ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)},
+    0 -1px ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)};
 `
 
 const StyledContainer = styled.div`
   width: 100%;
   display: flex;
-  background-color: ${({ theme }) => theme.colors.gray100};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray100};
   border-radius: ${({ theme }) => theme.radii.default};
-  box-shadow: inset 0px 0px 0px 1px ${({ theme }) => theme.colors.gray300};
+  box-shadow: inset 0px 0px 0px 1px
+    ${({ theme }) => theme.colorsDeprecated.gray300};
   overflow: hidden;
 
   ${StyledBarWrapper}:nth-child(5n+1) {
     ${({ theme }) => `background: linear-gradient(-45deg, ${transparentize(
       0.9,
-      theme.colors.white,
+      theme.colorsDeprecated.white,
     )} 25%,
-      ${theme.colors.primary} 25%, ${theme.colors.primary} 50%,
-      ${transparentize(0.9, theme.colors.white)} 50%, ${transparentize(
-      0.9,
-      theme.colors.white,
-    )} 75%, ${theme.colors.primary}
+      ${theme.colorsDeprecated.primary} 25%, ${
+      theme.colorsDeprecated.primary
+    } 50%,
+      ${transparentize(
+        0.9,
+        theme.colorsDeprecated.white,
+      )} 50%, ${transparentize(0.9, theme.colorsDeprecated.white)} 75%, ${
+      theme.colorsDeprecated.primary
+    }
        75%);`}
     background-size: 30px 30px;
-    background-color: ${({ theme }) => theme.colors.primary};
+    background-color: ${({ theme }) => theme.colorsDeprecated.primary};
   }
 
   ${StyledBarWrapper}:nth-child(5n+2) {
-    background-color: ${({ theme }) => lighten(0.1, theme.colors.primary)};
+    background-color: ${({ theme }) =>
+      lighten(0.1, theme.colorsDeprecated.primary)};
 
     background-image: linear-gradient(
         135deg,
-        ${({ theme }) => transparentize(0.75, theme.colors.white)} 25%,
+        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
         transparent 25%
       ),
       linear-gradient(
         225deg,
-        ${({ theme }) => transparentize(0.75, theme.colors.white)} 25%,
+        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
         transparent 25%
       ),
       linear-gradient(
         45deg,
-        ${({ theme }) => transparentize(0.75, theme.colors.white)} 25%,
+        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
         transparent 25%
       ),
       linear-gradient(
         315deg,
-        ${({ theme }) => transparentize(0.75, theme.colors.white)} 25%,
-        ${({ theme }) => lighten(0.1, theme.colors.primary)} 25%
+        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) => lighten(0.1, theme.colorsDeprecated.primary)} 25%
       );
     background-position: 10px 0, 10px 0, 0 0, 0 0;
     background-size: 10px 10px;
@@ -110,40 +117,45 @@ const StyledContainer = styled.div`
   ${StyledBarWrapper}:nth-child(5n+3) {
     ${({ theme }) => `background: linear-gradient(-45deg, ${transparentize(
       0.9,
-      theme.colors.white,
+      theme.colorsDeprecated.white,
     )} 25%,
-      ${theme.colors.lightViolet} 25%, ${theme.colors.lightViolet} 50%,
-      ${transparentize(0.9, theme.colors.white)} 50%, ${transparentize(
-      0.9,
-      theme.colors.white,
-    )} 75%, ${theme.colors.lightViolet}
+      ${theme.colorsDeprecated.lightViolet} 25%, ${
+      theme.colorsDeprecated.lightViolet
+    } 50%,
+      ${transparentize(
+        0.9,
+        theme.colorsDeprecated.white,
+      )} 50%, ${transparentize(0.9, theme.colorsDeprecated.white)} 75%, ${
+      theme.colorsDeprecated.lightViolet
+    }
        75%);`}
     background-size: 30px 30px;
-    background-color: ${({ theme }) => darken(0.2, theme.colors.lightViolet)};
+    background-color: ${({ theme }) =>
+      darken(0.2, theme.colorsDeprecated.lightViolet)};
   }
 
   ${StyledBarWrapper}:nth-child(5n+4) {
-    background-color: ${({ theme }) => theme.colors.lightViolet};
+    background-color: ${({ theme }) => theme.colorsDeprecated.lightViolet};
 
     background-image: linear-gradient(
         135deg,
-        ${({ theme }) => transparentize(0.8, theme.colors.white)} 25%,
+        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
         transparent 25%
       ),
       linear-gradient(
         225deg,
-        ${({ theme }) => transparentize(0.8, theme.colors.white)} 25%,
+        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
         transparent 25%
       ),
       linear-gradient(
         45deg,
-        ${({ theme }) => transparentize(0.8, theme.colors.white)} 25%,
+        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
         transparent 25%
       ),
       linear-gradient(
         315deg,
-        ${({ theme }) => transparentize(0.8, theme.colors.white)} 25%,
-        ${({ theme }) => theme.colors.lightViolet} 25%
+        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) => theme.colorsDeprecated.lightViolet} 25%
       );
     background-position: 10px 0, 10px 0, 0 0, 0 0;
     background-size: 10px 10px;
@@ -153,19 +165,23 @@ const StyledContainer = styled.div`
   ${StyledBarWrapper}:nth-child(5n+5) {
     ${({ theme }) => `background: linear-gradient(-45deg, ${transparentize(
       0.8,
-      theme.colors.white,
+      theme.colorsDeprecated.white,
     )} 25%,
-      ${lighten(0.1, theme.colors.lightViolet)} 25%, ${lighten(
+      ${lighten(0.1, theme.colorsDeprecated.lightViolet)} 25%, ${lighten(
       0.1,
-      theme.colors.lightViolet,
+      theme.colorsDeprecated.lightViolet,
     )} 50%,
-      ${transparentize(0.8, theme.colors.white)} 50%, ${transparentize(
+      ${transparentize(
+        0.8,
+        theme.colorsDeprecated.white,
+      )} 50%, ${transparentize(
       0.8,
-      theme.colors.white,
-    )} 75%, ${lighten(0.1, theme.colors.lightViolet)}
+      theme.colorsDeprecated.white,
+    )} 75%, ${lighten(0.1, theme.colorsDeprecated.lightViolet)}
        75%);`}
     background-size: 30px 30px;
-    background-color: ${({ theme }) => lighten(0.1, theme.colors.lightViolet)};
+    background-color: ${({ theme }) =>
+      lighten(0.1, theme.colorsDeprecated.lightViolet)};
   }
 `
 

--- a/src/components/Box/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Box/__tests__/__snapshots__/index.tsx.snap
@@ -38,16 +38,15 @@ exports[`Box Box renders with bordered 1`] = `
 
 exports[`Box Box renders with system 1`] = `
 <DocumentFragment>
-  .cache-1yyq8hi.cache-1yyq8hi {
+  .cache-sf4awt.cache-sf4awt {
   height: 100px;
-  background-color: #4f0599;
   margin-right: auto;
   margin-left: auto;
   padding: 16px;
 }
 
 <div
-    class="cache-1yyq8hi e7ah3bn0"
+    class="cache-sf4awt e7ah3bn0"
   />
 </DocumentFragment>
 `;

--- a/src/components/Box/__tests__/index.tsx
+++ b/src/components/Box/__tests__/index.tsx
@@ -5,10 +5,9 @@ import { shouldMatchEmotionSnapshot } from '../../../helpers/jestHelpers'
 describe('Box', () => {
   test('Box renders correctly ', () => shouldMatchEmotionSnapshot(<Box />))
 
+  // We don't support colors any more with new theme
   test('Box renders with system', () =>
-    shouldMatchEmotionSnapshot(
-      <Box backgroundColor="primary" height={100} mx="auto" p={2} />,
-    ))
+    shouldMatchEmotionSnapshot(<Box height={100} mx="auto" p={2} />))
 
   test('Box renders with bordered', () =>
     shouldMatchEmotionSnapshot(<Box bordered />))

--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -65,7 +65,7 @@ export interface XStyledProps {
 const borderedStyles = ({ theme }: { theme: Theme }) => css`
   padding: ${theme.space['3']};
   border-radius: ${theme.radii.default};
-  border: 1px solid ${theme.colors.gray350};
+  border: 1px solid ${theme.colorsDeprecated.gray350};
 `
 
 const StyledBox = styled(x.div, {

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -58,9 +58,9 @@ const BubbleVariant = styled.li`
   margin-left: -${({ theme }) => theme.space['3']};
   margin-right: -${({ theme }) => theme.space['3']};
 
-  background-color: ${({ theme }) => theme.colors.success};
-  color: ${({ theme }) => theme.colors.white};
-  border-color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme }) => theme.colorsDeprecated.success};
+  color: ${({ theme }) => theme.colorsDeprecated.white};
+  border-color: ${({ theme }) => theme.colorsDeprecated.white};
 
   &:first-child {
     padding-left: ${({ theme }) => theme.space['3']};
@@ -73,24 +73,24 @@ const BubbleVariant = styled.li`
   }
 
   &[aria-current='page'] {
-    background-color: ${({ theme }) => theme.colors.primary};
-    color: ${({ theme }) => theme.colors.white};
-    border-color: ${({ theme }) => theme.colors.white};
+    background-color: ${({ theme }) => theme.colorsDeprecated.primary};
+    color: ${({ theme }) => theme.colorsDeprecated.white};
+    border-color: ${({ theme }) => theme.colorsDeprecated.white};
 
     &:focus {
       box-shadow: 0 0 0 2px
-        ${({ theme }) => transparentize(0.75, theme.colors.primary)};
+        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.primary)};
     }
   }
 
   &[aria-current='page'] ~ & {
-    background-color: ${({ theme }) => theme.colors.white};
-    color: ${({ theme }) => theme.colors.gray550};
-    border-color: ${({ theme }) => theme.colors.gray350};
+    background-color: ${({ theme }) => theme.colorsDeprecated.white};
+    color: ${({ theme }) => theme.colorsDeprecated.gray550};
+    border-color: ${({ theme }) => theme.colorsDeprecated.gray350};
 
     &:focus {
       box-shadow: 0 0 0 2px
-        ${({ theme }) => transparentize(0.75, theme.colors.gray550)};
+        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.gray550)};
     }
   }
 
@@ -103,7 +103,10 @@ const BubbleVariant = styled.li`
     }
 
   &:focus {
-    box-shadow: 0 0 0 2px ${transparentize(0.75, theme.colors.success)};
+    box-shadow: 0 0 0 2px ${transparentize(
+      0.75,
+      theme.colorsDeprecated.success,
+    )};
   }`
       : ``}
 
@@ -114,7 +117,7 @@ const LinkVariant = styled.li`
   display: inline;
 
   &[aria-current='page'] {
-    color: ${({ theme }) => theme.colors.gray550};
+    color: ${({ theme }) => theme.colorsDeprecated.gray550};
   }
 
   &:not(:last-child)::after {

--- a/src/components/BulletList/index.tsx
+++ b/src/components/BulletList/index.tsx
@@ -20,8 +20,8 @@ export const Chip = styled.span`
   min-width: 24px;
   height: 24px;
   border-radius: 12px;
-  background-color: ${({ theme }) => theme.colors.gray700};
-  color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.white};
   margin-right: 8px;
   text-align: center;
   font-weight: 600;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -23,7 +23,7 @@ import Tooltip from '../Tooltip'
 import UniversalLink from '../UniversalLink'
 
 const borderedVariant = ({
-  theme: { colors },
+  theme: { colorsDeprecated },
   color,
   bgColor,
   hoverColor,
@@ -33,9 +33,9 @@ const borderedVariant = ({
   bgColor: Color
   hoverColor: Color
 }) => {
-  const colorValue = colors[color]
-  const bgColorValue = colors[bgColor]
-  const hoverColorValue = colors[hoverColor]
+  const colorValue = colorsDeprecated[color]
+  const bgColorValue = colorsDeprecated[bgColor]
+  const hoverColorValue = colorsDeprecated[hoverColor]
 
   return `
     border: 1px solid ${colorValue};
@@ -66,7 +66,7 @@ const borderedVariant = ({
 }
 
 const plainVariant = ({
-  theme: { colors },
+  theme: { colorsDeprecated },
   bgColor,
   textColor,
 }: {
@@ -74,8 +74,8 @@ const plainVariant = ({
   bgColor: Color
   textColor: Color
 }) => {
-  const bgColorValue = colors[bgColor]
-  const textColorValue = colors[textColor]
+  const bgColorValue = colorsDeprecated[bgColor]
+  const textColorValue = colorsDeprecated[textColor]
 
   return `
     background-color: ${bgColorValue};
@@ -103,15 +103,15 @@ const variants = {
       hoverColor: 'blue',
       theme,
     }),
-  link: ({ theme: { colors } }: { theme: Theme }) => `
-    background-color: ${colors.white};
-    color: ${colors.blue};
+  link: ({ theme: { colorsDeprecated } }: { theme: Theme }) => `
+    background-color: ${colorsDeprecated.white};
+    color: ${colorsDeprecated.blue};
     vertical-align: baseline;
     font-weight: 400;
 
     &:hover,
     &:focus {
-      color: ${darken(0.2, colors.blue)};
+      color: ${darken(0.2, colorsDeprecated.blue)};
       text-decoration: underline;
     }
   `,
@@ -156,9 +156,9 @@ const variants = {
       hoverColor: 'success',
       theme,
     }),
-  transparent: ({ theme: { colors } }: { theme: Theme }) => `
+  transparent: ({ theme: { colorsDeprecated } }: { theme: Theme }) => `
     background-color: transparent;
-    color: ${colors.gray700};
+    color: ${colorsDeprecated.gray700};
   `,
   warning: ({ theme }: { theme: Theme }) =>
     plainVariant({ bgColor: 'warning', textColor: 'white', theme }),
@@ -308,14 +308,14 @@ const StyledButton = styled(Box, {
     `
     cursor: default;
     pointer-events: none;
-    color: ${theme.colors.gray350};`}
+    color: ${theme.colorsDeprecated.gray350};`}
 
   ${({ variant, disabled, theme }) =>
     variant !== 'link' &&
     disabled &&
     `
-    background-color: ${theme.colors.gray50};
-    border-color: ${theme.colors.gray50};
+    background-color: ${theme.colorsDeprecated.gray50};
+    border-color: ${theme.colorsDeprecated.gray50};
     box-shadow: none;
     `}
 

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -41,13 +41,14 @@ const StyledReakitCheckbox = styled(ReakitCheckbox, {
     svg {
       border-radius: ${({ theme }) => theme.radii.default};
       background-color: ${({ theme, disabled }) =>
-        !disabled && theme.colors.gray100};
-      fill: ${({ theme, disabled }) => !disabled && theme.colors.primary};
+        !disabled && theme.colorsDeprecated.gray100};
+      fill: ${({ theme, disabled }) =>
+        !disabled && theme.colorsDeprecated.primary};
       transition: fill 300ms;
     }
   }
   &:focus + svg {
-    outline: 1px ${({ theme }) => theme.colors.gray550} dotted;
+    outline: 1px ${({ theme }) => theme.colorsDeprecated.gray550} dotted;
   }
 `
 
@@ -69,7 +70,7 @@ const StyledActivityContainer = styled('div', {
 
 const StyledError = styled.div`
   font-size: 12px;
-  color: ${({ theme }) => theme.colors.warning};
+  color: ${({ theme }) => theme.colorsDeprecated.warning};
   padding: ${({ theme }) => `0 ${theme.space['0.5']}`};
 `
 

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -27,7 +27,9 @@ const StyledBox = styled(Box, {
   padding-bottom: ${({ small }) => (small ? 16 : 24)}px;
   border: 1px solid
     ${({ edition, theme }) =>
-      edition ? theme.colors.primary : theme.colors.gray350};
+      edition
+        ? theme.colorsDeprecated.primary
+        : theme.colorsDeprecated.gray350};
   opacity: ${({ disabled }) => (disabled ? '0.4' : 'inherit')};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'default')};
 

--- a/src/components/CreationProgress/index.tsx
+++ b/src/components/CreationProgress/index.tsx
@@ -74,12 +74,12 @@ const temporalStepStyles = ({
 }) =>
   temporal !== 'future'
     ? css`
-        background-color: ${theme.colors.success};
+        background-color: ${theme.colorsDeprecated.success};
       `
     : css`
         background-color: transparent;
         border-style: solid;
-        border-color: ${theme.colors.gray350};
+        border-color: ${theme.colorsDeprecated.gray350};
       `
 
 const StyledStep = styled('div', {
@@ -100,7 +100,8 @@ const StyledText = styled.div`
 `
 
 const StyledFutureInternalDot = styled.div`
-  background-color: ${({ theme: { colors } }) => colors.gray350};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.gray350};
   height: 7px;
   width: 7px;
   border-radius: 16px;
@@ -114,7 +115,8 @@ const StyledLine = styled.div<{ temporal: Temporal; animated: boolean }>`
   border-radius: 2px;
   flex-grow: 1;
   border-radius: 2px;
-  background-color: ${({ theme: { colors } }) => colors.gray350};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.gray350};
   position: relative;
 
   ::after {
@@ -124,7 +126,7 @@ const StyledLine = styled.div<{ temporal: Temporal; animated: boolean }>`
     top: 0;
     height: 100%;
     border-radius: 2px;
-    background-color: ${({ theme }) => theme.colors.success};
+    background-color: ${({ theme }) => theme.colorsDeprecated.success};
     ${({ temporal }) => temporal === 'past' && `width: 100%;`}
     ${({ temporal, animated }) =>
       temporal === 'current' && animated && loadingStyle}

--- a/src/components/DateInput/index.tsx
+++ b/src/components/DateInput/index.tsx
@@ -36,11 +36,13 @@ const StyledWrapper = styled.div`
   }
   .calendar {
     font-family: 'Asap';
-    border-color: ${({ theme: { colors } }) => colors.gray300};
+    border-color: ${({ theme: { colorsDeprecated } }) =>
+      colorsDeprecated.gray300};
 
     ${PREFIX}__header {
-      color: ${({ theme: { colors } }) => colors.gray700};
-      background-color: ${({ theme: { colors } }) => colors.white};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray700};
+      background-color: ${({ theme: { colorsDeprecated } }) =>
+        colorsDeprecated.white};
       border-bottom: none;
       text-align: inherit;
       display: block;
@@ -49,7 +51,8 @@ const StyledWrapper = styled.div`
     }
 
     ${PREFIX}__triangle {
-      border-bottom-color: ${({ theme: { colors } }) => colors.white};
+      border-bottom-color: ${({ theme: { colorsDeprecated } }) =>
+        colorsDeprecated.white};
     }
     ${PREFIX}__month {
       margin: 0;
@@ -61,7 +64,7 @@ const StyledWrapper = styled.div`
 
     ${PREFIX}__day-name {
       font-family: 'Asap';
-      color: ${({ theme: { colors } }) => colors.gray700};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray700};
       font-weight: 500;
       font-size: 14px;
       line-height: 24px;
@@ -71,7 +74,7 @@ const StyledWrapper = styled.div`
     }
 
     ${PREFIX}__day {
-      color: ${({ theme: { colors } }) => colors.gray550};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
       font-size: 16px;
       width: 1.7rem;
       height: 1.7rem;
@@ -80,29 +83,33 @@ const StyledWrapper = styled.div`
     }
 
     ${PREFIX}__day--selected {
-      color: ${({ theme: { colors } }) => colors.gray200};
-      background-color: ${({ theme: { colors } }) => colors.primary};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray200};
+      background-color: ${({ theme: { colorsDeprecated } }) =>
+        colorsDeprecated.primary};
       border-radius: 50%;
     }
     ${PREFIX}__day--keyboard-selected {
-      color: ${({ theme: { colors } }) => colors.primary};
-      background-color: ${({ theme: { colors } }) => colors.gray200};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.primary};
+      background-color: ${({ theme: { colorsDeprecated } }) =>
+        colorsDeprecated.gray200};
       border-radius: 50%;
     }
 
     ${PREFIX}__day: hover {
-      color: ${({ theme: { colors } }) => colors.primary};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.primary};
       border-radius: 50%;
-      background-color: ${({ theme: { colors } }) => colors.gray200};
+      background-color: ${({ theme: { colorsDeprecated } }) =>
+        colorsDeprecated.gray200};
     }
 
     ${PREFIX}__day--disabled {
-      color: ${({ theme: { colors } }) => colors.gray200};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray200};
     }
 
     ${PREFIX}__day--disabled: hover {
-      color: ${({ theme: { colors } }) => colors.gray200};
-      background-color: ${({ theme: { colors } }) => colors.transparent};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray200};
+      background-color: ${({ theme: { colorsDeprecated } }) =>
+        colorsDeprecated.transparent};
     }
   }
 `
@@ -127,7 +134,8 @@ const TopHeaderDiv = styled.div`
   margin-bottom: 8px;
   margin-left: 8px;
   display: inline-block;
-  background-color: ${({ theme: { colors } }) => colors.white};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.white};
 `
 export type DateInputProps = Pick<
   ReactDatePickerProps<string>,

--- a/src/components/Description/index.tsx
+++ b/src/components/Description/index.tsx
@@ -6,13 +6,13 @@ import Box, { BoxProps } from '../Box'
 
 const StyledDt = styled(Box.withComponent('dt'))`
   font-weight: 500;
-  color: ${({ theme }) => theme.colors.gray950};
+  color: ${({ theme }) => theme.colorsDeprecated.gray950};
   &:after {
     content: ':';
   }
 `
 const StyledDd = styled(Box.withComponent('dd'))`
-  color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.gray700};
   margin: 0;
   margin-top: ${({ theme }) => theme.space['1']};
 `
@@ -55,8 +55,8 @@ const StyledBox = styled(Box, {
         user-select: all;
 
         &::selection {
-          color: ${theme.colors.gray200};
-          background: ${theme.colors.primary};
+          color: ${theme.colorsDeprecated.gray200};
+          background: ${theme.colorsDeprecated.primary};
         }
       }
     `}

--- a/src/components/Dot/index.tsx
+++ b/src/components/Dot/index.tsx
@@ -11,8 +11,8 @@ const StyledDot = styled(Box, {
   border-radius: 50%;
   width: 10px;
   height: 10px;
-  background-color: ${({ theme: { colors }, color }) =>
-    colors[color as Color] ?? color};
+  background-color: ${({ theme: { colorsDeprecated }, color }) =>
+    colorsDeprecated[color as Color] ?? color};
 `
 
 export type DotProps = {

--- a/src/components/DotSteps/index.tsx
+++ b/src/components/DotSteps/index.tsx
@@ -25,7 +25,7 @@ const DotStep = styled(Dot)`
     width: ${dotSize}px;
     height: ${dotSize}px;
     margin: ${-dotSize / 2}px;
-    background-color: ${({ theme }) => theme.colors.primary};
+    background-color: ${({ theme }) => theme.colorsDeprecated.primary};
   }
   &::after {
     width: ${dotSize * 2}px;
@@ -38,7 +38,7 @@ const DotStep = styled(Dot)`
     }
   }
   &:last-child::after {
-    border: 1px solid ${({ theme }) => theme.colors.primary};
+    border: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
   }
 `
 const selectedStepPosition = (length: number, width: number) =>

--- a/src/components/ExtendedReminder/index.tsx
+++ b/src/components/ExtendedReminder/index.tsx
@@ -9,21 +9,21 @@ import Icon, { IconName, icons } from '../Icon'
 import Typography from '../Typography'
 
 export const variants = {
-  error: ({ colors }: Theme) => ({
-    background: colors.pippin,
-    main: colors.red,
+  error: ({ colorsDeprecated }: Theme) => ({
+    background: colorsDeprecated.pippin,
+    main: colorsDeprecated.red,
   }),
-  info: ({ colors }: Theme) => ({
-    background: colors.zumthor,
-    main: colors.blue,
+  info: ({ colorsDeprecated }: Theme) => ({
+    background: colorsDeprecated.zumthor,
+    main: colorsDeprecated.blue,
   }),
-  success: ({ colors }: Theme) => ({
-    background: colors.foam,
-    main: colors.gray700,
+  success: ({ colorsDeprecated }: Theme) => ({
+    background: colorsDeprecated.foam,
+    main: colorsDeprecated.gray700,
   }),
-  warning: ({ colors }: Theme) => ({
-    background: colors.serenade,
-    main: colors.orange,
+  warning: ({ colorsDeprecated }: Theme) => ({
+    background: colorsDeprecated.serenade,
+    main: colorsDeprecated.orange,
   }),
 }
 
@@ -59,8 +59,9 @@ const StyledTitle = styled(Typography, {
 
 const StyledButtonLink = styled(Button)`
   margin-top: auto;
-  color: ${({ theme: { colors } }) => colors.blue};
-  background-color: ${({ theme: { colors } }) => colors.transparent};
+  color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.blue};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.transparent};
   padding: 0;
   width: transparent;
   display: flex;
@@ -124,7 +125,12 @@ const ExtendedReminder: FunctionComponent<ExtendedReminderProps> = ({
     <StyledContainer variant={variant} {...props}>
       <StyledBadgeContainer>
         <Badge size="small" variant={badgeVariant[variant]}>
-          <Icon mr="4px" color={theme.colors.white} name={icon} size={16} />
+          <Icon
+            mr="4px"
+            color={theme.colorsDeprecated.white}
+            name={icon}
+            size={16}
+          />
           {badgeText}
         </Badge>
       </StyledBadgeContainer>

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -552,7 +552,8 @@ const StyledIcon = styled(Box, {
     viewBox: string
   } & XStyledProps
 >`
-  fill: ${({ theme, color }) => theme.colors[color as Color] ?? color};
+  fill: ${({ theme, color }) =>
+    theme.colorsDeprecated[color as Color] ?? color};
   ${sizeStyles}
 `
 

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled'
 import React, { FunctionComponent, LabelHTMLAttributes } from 'react'
 
 const StyledLabel = styled.label`
-  color: ${({ theme }) => theme.colors.gray950};
+  color: ${({ theme }) => theme.colorsDeprecated.gray950};
   font-size: 16px;
   line-height: 24px;
   font-weight: 500;

--- a/src/components/LineChart/CustomLegend.tsx
+++ b/src/components/LineChart/CustomLegend.tsx
@@ -13,7 +13,7 @@ import { getAverage, getCurrent, getMax, getMin, getSelected } from './helpers'
 const styles = {
   body: (theme: Theme) => css`
     > :not(:last-child) {
-      border-bottom: 1px solid ${theme.colors.gray100};
+      border-bottom: 1px solid ${theme.colorsDeprecated.gray100};
     }
   `,
   cell: css`
@@ -24,7 +24,7 @@ const styles = {
   head: (theme: Theme) => css`
     display: flex;
     padding-bottom: 8px;
-    border-bottom: 1px solid ${theme.colors.gray100};
+    border-bottom: 1px solid ${theme.colorsDeprecated.gray100};
 
     > :not(:last-child) {
       margin-right: 8px;

--- a/src/components/LineChart/index.tsx
+++ b/src/components/LineChart/index.tsx
@@ -54,14 +54,14 @@ const LineChart: FunctionComponent<LineChartProps> = ({
     axis: {
       ticks: {
         line: {
-          stroke: theme.colors.gray300,
+          stroke: theme.colorsDeprecated.gray300,
           strokeWidth: 1,
         },
       },
     },
     fontFamily: theme.fonts.sansSerif,
     fontSize: 12,
-    textColor: theme.colors.gray550,
+    textColor: theme.colorsDeprecated.gray550,
   }
 
   const [selected, setState] = useState(

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -11,10 +11,10 @@ const generateVariant =
   (color: Color | string) =>
   ({ theme }: { theme: Theme }) =>
     css`
-      color: ${theme.colors[color as Color] ?? color};
+      color: ${theme.colorsDeprecated[color as Color] ?? color};
       &:hover,
       &:focus {
-        color: ${darken(0.2, theme.colors[color as Color] ?? color)};
+        color: ${darken(0.2, theme.colorsDeprecated[color as Color] ?? color)};
       }
     `
 
@@ -31,10 +31,10 @@ const variants = {
     }
   `,
   primary: ({ theme }: { theme: Theme }) => css`
-    color: ${theme.colors.primary};
+    color: ${theme.colorsDeprecated.primary};
     &:hover,
     &:focus {
-      color: ${theme.colors.primary};
+      color: ${theme.colorsDeprecated.primary};
     }
   `,
   white: generateVariant('white'),

--- a/src/components/List/SelectBar.tsx
+++ b/src/components/List/SelectBar.tsx
@@ -17,9 +17,9 @@ const StyledItemsCount = styled.div`
   line-height: 20px;
   text-align: center;
   border-radius: 4px;
-  background-color: ${({ theme }) => theme.colors.gray100};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray100};
   font-weight: 500;
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colorsDeprecated.primary};
 `
 
 export type ListSelectBarProps = {

--- a/src/components/List/variantExplorer.tsx
+++ b/src/components/List/variantExplorer.tsx
@@ -25,13 +25,15 @@ const StyledRow = styled(Box, {
   align-items: center;
   flex-wrap: wrap;
 
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray350};
+  border-bottom: 1px solid ${({ theme }) => theme.colorsDeprecated.gray350};
 
   color: ${({ selected, highlighted, theme }) =>
-    selected && highlighted ? theme.colors.primary : theme.colors.gray700};
+    selected && highlighted
+      ? theme.colorsDeprecated.primary
+      : theme.colorsDeprecated.gray700};
 
   &:hover {
-    color: ${({ theme }) => theme.colors.primary};
+    color: ${({ theme }) => theme.colorsDeprecated.primary};
   }
 
   ${Cell} {
@@ -52,11 +54,11 @@ const StyledHeader = styled.div`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray350};
+  border-bottom: 1px solid ${({ theme }) => theme.colorsDeprecated.gray350};
 
   ${Cell} {
     font-size: 14px;
-    color: ${({ theme }) => theme.colors.gray550};
+    color: ${({ theme }) => theme.colorsDeprecated.gray550};
     padding: 4px 8px !important;
 
     &[disabled] {
@@ -74,7 +76,8 @@ const StyledCheckbox = styled(Checkbox)`
 `
 
 const StyledSpan = styled.span<{ color?: Color }>`
-  ${({ theme, color }) => (color ? `color: ${theme.colors[color]};` : ``)}
+  ${({ theme, color }) =>
+    color ? `color: ${theme.colorsDeprecated[color]};` : ``}
 `
 
 export const Header: VoidFunctionComponent = () => {

--- a/src/components/List/variantProduct.tsx
+++ b/src/components/List/variantProduct.tsx
@@ -32,10 +32,10 @@ const getBorderColor = ({
   selected?: boolean
   theme: Theme
 }) => {
-  if (alert) return theme.colors.orange
-  if (selected || highlighted) return theme.colors.primary
+  if (alert) return theme.colorsDeprecated.orange
+  if (selected || highlighted) return theme.colorsDeprecated.primary
 
-  return theme.colors.gray350
+  return theme.colorsDeprecated.gray350
 }
 
 const fadeInAnimation = keyframes`
@@ -56,7 +56,7 @@ const StyledExpendableContainer = styled('div', {
   flex: 0 0 100%;
 
   [data-expandable] {
-    border-top: 1px solid ${({ theme }) => theme.colors.gray200};
+    border-top: 1px solid ${({ theme }) => theme.colorsDeprecated.gray200};
     padding: 16px 16px 8px ${({ multiselect }) => (multiselect ? 48 : 16)}px;
     margin-top: 8px;
 
@@ -105,16 +105,20 @@ const StyledRow = styled('details', {
   padding: 8px 0;
   transition: box-shadow 200ms ease, border-color 200ms ease;
   background-color: ${({ alert, theme }) =>
-    alert ? theme.colors.pippin : `initial`};
+    alert ? theme.colorsDeprecated.pippin : `initial`};
 
   cursor: ${({ openable }) => (openable ? 'pointer' : 'auto')};
-  color: ${({ alert, theme }) => (alert ? theme.colors.orange : 'inherit')};
+  color: ${({ alert, theme }) =>
+    alert ? theme.colorsDeprecated.orange : 'inherit'};
 
   ${({ highlighted, isHoverable, theme }) =>
     isHoverable
       ? `&:hover${highlighted ? ', &' : ''} {
-        border-color: ${theme.colors.primary};
-        box-shadow: 0 2px 14px 8px ${transparentize(0.5, theme.colors.gray200)};
+        border-color: ${theme.colorsDeprecated.primary};
+        box-shadow: 0 2px 14px 8px ${transparentize(
+          0.5,
+          theme.colorsDeprecated.gray200,
+        )};
       }`
       : ''}
 
@@ -159,7 +163,7 @@ const StyledHeader = styled('div', {
 
   > ${Cell} {
     font-size: 14px;
-    color: ${({ theme }) => theme.colors.gray550};
+    color: ${({ theme }) => theme.colorsDeprecated.gray550};
     height: 40px;
 
     padding: 0 8px;
@@ -192,7 +196,8 @@ const StyledSummary = styled.summary`
 const StyledSpan = styled.span<{ color?: Color }>`
   text-overflow: ellipsis;
   overflow: hidden;
-  ${({ theme, color }) => (color ? `color: ${theme.colors[color]};` : ``)}
+  ${({ theme, color }) =>
+    color ? `color: ${theme.colorsDeprecated[color]};` : ``}
 `
 
 export const Header: FunctionComponent = props => {

--- a/src/components/List/variantTable.tsx
+++ b/src/components/List/variantTable.tsx
@@ -32,11 +32,11 @@ const StyledHeader = styled.div`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray350};
+  border-bottom: 1px solid ${({ theme }) => theme.colorsDeprecated.gray350};
 
   ${Cell} {
     font-size: 14px;
-    color: ${({ theme }) => theme.colors.gray550};
+    color: ${({ theme }) => theme.colorsDeprecated.gray550};
     padding: 4px 8px !important;
 
     &[disabled] {
@@ -56,10 +56,10 @@ const getRowColor = ({
   selected?: boolean
   theme: Theme
 }) => {
-  if (disabled) return theme.colors.gray550
-  if (selected && highlighted) return theme.colors.primary
+  if (disabled) return theme.colorsDeprecated.gray550
+  if (selected && highlighted) return theme.colorsDeprecated.primary
 
-  return theme.colors.gray700
+  return theme.colorsDeprecated.gray700
 }
 
 const StyledRow = styled(Box, {
@@ -87,14 +87,16 @@ const StyledRow = styled(Box, {
   flex-wrap: wrap;
 
   &:nth-of-type(even) {
-    background-color: ${({ theme }) => theme.colors.gray50};
+    background-color: ${({ theme }) => theme.colorsDeprecated.gray50};
   }
 
   color: ${getRowColor};
 
   &:hover {
     color: ${({ disabled, theme }) =>
-      disabled ? theme.colors.gray550 : theme.colors.primary};
+      disabled
+        ? theme.colorsDeprecated.gray550
+        : theme.colorsDeprecated.primary};
   }
 
   ${Cell} {
@@ -119,7 +121,8 @@ const StyledCheckbox = styled(Checkbox)`
 `
 
 const StyledSpan = styled.span<{ color?: Color }>`
-  ${({ theme, color }) => (color ? `color: ${theme.colors[color]};` : ``)}
+  ${({ theme, color }) =>
+    color ? `color: ${theme.colorsDeprecated[color]};` : ``}
 `
 
 export const Header: FunctionComponent = () => {

--- a/src/components/Menu/Item.tsx
+++ b/src/components/Menu/Item.tsx
@@ -6,27 +6,27 @@ import Button, { ButtonProps } from '../Button'
 const variantStyle = {
   danger: (theme: Theme) => css`
     display: inline-block;
-    color: ${theme.colors.red};
+    color: ${theme.colorsDeprecated.red};
     &:hover,
     &:focus {
-      color: ${theme.colors.crimson};
+      color: ${theme.colorsDeprecated.crimson};
       svg {
-        fill: ${theme.colors.crimson};
+        fill: ${theme.colorsDeprecated.crimson};
       }
     }
     svg {
-      fill: ${theme.colors.red};
+      fill: ${theme.colorsDeprecated.red};
     }
   `,
   nav: (theme: Theme) => css`
     font-size: 16px;
     line-height: 24px;
-    color: ${theme.colors.gray550};
+    color: ${theme.colorsDeprecated.gray550};
     &:hover,
     &:focus {
-      color: ${theme.colors.primary};
+      color: ${theme.colorsDeprecated.primary};
       svg {
-        fill: ${theme.colors.primary};
+        fill: ${theme.colorsDeprecated.primary};
       }
     }
   `,
@@ -38,14 +38,14 @@ const styles = {
   `,
   disabled: (theme: Theme) => css`
     cursor: not-allowed;
-    color: ${theme.colors.gray350};
+    color: ${theme.colorsDeprecated.gray350};
 
     &:hover,
     &:focus {
-      color: ${theme.colors.gray350};
-      background-color: ${theme.colors.white};
+      color: ${theme.colorsDeprecated.gray350};
+      background-color: ${theme.colorsDeprecated.white};
       svg {
-        fill: ${theme.colors.gray550};
+        fill: ${theme.colorsDeprecated.gray550};
       }
     }
   `,
@@ -55,19 +55,19 @@ const styles = {
     line-height: 22px;
     font-weight: inherit;
     padding: 4px 8px;
-    color: ${theme.colors.gray700};
+    color: ${theme.colorsDeprecated.gray700};
     border: 0;
-    border-bottom: 1px solid ${theme.colors.gray100};
+    border-bottom: 1px solid ${theme.colorsDeprecated.gray100};
     cursor: pointer;
     transition: color 300ms;
     min-width: 110px;
-    background-color: ${theme.colors.transparent};
+    background-color: ${theme.colorsDeprecated.transparent};
     &:hover,
     &:focus {
-      color: ${theme.colors.primary};
+      color: ${theme.colorsDeprecated.primary};
       svg {
         transition: fill 300ms;
-        fill: ${theme.colors.primary};
+        fill: ${theme.colorsDeprecated.primary};
       }
     }
 

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -6,26 +6,27 @@ import Popper, { PopperProps } from '../Popper'
 import Item from './Item'
 
 const bottomStyles = (theme: Theme) => css`
-  box-shadow: 0 -1px 5px 3px ${transparentize(0.85, theme.colors.shadow)};
+  box-shadow: 0 -1px 5px 3px ${transparentize(0.85, theme.colorsDeprecated.shadow)};
   &:after,
   &:before {
     bottom: 100%;
   }
   &:after {
-    border-bottom-color: ${theme.colors.white};
+    border-bottom-color: ${theme.colorsDeprecated.white};
   }
   &:before {
     border-bottom-color: rgba(165, 165, 205, 0.4);
   }
 `
 const topStyles = (theme: Theme) => css`
-  box-shadow: 0 1px 5px 3px ${transparentize(0.85, theme.colors.shadow)};
+  box-shadow: 0 1px 5px 3px
+    ${transparentize(0.85, theme.colorsDeprecated.shadow)};
   &:after,
   &:before {
     top: 100%;
   }
   &:after {
-    border-top-color: ${theme.colors.white};
+    border-top-color: ${theme.colorsDeprecated.white};
   }
   &:before {
     border-top-color: rgba(165, 165, 205, 0.4);
@@ -107,12 +108,12 @@ const styles = {
     }
   `,
   menu: (theme: Theme) => css`
-    background-color: ${theme.colors.white};
+    background-color: ${theme.colorsDeprecated.white};
     display: flex;
     flex-direction: column;
     text-align: center;
     justify-content: center;
-    color: ${theme.colors.gray550};
+    color: ${theme.colorsDeprecated.gray550};
     border-radius: 4px;
     position: relative;
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -196,7 +196,8 @@ const StyledDialogBackdrop = styled(DialogBackdrop)`
   left: 0;
   z-index: 999;
   opacity: 1;
-  background-color: ${({ theme }) => transparentize(0.8, theme.colors.gray700)};
+  background-color: ${({ theme }) =>
+    transparentize(0.8, theme.colorsDeprecated.gray700)};
   ${({ animated }) => animated && backdropAnimatedStyle}
 `
 
@@ -214,7 +215,7 @@ const StyledDialog = styled(Dialog, {
       props.toString(),
     ),
 })<StyledDialogProps>`
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme }) => theme.colorsDeprecated.white};
   position: relative;
   border-radius: ${({ bordered }) => (bordered ? 4 : 0)}px;
   border: 0;
@@ -223,7 +224,7 @@ const StyledDialog = styled(Dialog, {
   width: ${({ width }) => MODAL_WIDTH[width]}px;
   min-height: ${({ height }) => height};
   box-shadow: 0 0 12px 18px
-    ${({ theme }) => transparentize(0.8, theme.colors.shadow)};
+    ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.shadow)};
   opacity: 1;
   &::before {
     content: '';

--- a/src/components/NavigationStepper/index.tsx
+++ b/src/components/NavigationStepper/index.tsx
@@ -63,20 +63,20 @@ const StyledStep = styled('li', {
   ${({ condensed, isCompleted, theme }) =>
     isCompleted
       ? css`
-          color: ${theme.colors.success};
+          color: ${theme.colorsDeprecated.success};
           ${StyledStepNumber} {
-            background-color: ${theme.colors.success};
-            color: ${theme.colors.white};
+            background-color: ${theme.colorsDeprecated.success};
+            color: ${theme.colorsDeprecated.white};
           }
         `
       : css`
-          color: ${theme.colors.gray550};
+          color: ${theme.colorsDeprecated.gray550};
           ${StyledStepNumber} {
-            border: 3px solid ${theme.colors.gray550};
+            border: 3px solid ${theme.colorsDeprecated.gray550};
           }
 
           &[aria-current='true'] {
-            color: ${theme.colors.primary};
+            color: ${theme.colorsDeprecated.primary};
             ${condensed
               ? css`
                   flex-grow: 1;
@@ -84,9 +84,9 @@ const StyledStep = styled('li', {
               : ``}
 
             ${StyledStepNumber} {
-              border-color: ${theme.colors.primary};
-              color: ${theme.colors.white};
-              background-color: ${theme.colors.primary};
+              border-color: ${theme.colorsDeprecated.primary};
+              color: ${theme.colorsDeprecated.white};
+              background-color: ${theme.colorsDeprecated.primary};
             }
           }
         `};

--- a/src/components/Notice/index.tsx
+++ b/src/components/Notice/index.tsx
@@ -6,7 +6,7 @@ import Icon from '../Icon'
 import MarkDown from '../MarkDown'
 
 const Container = styled(Box)`
-  color: ${({ theme: { colors } }) => colors.gray550};
+  color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
   font-size: 12px;
   display: flex;
   align-items: center;

--- a/src/components/PasswordStrengthMeter/index.tsx
+++ b/src/components/PasswordStrengthMeter/index.tsx
@@ -17,7 +17,7 @@ const StyledStrength = styled(Typography)`
 `
 
 const StyledWrapper = styled(Box)`
-  background-color: ${({ theme }) => theme.colors.gray100};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray100};
   border-radius: 5px;
   height: 8px;
 `

--- a/src/components/Pentagon/__stories__/index.stories.tsx
+++ b/src/components/Pentagon/__stories__/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, Story } from '@storybook/react'
 import React from 'react'
 import Pentagon, { PentagonProps } from '..'
-import { colors } from '../../../theme'
+import { colorsDeprecated } from '../../../theme'
 import { FlexBox } from '../../index'
 
 export default {
@@ -9,7 +9,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: 'Simple pentagon with different sizes and colors.',
+        component: 'Simple pentagon with different sizes and colorsDeprecated.',
       },
     },
   },
@@ -24,10 +24,10 @@ export const Color = Template.bind({})
 Color.decorators = [
   () => (
     <FlexBox inline>
-      <Pentagon color={colors.zumthor} />
-      <Pentagon color={colors.foam} />
-      <Pentagon color={colors.serenade} />
-      <Pentagon color={colors.pippin} />
+      <Pentagon color={colorsDeprecated.zumthor} />
+      <Pentagon color={colorsDeprecated.foam} />
+      <Pentagon color={colorsDeprecated.serenade} />
+      <Pentagon color={colorsDeprecated.pippin} />
     </FlexBox>
   ),
 ]

--- a/src/components/Pentagon/index.tsx
+++ b/src/components/Pentagon/index.tsx
@@ -19,7 +19,7 @@ const StyledPentagon = styled('div', {
   ${({ size = '48px', color = 'pippin', theme }) => `
     width: ${size};
     height: ${size};
-    background-color: ${theme.colors[color as Color] ?? color};
+    background-color: ${theme.colorsDeprecated[color as Color] ?? color};
   `}
 `
 

--- a/src/components/PhoneInput/index.tsx
+++ b/src/components/PhoneInput/index.tsx
@@ -22,7 +22,8 @@ const StyledSpan = styled.span`
   left: 10px;
   font-size: 14px;
   padding: 0 10px;
-  background-color: ${({ theme: { colors } }) => colors.white};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.white};
 `
 
 interface PhoneInputLabelProps {
@@ -34,7 +35,8 @@ const StyledLabel = styled.label<PhoneInputLabelProps>`
   position: relative;
   display: flex;
   border-radius: 4px;
-  border: 1px solid ${({ theme: { colors } }) => colors.gray350};
+  border: 1px solid
+    ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray350};
   padding: 0.8rem 0rem;
 
   &[aria-disabled='true'] {
@@ -43,9 +45,11 @@ const StyledLabel = styled.label<PhoneInputLabelProps>`
   }
 
   &:focus-within {
-    border: 1px solid ${({ theme: { colors } }) => colors.primary};
+    border: 1px solid
+      ${({ theme: { colorsDeprecated } }) => colorsDeprecated.primary};
     box-shadow: 0 0 0 2px
-      ${({ theme: { colors } }) => transparentize(0.75, colors.primary)};
+      ${({ theme: { colorsDeprecated } }) =>
+        transparentize(0.75, colorsDeprecated.primary)};
   }
 
   & .input__tel__container {

--- a/src/components/PieChart/Legends.tsx
+++ b/src/components/PieChart/Legends.tsx
@@ -44,7 +44,9 @@ const ListItem = styled.li<{ isFocused: boolean }>`
   margin-top: 8px;
   width: 100%;
   color: ${({ isFocused, theme }) =>
-    isFocused ? theme.colors.primary : theme.colors.gray700};
+    isFocused
+      ? theme.colorsDeprecated.primary
+      : theme.colorsDeprecated.gray700};
 `
 
 const Bullet = styled.div<{
@@ -57,13 +59,14 @@ const Bullet = styled.div<{
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: ${({ color, theme }) => theme.colors[color as Color] ?? color};
+  background: ${({ color, theme }) =>
+    theme.colorsDeprecated[color as Color] ?? color};
 
   ${({ needPattern, color, theme, id }) => {
     if (!needPattern) return null
 
     return patternVariants?.[`${id}-dot` as keyof typeof patternVariants]?.(
-      theme.colors[color as Color] ?? color,
+      theme.colorsDeprecated[color as Color] ?? color,
     )
   }}
 
@@ -94,13 +97,13 @@ const ToggleBox = styled.div`
 `
 
 const Line = styled.span`
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray300};
+  border-bottom: 1px solid ${({ theme }) => theme.colorsDeprecated.gray300};
   position: relative;
   width: 100%;
 `
 
 const ProgressiveLine = styled.span<{ isFocused: boolean }>`
-  border-bottom: 1px solid ${({ theme }) => theme.colors.primary};
+  border-bottom: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
   position: absolute;
   left: 0;
   top: 0;

--- a/src/components/PieChart/index.tsx
+++ b/src/components/PieChart/index.tsx
@@ -64,7 +64,7 @@ const PieChart: VoidFunctionComponent<PieChartProps> = ({
   margin = { bottom: 10, left: 10, right: 10, top: 10 },
   chartProps = {},
 }) => {
-  const { colors } = useTheme()
+  const { colorsDeprecated } = useTheme()
   const [currentFocusIndex, setCurrentFocusIndex] = useState<string>()
   const emptyTooltip = useCallback(() => <span />, [])
   const isEmpty = !data || data?.length === 0
@@ -108,7 +108,7 @@ const PieChart: VoidFunctionComponent<PieChartProps> = ({
               ? data
               : [
                   {
-                    color: colors.gray300,
+                    color: colorsDeprecated.gray300,
                     id: 'empty',
                     percent: 100,
                   },
@@ -117,7 +117,7 @@ const PieChart: VoidFunctionComponent<PieChartProps> = ({
           defs={[
             {
               background: 'inherit',
-              color: colors.white,
+              color: colorsDeprecated.white,
               id: 'lines',
               lineWidth: 2,
               rotation: 0,

--- a/src/components/Placeholder/Block.tsx
+++ b/src/components/Placeholder/Block.tsx
@@ -16,7 +16,7 @@ const styles = {
     margin-bottom: 16px;
     border-style: solid;
     border-width: 1px;
-    border-color: ${theme.colors.gray300};
+    border-color: ${theme.colorsDeprecated.gray300};
     border-radius: 4px;
   `,
   container: css`
@@ -27,7 +27,7 @@ const styles = {
     width: 32px;
     height: 32px;
     border-radius: 12px;
-    background-color: ${theme.colors.gray300};
+    background-color: ${theme.colorsDeprecated.gray300};
   `,
 }
 

--- a/src/components/Placeholder/Blocks.tsx
+++ b/src/components/Placeholder/Blocks.tsx
@@ -14,7 +14,7 @@ const styles = {
     margin-bottom: 16px;
     border-style: solid;
     border-width: 1px;
-    border-color: ${theme.colors.gray300};
+    border-color: ${theme.colorsDeprecated.gray300};
     border-radius: 4px;
   `,
   container: ({ length }: { length: number }) => css`
@@ -25,7 +25,7 @@ const styles = {
     width: 32px;
     height: 32px;
     border-radius: 12px;
-    background-color: ${theme.colors.gray300};
+    background-color: ${theme.colorsDeprecated.gray300};
   `,
 }
 

--- a/src/components/Placeholder/BoxWithIcon.tsx
+++ b/src/components/Placeholder/BoxWithIcon.tsx
@@ -9,7 +9,7 @@ const iconStyle = (size: number) => (theme: Theme) =>
     width: ${size}px;
     height: ${size}px;
     border-radius: ${size}px;
-    background-color: ${theme.colors.gray300};
+    background-color: ${theme.colorsDeprecated.gray300};
   `
 
 const boxStyled = (theme: Theme) => css`
@@ -17,7 +17,7 @@ const boxStyled = (theme: Theme) => css`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border: 1px solid ${theme.colors.gray300};
+  border: 1px solid ${theme.colorsDeprecated.gray300};
 `
 
 const BoxWithIcon: VoidFunctionComponent<{

--- a/src/components/Placeholder/Donut.tsx
+++ b/src/components/Placeholder/Donut.tsx
@@ -7,7 +7,7 @@ import Line from './Line'
 const styles = {
   circle: (theme: Theme) => css`
     transform-origin: 50% 50%;
-    stroke: ${theme.colors.gray300};
+    stroke: ${theme.colorsDeprecated.gray300};
     stroke-width: 18;
     stroke-linecap: butt;
     fill: none;

--- a/src/components/Placeholder/Line.tsx
+++ b/src/components/Placeholder/Line.tsx
@@ -12,7 +12,7 @@ const Line = styled(Box, {
   height: 12px;
   width: ${({ width }) => width ?? randomSize()}px;
   border-radius: 10px;
-  background-color: ${({ theme }) => theme.colors.gray300};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray300};
 `
 
 Line.propTypes = {

--- a/src/components/Placeholder/List.tsx
+++ b/src/components/Placeholder/List.tsx
@@ -16,7 +16,7 @@ const StyledList = styled.ul`
   margin: 0;
 
   > ${StyledItem}:nth-of-type(even) {
-    background-color: ${({ theme }) => theme.colors.gray50};
+    background-color: ${({ theme }) => theme.colorsDeprecated.gray50};
   }
 `
 

--- a/src/components/Placeholder/Slider.tsx
+++ b/src/components/Placeholder/Slider.tsx
@@ -5,7 +5,7 @@ import Box from '../Box'
 
 const styles = {
   card: (theme: Theme) => css`
-    border: 1px solid ${theme.colors.gray300};
+    border: 1px solid ${theme.colorsDeprecated.gray300};
     border-radius: 4px;
     width: 240px;
     height: 261px;
@@ -17,8 +17,8 @@ const styles = {
     overflow: auto;
   `,
   img: (theme: Theme) => css`
-    border: 1px solid ${theme.colors.gray300};
-    background-color: ${theme.colors.gray300};
+    border: 1px solid ${theme.colorsDeprecated.gray300};
+    background-color: ${theme.colorsDeprecated.gray300};
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;
     width: 240px;

--- a/src/components/Popper/index.tsx
+++ b/src/components/Popper/index.tsx
@@ -36,11 +36,14 @@ const buildVariant =
   }) =>
   ({ theme }: { theme: Theme }) =>
     css`
-      background-color: ${theme.colors[bgColor as Color] ?? bgColor};
-      color: ${theme.colors[color as Color] ?? color};
-      fill: ${theme.colors[fill as Color] ?? fill};
+      background-color: ${theme.colorsDeprecated[bgColor as Color] ?? bgColor};
+      color: ${theme.colorsDeprecated[color as Color] ?? color};
+      fill: ${theme.colorsDeprecated[fill as Color] ?? fill};
       box-shadow: 0 2px 5px 5px
-        ${transparentize(0.7, theme.colors[shadow as Color] ?? shadow)};
+        ${transparentize(
+          0.7,
+          theme.colorsDeprecated[shadow as Color] ?? shadow,
+        )};
     `
 const variants = {
   black: buildVariant({

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -26,7 +26,7 @@ const StyledBox = styled(Box, {
   margin-right: 0;
   border-radius: 2px;
   background-color: ${({ theme, backgroundColor }) =>
-    theme.colors[backgroundColor as Color] ?? backgroundColor};
+    theme.colorsDeprecated[backgroundColor as Color] ?? backgroundColor};
 `
 
 const StyledProgress = styled.div`
@@ -56,7 +56,7 @@ const StyledFilled = styled('div', {
   left: 0;
   bottom: 0;
   background-color: ${({ theme, variant }) =>
-    theme.colors[variant as Color] ?? 'inherit'};
+    theme.colorsDeprecated[variant as Color] ?? 'inherit'};
   transition: 0.3s width;
   width: ${({ value }) => Math.max(0, Math.min(100, value))}%;
 `

--- a/src/components/ProgressionButton/index.tsx
+++ b/src/components/ProgressionButton/index.tsx
@@ -25,10 +25,10 @@ const ProgressionContainer = styled(Box)`
   ${({ theme }) => `
   background: repeating-linear-gradient(
     45deg,
-    ${theme.colors.gray550},
-    ${theme.colors.gray550} 10px,
-    ${transparentize(0.25, theme.colors.gray550)} 10px,
-    ${transparentize(0.25, theme.colors.gray550)} 30px
+    ${theme.colorsDeprecated.gray550},
+    ${theme.colorsDeprecated.gray550} 10px,
+    ${transparentize(0.25, theme.colorsDeprecated.gray550)} 10px,
+    ${transparentize(0.25, theme.colorsDeprecated.gray550)} 30px
   );`}
 
   overflow: hidden;
@@ -50,7 +50,7 @@ interface ProgressionProps {
 
 const Progression = styled.div<ProgressionProps>`
   background-color: ${({ theme, color }) =>
-    theme.colors[color as Color] ?? color};
+    theme.colorsDeprecated[color as Color] ?? color};
   position: absolute;
   z-index: -1;
   top: 0;

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -20,7 +20,7 @@ const IconContainer = styled(Box)`
 `
 
 const disabledClass = ({ theme }: { theme: Theme }) => css`
-  color: ${theme.colors.gray300};
+  color: ${theme.colorsDeprecated.gray300};
   cursor: not-allowed;
 `
 
@@ -28,11 +28,11 @@ const activeFocusClass = ({ theme }: { theme: Theme }) => css`
   :hover,
   :focus {
     ${IconContainer} {
-      background-color: ${transparentize(0.75, theme.colors.gray300)};
+      background-color: ${transparentize(0.75, theme.colorsDeprecated.gray300)};
       border-radius: 50%;
 
       > ${StyledIcon} {
-        fill: ${theme.colors.primary};
+        fill: ${theme.colorsDeprecated.primary};
       }
     }
   }

--- a/src/components/RadioBorderedBox/index.tsx
+++ b/src/components/RadioBorderedBox/index.tsx
@@ -8,16 +8,16 @@ import Box, { XStyledProps } from '../Box'
 import Radio from '../Radio'
 
 const StyledBox = styled(Box)<{ disabled: boolean; checked: boolean }>`
-  ${({ disabled, checked, theme: { colors } }) => {
+  ${({ disabled, checked, theme: { colorsDeprecated } }) => {
     if (disabled)
       return `
         cursor: not-allowed !important;
-        color: ${colors.gray300};
+        color: ${colorsDeprecated.gray300};
       `
     if (checked)
       return `
-        border: 1px solid ${colors.primary} !important;
-        box-shadow: 0 0 0 2px ${transparentize(0.75, colors.primary)};
+        border: 1px solid ${colorsDeprecated.primary} !important;
+        box-shadow: 0 0 0 2px ${transparentize(0.75, colorsDeprecated.primary)};
       `
 
     return null

--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -64,7 +64,7 @@ const StyledBar = styled('div', {
   position: absolute;
   height: 4px;
   width: 100%;
-  background-color: ${({ theme }) => theme.colors.zumthor};
+  background-color: ${({ theme }) => theme.colorsDeprecated.zumthor};
   border-radius: 8px;
   user-select: none;
   top: ${({ offsetTop }) => offsetTop}px;
@@ -76,13 +76,13 @@ const StyledLimit = styled(Box, {
 })<{ offsetTop: number }>`
   position: absolute;
   font-size: 12px;
-  color: ${({ theme }) => theme.colors.gray950};
+  color: ${({ theme }) => theme.colorsDeprecated.gray950};
   font-weight: 500;
   top: ${({ offsetTop }) => offsetTop + 8}px;
 
   ::before {
     content: '';
-    background-color: ${({ theme }) => theme.colors.gray950};
+    background-color: ${({ theme }) => theme.colorsDeprecated.gray950};
     width: 2px;
     position: absolute;
     height: 10px;
@@ -143,7 +143,7 @@ const StyledCursorLink = styled('div', {
   top: ${({ offsetTop = 0 }) => offsetTop + 0}px;
   height: 4px;
   width: 100%;
-  background-color: ${({ theme }) => theme.colors.violet};
+  background-color: ${({ theme }) => theme.colorsDeprecated.violet};
   border-radius: 8px;
   user-select: none;
 `
@@ -157,7 +157,7 @@ const StyledCursor = styled(Box, {
   height: 16px;
   width: ${({ width }) => width}px;
   border-radius: 50%;
-  border: 4px solid ${({ theme }) => theme.colors.violet};
+  border: 4px solid ${({ theme }) => theme.colorsDeprecated.violet};
   background-color: white;
   cursor: ${({ grabbed }) => (grabbed ? 'grabbing' : 'grab')};
   margin-bottom: 16px;
@@ -165,10 +165,10 @@ const StyledCursor = styled(Box, {
 
 const StyledInput = styled.input`
   position: absolute;
-  color: ${({ theme }) => theme.colors.gray950};
-  background-color: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colorsDeprecated.gray950};
+  background-color: ${({ theme }) => theme.colorsDeprecated.white};
   font-size: 16px;
-  border: 1px solid ${({ theme }) => theme.colors.violet};
+  border: 1px solid ${({ theme }) => theme.colorsDeprecated.violet};
   border-radius: 4px;
   min-height: 25px;
   min-width: 40px;

--- a/src/components/Reminder/index.tsx
+++ b/src/components/Reminder/index.tsx
@@ -40,7 +40,7 @@ const Notification = styled(Box, {
   cursor: pointer;
   border-radius: 14px;
   text-decoration: none;
-  color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.gray700};
   font-weight: 400;
 
   &:hover {
@@ -50,25 +50,29 @@ const Notification = styled(Box, {
   ${({ variant, bordered, theme }) => `
     background-color: ${
       bordered
-        ? theme.colors.transparent
-        : theme.colors[variants[variant].background as Color]
+        ? theme.colorsDeprecated.transparent
+        : theme.colorsDeprecated[variants[variant].background as Color]
     };
     border: 1px solid ${
-      bordered ? theme.colors.gray300 : theme.colors.transparent
+      bordered
+        ? theme.colorsDeprecated.gray300
+        : theme.colorsDeprecated.transparent
     };
     transition: all .3s ease-in-out;
 
     &:hover {
       box-shadow: 0 3px 6px ${
-        theme.colors[variants[variant].background as Color]
+        theme.colorsDeprecated[variants[variant].background as Color]
       };
-      border: 1px solid ${theme.colors[variants[variant].main as Color]};
+      border: 1px solid ${
+        theme.colorsDeprecated[variants[variant].main as Color]
+      };
     }
   `}
 
   & strong {
     ${({ variant, theme }) => `
-      color: ${theme.colors[variants[variant].main as Color]};
+      color: ${theme.colorsDeprecated[variants[variant].main as Color]};
     `}
   }
 `

--- a/src/components/RichSelect/index.tsx
+++ b/src/components/RichSelect/index.tsx
@@ -51,10 +51,10 @@ type SelectStyleGetterProps = {
 }
 
 const getControlColor = ({ state, error, theme }: SelectStyleGetterProps) => {
-  if (state.isDisabled) return theme.colors.gray300
-  if (error) return theme.colors.warning
+  if (state.isDisabled) return theme.colorsDeprecated.gray300
+  if (error) return theme.colorsDeprecated.warning
 
-  return theme.colors.gray700
+  return theme.colorsDeprecated.gray700
 }
 
 const getPlaceholderColor = ({
@@ -62,23 +62,23 @@ const getPlaceholderColor = ({
   error,
   theme,
 }: SelectStyleGetterProps) => {
-  if (state.isDisabled) return theme.colors.gray300
-  if (error) return theme.colors.warning
+  if (state.isDisabled) return theme.colorsDeprecated.gray300
+  if (error) return theme.colorsDeprecated.warning
 
-  return theme.colors.gray550
+  return theme.colorsDeprecated.gray550
 }
 
 const getOptionColor = ({ state, theme }: SelectStyleGetterProps) => {
-  let color: string = theme.colors.gray700
-  let backgroundColor: string = theme.colors.white
+  let color: string = theme.colorsDeprecated.gray700
+  let backgroundColor: string = theme.colorsDeprecated.white
   if (state.isDisabled) {
-    backgroundColor = theme.colors.gray50
-    color = theme.colors.gray300
+    backgroundColor = theme.colorsDeprecated.gray50
+    color = theme.colorsDeprecated.gray300
   } else if (state.isSelected) {
-    backgroundColor = theme.colors.primary
-    color = theme.colors.white
+    backgroundColor = theme.colorsDeprecated.primary
+    color = theme.colorsDeprecated.white
   } else if (state.isFocused) {
-    backgroundColor = theme.colors.gray200
+    backgroundColor = theme.colorsDeprecated.gray200
   }
 
   return { backgroundColor, color }
@@ -113,9 +113,11 @@ const getSelectStyles = ({
   control: (provided, state) => ({
     ...provided,
     backgroundColor: state.isDisabled
-      ? theme.colors.gray50
-      : theme.colors.white,
-    borderColor: error ? theme.colors.warning : theme.colors.gray300,
+      ? theme.colorsDeprecated.gray50
+      : theme.colorsDeprecated.white,
+    borderColor: error
+      ? theme.colorsDeprecated.warning
+      : theme.colorsDeprecated.gray300,
     borderRadius: '4px',
     borderStyle: state.isDisabled ? 'none' : 'solid',
     borderWidth: state.isDisabled ? 0 : '1px',
@@ -129,19 +131,29 @@ const getSelectStyles = ({
 
     ...(!state.isDisabled && {
       ':focus-within': {
-        borderColor: error ? theme.colors.warning : theme.colors.primary,
+        borderColor: error
+          ? theme.colorsDeprecated.warning
+          : theme.colorsDeprecated.primary,
         boxShadow: `0 0 2px 2px ${transparentize(
           0.75,
-          error ? theme.colors.warning : theme.colors.primary,
+          error
+            ? theme.colorsDeprecated.warning
+            : theme.colorsDeprecated.primary,
         )}`,
         svg: {
-          fill: error ? theme.colors.warning : theme.colors.primary,
+          fill: error
+            ? theme.colorsDeprecated.warning
+            : theme.colorsDeprecated.primary,
         },
       },
       ':hover': {
-        borderColor: error ? theme.colors.warning : theme.colors.primary,
+        borderColor: error
+          ? theme.colorsDeprecated.warning
+          : theme.colorsDeprecated.primary,
         svg: {
-          fill: error ? theme.colors.warning : theme.colors.primary,
+          fill: error
+            ? theme.colorsDeprecated.warning
+            : theme.colorsDeprecated.primary,
         },
       },
     }),
@@ -160,7 +172,7 @@ const getSelectStyles = ({
   }),
   indicatorSeparator: (provided, state) => ({
     ...provided,
-    backgroundColor: theme.colors.gray200,
+    backgroundColor: theme.colorsDeprecated.gray200,
     display: state.selectProps?.time ? 'flex' : 'none',
     ...(customStyle(state)?.indicatorSeparator || {}),
   }),
@@ -175,12 +187,12 @@ const getSelectStyles = ({
     ...(customStyle(state)?.menu || {}),
     boxShadow: `0 0 0 1px ${transparentize(
       0.9,
-      theme.colors.black,
-    )}, 0 4px 11px ${transparentize(0.9, theme.colors.black)}`,
+      theme.colorsDeprecated.black,
+    )}, 0 4px 11px ${transparentize(0.9, theme.colorsDeprecated.black)}`,
   }),
   menuList: (provided, state) => ({
     ...provided,
-    backgroundColor: theme.colors.white,
+    backgroundColor: theme.colorsDeprecated.white,
     maxHeight: '225px',
     ...(customStyle(state)?.menuList || {}),
   }),
@@ -192,9 +204,9 @@ const getSelectStyles = ({
   multiValue: (provided, state) => ({
     ...provided,
     alignItems: 'center',
-    backgroundColor: theme.colors.gray100,
+    backgroundColor: theme.colorsDeprecated.gray100,
     borderRadius: '4px',
-    color: theme.colors.gray700,
+    color: theme.colorsDeprecated.gray700,
     fontSize: '14px',
     fontWeight: 500,
     height: '24px',
@@ -205,7 +217,9 @@ const getSelectStyles = ({
   }),
   multiValueLabel: (provided, state) => ({
     ...provided,
-    color: state.isDisabled ? theme.colors.gray300 : theme.colors.gray700,
+    color: state.isDisabled
+      ? theme.colorsDeprecated.gray300
+      : theme.colorsDeprecated.gray700,
     fontSize: '14px',
     fontWeight: 'normal',
     lineHeight: '20px',
@@ -215,15 +229,17 @@ const getSelectStyles = ({
     ...provided,
     ...(state.isDisabled
       ? {
-          color: theme.colors.gray300,
+          color: theme.colorsDeprecated.gray300,
           cursor: 'none',
           pointerEvents: 'none',
         }
       : {
-          color: theme.colors.gray550,
+          color: theme.colorsDeprecated.gray550,
         }),
     ':hover': {
-      color: state.isDisabled ? theme.colors.gray300 : theme.colors.primary,
+      color: state.isDisabled
+        ? theme.colorsDeprecated.gray300
+        : theme.colorsDeprecated.primary,
       cursor: state.isDisabled ? 'none' : 'pointer',
       pointerEvents: state.isDisabled ? 'none' : 'fill',
     },
@@ -234,15 +250,19 @@ const getSelectStyles = ({
     ...getOptionColor({ state, theme }),
     ':active': {
       backgroundColor: state.isDisabled
-        ? theme.colors.gray50
-        : theme.colors.gray200,
-      color: state.isDisabled ? theme.colors.gray300 : theme.colors.gray700,
+        ? theme.colorsDeprecated.gray50
+        : theme.colorsDeprecated.gray200,
+      color: state.isDisabled
+        ? theme.colorsDeprecated.gray300
+        : theme.colorsDeprecated.gray700,
     },
     ':hover': {
       backgroundColor: state.isDisabled
-        ? theme.colors.gray50
-        : theme.colors.gray200,
-      color: state.isDisabled ? theme.colors.gray300 : theme.colors.gray700,
+        ? theme.colorsDeprecated.gray50
+        : theme.colorsDeprecated.gray200,
+      color: state.isDisabled
+        ? theme.colorsDeprecated.gray300
+        : theme.colorsDeprecated.gray700,
     },
     ...(customStyle(state)?.option || {}),
   }),
@@ -253,7 +273,9 @@ const getSelectStyles = ({
   }),
   singleValue: (provided, state) => ({
     ...provided,
-    color: state.isDisabled ? theme.colors.gray550 : theme.colors.gray700,
+    color: state.isDisabled
+      ? theme.colorsDeprecated.gray550
+      : theme.colorsDeprecated.gray700,
     marginLeft: state.hasValue ? 0 : undefined,
     marginRight: state.hasValue ? 0 : undefined,
     marginTop: !state.hasValue || noTopLabel ? 0 : '5px',
@@ -304,7 +326,7 @@ const StyledContainer = styled(Box, {
 
 const StyledError = styled.div`
   font-size: 12px;
-  color: ${({ theme }) => theme.colors.warning};
+  color: ${({ theme }) => theme.colorsDeprecated.warning};
   padding-top: ${({ theme }) => theme.space['0.25']};
 `
 
@@ -416,7 +438,7 @@ const StyledPlaceholder = styled(Box, {
   left: 0;
   font-weight: 400;
   pointer-events: none;
-  color: ${({ theme }) => theme.colors.gray550};
+  color: ${({ theme }) => theme.colorsDeprecated.gray550};
   white-space: nowrap;
   width: 100%;
   height: 100%;
@@ -424,7 +446,7 @@ const StyledPlaceholder = styled(Box, {
   transition: transform 250ms ease;
   opacity: 0;
 
-  ${({ error, theme }) => error && `color: ${theme.colors.warning};`}
+  ${({ error, theme }) => error && `color: ${theme.colorsDeprecated.warning};`}
   ${({ hasValue }) =>
     hasValue &&
     `

--- a/src/components/Separator/index.tsx
+++ b/src/components/Separator/index.tsx
@@ -39,7 +39,7 @@ const StyledHr = styled(Box.withComponent('hr'), {
     direction === 'horizontal' ? `${thickness}px` : 'auto'};
   flex-shrink: 0;
   background-color: ${({ theme, color }) =>
-    theme.colors[color as Color] ?? color};
+    theme.colorsDeprecated[color as Color] ?? color};
   ${({ flex }) => flex && `flex: ${flex};`}
 `
 

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -23,7 +23,7 @@ const StyledBeforeScroll = styled.span`
   background: linear-gradient(
     -90deg,
     rgba(255, 255, 255, 0),
-    ${({ theme }) => theme.colors.white}
+    ${({ theme }) => theme.colorsDeprecated.white}
   );
   cursor: w-resize;
   z-index: auto;
@@ -53,7 +53,7 @@ const StyledAfterScroll = styled.span`
   z-index: auto;
   background: linear-gradient(
     -90deg,
-    ${({ theme }) => theme.colors.white},
+    ${({ theme }) => theme.colorsDeprecated.white},
     rgba(255, 255, 255, 0)
   );
 `
@@ -61,7 +61,7 @@ const StyledAfterScroll = styled.span`
 const StyledBorderWrapper = styled(Box)`
   display: inline-block;
   border-radius: 4px;
-  border: 1px solid ${({ theme }) => theme.colors.gray350};
+  border: 1px solid ${({ theme }) => theme.colorsDeprecated.gray350};
   height: 261px;
   width: 248px;
   max-width: 240px;
@@ -72,9 +72,10 @@ const StyledBorderWrapper = styled(Box)`
   &:hover,
   &:active,
   &:focus {
-    border: 1px solid ${({ theme }) => theme.colors.primary};
+    border: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
     transition: box-shadow 0.2s ease;
-    box-shadow: 2px 2px 14px 8px ${({ theme }) => theme.colors.gray200};
+    box-shadow: 2px 2px 14px 8px
+      ${({ theme }) => theme.colorsDeprecated.gray200};
   }
 
   img {

--- a/src/components/Sphere/index.tsx
+++ b/src/components/Sphere/index.tsx
@@ -16,7 +16,7 @@ const bordersStyles = ({
 }) => {
   const isHalved = bgColors.length > 1
   const finalColors = bgColors?.map(
-    bgColor => theme.colors[bgColor as Color] ?? bgColor,
+    bgColor => theme.colorsDeprecated[bgColor as Color] ?? bgColor,
   )
 
   return css`
@@ -44,7 +44,8 @@ const StyledSphere = styled(Box, {
 const StyledTextSphere = styled('div', {
   shouldForwardProp: prop => !['color', 'fontSize'].includes(prop.toString()),
 })<{ color: string; fontSize?: number }>`
-  color: ${({ theme, color }) => theme.colors[color as Color] ?? color};
+  color: ${({ theme, color }) =>
+    theme.colorsDeprecated[color as Color] ?? color};
   font-size: ${({ fontSize = 10 }) => fontSize}px;
 `
 

--- a/src/components/StealthCopiable/index.tsx
+++ b/src/components/StealthCopiable/index.tsx
@@ -5,9 +5,9 @@ import useClipboard from 'react-use-clipboard'
 import recursivelyGetChildrenString from '../../helpers/recursivelyGetChildrenString'
 
 const CopyButton = styled.button`
-  background-color: ${({ theme }) => theme.colors.transparent};
+  background-color: ${({ theme }) => theme.colorsDeprecated.transparent};
   border: none;
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colorsDeprecated.primary};
   display: inline-block;
   padding-left: 8px;
   opacity: 0;

--- a/src/components/Stepper/index.tsx
+++ b/src/components/Stepper/index.tsx
@@ -33,9 +33,9 @@ const disabledStyles = ({
 }) =>
   disabled &&
   `
-    background-color: ${theme.colors.gray100};
+    background-color: ${theme.colorsDeprecated.gray100};
     border: none;
-    color: ${theme.colors.gray550};
+    color: ${theme.colorsDeprecated.gray550};
     opacity: 1;
     cursor: not-allowed;
   `
@@ -70,11 +70,12 @@ const StyledTouchable = styled(Touchable, {
   width: ${({ size }) => containerSizes[size] - 10}px;
 
   > ${StyledIcon} {
-    fill: ${({ disabled, theme }) => !disabled && theme.colors.primary};
+    fill: ${({ disabled, theme }) =>
+      !disabled && theme.colorsDeprecated.primary};
   }
 
   :hover:not([disabled]) {
-    background: ${({ theme }) => theme.colors.gray200};
+    background: ${({ theme }) => theme.colorsDeprecated.gray200};
   }
 
   margin: 0 4px;
@@ -90,18 +91,18 @@ const StyledCenterTouchable = styled(Touchable)<{ size: ContainerSizesType }>`
   border-radius: 4px;
   border: 1px solid transparent;
   :hover:not([disabled], :focus) {
-    border: 1px solid ${({ theme }) => theme.colors.primary};
+    border: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
   }
   :focus-within:not([disabled]) {
     box-shadow: 0 0 2px 2px
-      ${({ theme }) => transparentize(0.7, theme.colors.primary)};
-    border: 1px solid ${({ theme }) => theme.colors.primary};
+      ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.primary)};
+    border: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
   }
   max-width: calc(100% - ${({ size }) => containerSizes[size] * 2}px);
 `
 
 const StyledInput = styled.input`
-  color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.gray700};
   background-color: transparent;
   font-size: 16;
   border: none;
@@ -118,14 +119,14 @@ const StyledContainer = styled(Box, {
   shouldForwardProp: prop => !['size'].includes(prop.toString()),
 })<{ disabled: boolean; size: ContainerSizesType }>`
   background-color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.gray100 : theme.colors.white};
+    disabled ? theme.colorsDeprecated.gray100 : theme.colorsDeprecated.white};
   display: flex;
   flex-direction: row;
   align-items: center;
   align-self: stretch;
   font-weight: 500;
   height: ${({ size }) => containerSizes[size]}px;
-  border: 1px solid ${({ theme }) => theme.colors.gray300};
+  border: 1px solid ${({ theme }) => theme.colorsDeprecated.gray300};
   border-radius: 4px;
   ${({ disabled, theme }) =>
     disabled

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -86,7 +86,7 @@ const SwitchBall = styled.span<{ size: Sizes }>`
   height: ${({ size }) => SIZES[size].ball}px;
 
   background-color: ${({ size, theme }) =>
-    theme.colors[
+    theme.colorsDeprecated[
       size === 'small' ? COLORS.smallBallColor : COLORS.inactiveBigBallColor
     ]};
 `
@@ -144,7 +144,7 @@ const buildVariants =
   }: VariantProps & { theme: Theme }) =>
     css`
       &[aria-checked='true'] {
-        background-color: ${theme.colors[bgColor] ?? bgColor};
+        background-color: ${theme.colorsDeprecated[bgColor] ?? bgColor};
       }
 
       &[aria-checked='true'] > ${SwitchBall} {
@@ -160,17 +160,17 @@ const buildVariants =
           )
           translateX(-100%);
         background-color: ${size === 'small'
-          ? theme.colors[COLORS.smallBallColor]
-          : theme.colors[activeBigBallColor] ?? activeBigBallColor};
+          ? theme.colorsDeprecated[COLORS.smallBallColor]
+          : theme.colorsDeprecated[activeBigBallColor] ?? activeBigBallColor};
       }
 
       &[aria-checked='false'] > ${StyledSpan} {
-        color: ${theme.colors[COLORS.inactiveLabelColor]};
+        color: ${theme.colorsDeprecated[COLORS.inactiveLabelColor]};
         right: 0;
       }
 
       &[aria-checked='true'] > ${StyledSpan} {
-        color: ${theme.colors[activeLabelColor] ?? activeLabelColor};
+        color: ${theme.colorsDeprecated[activeLabelColor] ?? activeLabelColor};
         left: 0;
       }
     `
@@ -209,7 +209,9 @@ const StyledSwitch = styled('span', {
   display: inline-flex;
   align-items: center;
   background-color: ${({ disabled, theme }) =>
-    theme.colors[disabled ? COLORS.disabled : COLORS.inactiveBgColor]};
+    theme.colorsDeprecated[
+      disabled ? COLORS.disabled : COLORS.inactiveBgColor
+    ]};
   border: none;
   border-radius: 34px;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};

--- a/src/components/SwitchButton/index.tsx
+++ b/src/components/SwitchButton/index.tsx
@@ -24,26 +24,26 @@ const variants = {
     &:hover,
     &:focus {
       box-shadow: none;
-      border-color: ${theme.colors.transparent};
-      color: ${theme.colors.gray700};
+      border-color: ${theme.colorsDeprecated.transparent};
+      color: ${theme.colorsDeprecated.gray700};
     }
 
     &[aria-checked='true'] {
-      background-color: ${theme.colors.primary};
-      color: ${theme.colors.white};
+      background-color: ${theme.colorsDeprecated.primary};
+      color: ${theme.colorsDeprecated.white};
       :hover {
-        color: ${theme.colors.white};
+        color: ${theme.colorsDeprecated.white};
       }
     }
 
     &[aria-checked='false'] {
       background-color: white;
-      color: ${theme.colors.gray700};
-      border-color: ${theme.colors.transparent};
+      color: ${theme.colorsDeprecated.gray700};
+      border-color: ${theme.colorsDeprecated.transparent};
       :hover,
       :focus {
-        color: ${theme.colors.gray700};
-        border-color: ${theme.colors.transparent};
+        color: ${theme.colorsDeprecated.gray700};
+        border-color: ${theme.colorsDeprecated.transparent};
         box-shadow: none;
       }
     }
@@ -57,29 +57,30 @@ const switchButtonVariants = Object.keys(variants) as Variants[]
 const active = ({ theme }: { theme: Theme }) => css`
   &:hover,
   &:focus {
-    color: ${theme.colors.gray550};
-    border-color: ${theme.colors.primary};
+    color: ${theme.colorsDeprecated.gray550};
+    border-color: ${theme.colorsDeprecated.primary};
   }
 
   &:hover {
-    box-shadow: 0 0 8px 2px ${theme.colors.gray200};
+    box-shadow: 0 0 8px 2px ${theme.colorsDeprecated.gray200};
   }
 
   &:focus {
-    box-shadow: 0 0 1px 2px ${transparentize(0.75, theme.colors.primary)};
+    box-shadow: 0 0 1px 2px
+      ${transparentize(0.75, theme.colorsDeprecated.primary)};
   }
 `
 
 const disabledClass = ({ theme }: { theme: Theme }) => css`
   cursor: not-allowed;
-  color: ${theme.colors.gray350};
-  background-color: ${theme.colors.gray50};
-  border-color: ${theme.colors.gray350};
+  color: ${theme.colorsDeprecated.gray350};
+  background-color: ${theme.colorsDeprecated.gray50};
+  border-color: ${theme.colorsDeprecated.gray350};
   pointer-events: none;
 
   &[aria-checked='true'] {
-    color: ${theme.colors.gray350};
-    border-color: ${theme.colors.gray350};
+    color: ${theme.colorsDeprecated.gray350};
+    border-color: ${theme.colorsDeprecated.gray350};
   }
 `
 
@@ -99,13 +100,13 @@ const StyledSwitch = styled(Box, {
   border-radius: 4px;
   align-items: center;
   border-style: solid;
-  border-color: ${({ theme }) => theme.colors.gray350};
+  border-color: ${({ theme }) => theme.colorsDeprecated.gray350};
   border-width: 1px;
   padding: 16px;
   transition: color 0.2s, border-color 0.2s, box-shadow 0.2s;
   user-select: none;
   touch-action: manipulation;
-  color: ${({ theme }) => theme.colors.gray550};
+  color: ${({ theme }) => theme.colorsDeprecated.gray550};
   font-size: 16px;
   line-height: 22px;
   position: relative;
@@ -114,8 +115,8 @@ const StyledSwitch = styled(Box, {
 
   &[aria-checked='true'] {
     cursor: auto;
-    color: ${({ theme }) => theme.colors.primary};
-    border-color: ${({ theme }) => theme.colors.primary};
+    color: ${({ theme }) => theme.colorsDeprecated.primary};
+    border-color: ${({ theme }) => theme.colorsDeprecated.primary};
   }
 
   ${({ checked, disabled }) => !checked && !disabled && active}

--- a/src/components/TabGroup/Tab.tsx
+++ b/src/components/TabGroup/Tab.tsx
@@ -19,7 +19,7 @@ export const StyledTab = styled.span`
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  color: ${({ theme: { colors } }) => colors.gray550};
+  color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
   font-weight: 500;
   text-decoration: none;
   user-select: none;
@@ -29,7 +29,7 @@ export const StyledTab = styled.span`
   &:hover,
   &:active,
   &:focus {
-    color: ${({ theme: { colors } }) => colors.primary};
+    color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.primary};
     text-decoration: none;
     outline: none;
   }
@@ -39,7 +39,7 @@ export const StyledTab = styled.span`
   }
 
   &[aria-selected='true'] {
-    color: ${({ theme: { colors } }) => colors.primary};
+    color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.primary};
   }
 
   &[aria-disabled='true'] {
@@ -47,7 +47,7 @@ export const StyledTab = styled.span`
     opacity: 0.5;
     &:hover,
     &:focus {
-      color: ${({ theme: { colors } }) => colors.gray550};
+      color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
     }
   }
 `

--- a/src/components/TabGroup/index.tsx
+++ b/src/components/TabGroup/index.tsx
@@ -22,13 +22,15 @@ const StyledTabs = styled.div`
   flex-direction: row;
   border-bottom-width: 1px;
   border-bottom-style: solid;
-  border-bottom-color: ${({ theme: { colors } }) => colors.gray350};
+  border-bottom-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.gray350};
 `
 
 const StyledBorderBottom = styled.div`
   position: absolute;
   display: block;
-  background-color: ${({ theme: { colors } }) => colors.primary};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.primary};
   height: 2px;
   padding: inherit;
   transition: left 300ms cubic-bezier(0.5, 1, 0.89, 1),

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -22,7 +22,7 @@ const Table: FunctionComponent<BoxProps> & {
 const StyledHead = styled(Box.withComponent('thead'))`
   border: 0;
   border-bottom-width: 1px;
-  border-color: ${({ theme }) => theme.colors.gray350};
+  border-color: ${({ theme }) => theme.colorsDeprecated.gray350};
   border-style: solid;
 `
 
@@ -33,21 +33,21 @@ export const Head: FunctionComponent<BoxProps> = props => (
 const StyledRow = styled(Box.withComponent('tr'), {
   shouldForwardProp: prop => prop !== 'highlight',
 })<{ highlight?: boolean }>`
-  color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.gray700};
 
   a {
     color: inherit;
   }
 
   tr:nth-of-type(even) {
-    background-color: ${({ theme }) => theme.colors.gray50};
+    background-color: ${({ theme }) => theme.colorsDeprecated.gray50};
   }
 
   ${({ highlight = true, theme }) =>
     highlight &&
     css`
       &:hover {
-        color: ${theme.colors.primary};
+        color: ${theme.colorsDeprecated.primary};
 
         td:first-of-type {
           font-weight: 500;
@@ -92,7 +92,7 @@ const StyledHeadCell = styled(Box.withComponent('th'))`
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
-  color: ${({ theme }) => theme.colors.gray550};
+  color: ${({ theme }) => theme.colorsDeprecated.gray550};
   text-align: left;
   ${cellStyle};
 `

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -13,14 +13,14 @@ const disabledStyles = css`
 
 export const variantsContainer = {
   base: ({ theme }: { theme: Theme }) => css`
-    background-color: ${theme.colors.gray100};
+    background-color: ${theme.colorsDeprecated.gray100};
     height: 24px;
     padding-left: 8px;
     padding-right: 8px;
   `,
   bordered: ({ theme }: { theme: Theme }) => css`
     padding: 8px;
-    border: 1px solid ${theme.colors.gray350};
+    border: 1px solid ${theme.colorsDeprecated.gray350};
   `,
 }
 
@@ -52,7 +52,7 @@ const StyledContainer = styled(Box, {
 
 const StyledText = styled('span')`
   ${({ 'aria-disabled': disabled }) => disabled && disabledStyles}
-  color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.gray700};
   font-size: 14px;
   align-self: center;
   max-width: 350px;
@@ -70,16 +70,16 @@ const StyledTouchable = styled(Touchable, {
   justify-content: center;
   &:hover,
   &:focus {
-    background-color: ${({ theme }) => theme.colors.gray200};
+    background-color: ${({ theme }) => theme.colorsDeprecated.gray200};
     svg {
-      fill: ${({ theme }) => theme.colors.primary};
+      fill: ${({ theme }) => theme.colorsDeprecated.primary};
     }
   }
   ${({ variant, theme }) =>
     variant === 'bordered' &&
     `
   border-radius: 4px;
-  border: 1px solid ${theme.colors.gray550};
+  border: 1px solid ${theme.colorsDeprecated.gray550};
   padding: 4px;
   width: 32px;
   height: 32px;

--- a/src/components/Tags/index.tsx
+++ b/src/components/Tags/index.tsx
@@ -23,25 +23,25 @@ type Keys = keyof typeof STATUS
 type StatusValue = typeof STATUS[Keys]
 
 const variants = {
-  base: ({ theme: { colors } }: { theme: Theme }) => `
+  base: ({ theme: { colorsDeprecated } }: { theme: Theme }) => `
     padding: 8px;
     border-radius: 4px;
-    border: 1px solid ${colors.gray350};
+    border: 1px solid ${colorsDeprecated.gray350};
     &:focus-within {
-      border: 1px solid ${colors.primary};
-      box-shadow: 0 0 1px 2px ${transparentize(0.75, colors.primary)};
+      border: 1px solid ${colorsDeprecated.primary};
+      box-shadow: 0 0 1px 2px ${transparentize(0.75, colorsDeprecated.primary)};
     }
 
     & > * {
       margin: 6px;
     }
   `,
-  bordered: ({ theme: { colors } }: { theme: Theme }) => `
+  bordered: ({ theme: { colorsDeprecated } }: { theme: Theme }) => `
     margin-top: 0;
     padding: 8px 0;
 
     > input:focus {
-      box-shadow: 0 0 1px 2px ${transparentize(0.6, colors.primary)};
+      box-shadow: 0 0 1px 2px ${transparentize(0.6, colorsDeprecated.primary)};
     }
 
     > * {
@@ -51,9 +51,9 @@ const variants = {
       }
     }
   `,
-  'no-border': ({ theme: { colors } }: { theme: Theme }) => `
+  'no-border': ({ theme: { colorsDeprecated } }: { theme: Theme }) => `
     &:focus-within {
-      box-shadow: 0 0 2px 4px ${transparentize(0.75, colors.primary)};
+      box-shadow: 0 0 2px 4px ${transparentize(0.75, colorsDeprecated.primary)};
     }
 
     > * {
@@ -81,12 +81,13 @@ const TagsContainer = styled('div', {
 
 const StyledInput = styled.input`
   font-size: 16px;
-  color: ${({ theme: { colors } }) => colors.gray700};
+  color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray700};
   border: none;
   outline: none;
-  background-color: ${({ theme: { colors } }) => colors.white};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.white};
   &::placeholder {
-    color: ${({ theme: { colors } }) => colors.gray550};
+    color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
   }
 `
 

--- a/src/components/TagsPoplist/index.tsx
+++ b/src/components/TagsPoplist/index.tsx
@@ -19,7 +19,7 @@ const textStyle = (maxTagWidth: number) => emotionCss`
 `
 
 const StyledTooltipReference = styled(TooltipReference)`
-  color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colorsDeprecated.primary};
   border: none;
   font-size: 14px;
   align-self: center;
@@ -35,7 +35,7 @@ const StyledTooltipReference = styled(TooltipReference)`
 const StyledTagContainer = styled.div<{ multiline?: boolean }>`
   display: flex;
   align-items: center;
-  color: ${({ theme }) => theme.colors.gray700};
+  color: ${({ theme }) => theme.colorsDeprecated.gray700};
   ${({ multiline, theme }) =>
     multiline &&
     `flex-wrap: wrap;
@@ -47,7 +47,7 @@ const StyledManyTagsContainer = styled.div`
   padding: ${({ theme }) => `${theme.space['0.5']} ${theme.space['1']}`};
   display: flex;
   align-items: center;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme }) => theme.colorsDeprecated.white};
   border-radius: ${({ theme }) => theme.radii.default};
   max-width: 80vw;
   flex-wrap: wrap;
@@ -110,7 +110,7 @@ const TagsPoplist = ({
           <Tooltip {...tooltip}>
             <TooltipArrow
               {...tooltip}
-              style={{ fill: theme.colors.white, top: '93%' }}
+              style={{ fill: theme.colorsDeprecated.white, top: '93%' }}
             />
             <StyledManyTagsContainer>
               {tags.slice(visibleTagsCount).map((tag, index) => (

--- a/src/components/TextBox/index.tsx
+++ b/src/components/TextBox/index.tsx
@@ -59,7 +59,8 @@ const StyledSeparator = styled(Separator)`
   margin-right: 8px;
   margin-top: 1px;
   height: calc(100% - 2px);
-  background-color: ${({ theme: { colors } }) => colors.gray350};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.gray350};
 `
 type StyledRightElementProps = {
   edit?: boolean
@@ -71,7 +72,7 @@ const StyledRightElement = styled('div', {
   shouldForwardProp: props =>
     !['edit', 'touchable', 'unit'].includes(props.toString()),
 })<StyledRightElementProps>`
-  ${({ theme: { colors } }) => css`
+  ${({ theme: { colorsDeprecated } }) => css`
     pointer-events: none;
     position: absolute;
     right: 0;
@@ -81,11 +82,11 @@ const StyledRightElement = styled('div', {
     display: flex;
     align-items: center;
     transition: transform 150ms, color 150ms;
-    color: ${colors.gray550};
+    color: ${colorsDeprecated.gray550};
 
     &:hover,
     &:focus-within {
-      color: ${colors.gray700};
+      color: ${colorsDeprecated.gray700};
     }
   `}
 
@@ -135,7 +136,7 @@ const StyledLabel = styled('label', {
   padding-left: 8px;
   padding-right: 8px;
   pointer-events: none;
-  color: ${({ theme: { colors } }) => colors.gray550};
+  color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -151,22 +152,22 @@ const StyledLabel = styled('label', {
       transform: translate(-9.6%, -3px) scale(0.8);
     `}
 
-  ${({ disabled, theme: { colors } }) =>
+  ${({ disabled, theme: { colorsDeprecated } }) =>
     disabled &&
     css`
-      color: ${colors.gray350};
+      color: ${colorsDeprecated.gray350};
     `}
 
-  ${({ readOnly, theme: { colors } }) =>
+  ${({ readOnly, theme: { colorsDeprecated } }) =>
     readOnly &&
     css`
-      color: ${colors.gray550};
+      color: ${colorsDeprecated.gray550};
     `}
 
-  ${({ error, theme: { colors } }) =>
+  ${({ error, theme: { colorsDeprecated } }) =>
     error &&
     css`
-      color: ${colors.warning};
+      color: ${colorsDeprecated.warning};
     `}
 `
 
@@ -176,7 +177,7 @@ const StyledRelativeDiv = styled.div`
 
 const StyledError = styled.div`
   font-size: 12px;
-  color: ${({ theme }) => theme.colors.warning};
+  color: ${({ theme }) => theme.colorsDeprecated.warning};
   padding-top: ${({ theme }) => theme.space['0.25']};
 `
 
@@ -218,11 +219,13 @@ const StyledInput = styled('input', {
 })<StyledInputProps>`
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
   appearance: none;
-  background-color: ${({ theme: { colors } }) => colors.white};
+  background-color: ${({ theme: { colorsDeprecated } }) =>
+    colorsDeprecated.white};
   background-image: none;
-  border: 1px solid ${({ theme: { colors } }) => colors.gray350};
+  border: 1px solid
+    ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray350};
   border-radius: ${({ theme: { radii } }) => radii.default};
-  color: ${({ theme: { colors } }) => colors.gray700};
+  color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray700};
   display: block;
   max-width: 100%;
   outline: none;
@@ -235,19 +238,22 @@ const StyledInput = styled('input', {
   line-height: 24px;
 
   &::placeholder {
-    color: ${({ theme: { colors } }) => colors.gray550};
+    color: ${({ theme: { colorsDeprecated } }) => colorsDeprecated.gray550};
     opacity: 0;
   }
 
   &:hover,
   &:focus {
-    border-color: ${({ theme: { colors } }) => colors.ngray300};
+    border-color: ${({ theme: { colorsDeprecated } }) =>
+      colorsDeprecated.ngray300};
   }
 
   &:focus {
     box-shadow: 0 0 0 2px
-      ${({ theme: { colors } }) => transparentize(0.75, colors.primary)};
-    border-color: ${({ theme: { colors } }) => colors.primary};
+      ${({ theme: { colorsDeprecated } }) =>
+        transparentize(0.75, colorsDeprecated.primary)};
+    border-color: ${({ theme: { colorsDeprecated } }) =>
+      colorsDeprecated.primary};
   }
 
   ${({ isPlaceholderVisible }) =>
@@ -256,37 +262,37 @@ const StyledInput = styled('input', {
       opacity: 1;
     }`}
 
-  ${({ disabled, theme: { colors } }) =>
+  ${({ disabled, theme: { colorsDeprecated } }) =>
     disabled &&
     `cursor: default;
     pointer-events: none;
-    background-color: ${colors.gray50};
-    border-color: ${colors.gray50};
-    color: ${colors.gray350};`}
+    background-color: ${colorsDeprecated.gray50};
+    border-color: ${colorsDeprecated.gray50};
+    color: ${colorsDeprecated.gray350};`}
 
-  ${({ readOnly, theme: { colors } }) =>
+  ${({ readOnly, theme: { colorsDeprecated } }) =>
     readOnly &&
-    `background-color: ${colors.gray100};
-    border-color: ${colors.gray100};
-    color: ${colors.gray700};`}
+    `background-color: ${colorsDeprecated.gray100};
+    border-color: ${colorsDeprecated.gray100};
+    color: ${colorsDeprecated.gray700};`}
 
   ${({ inputSize }) => inputSizes[inputSize]?.default}
 
   ${({ inputSize, hasLabel }) =>
     !!inputSize && !hasLabel && inputSizes[inputSize]?.full}
 
-  ${({ error, theme: { colors } }) =>
+  ${({ error, theme: { colorsDeprecated } }) =>
     error &&
-    `border-color: ${colors.warning};
+    `border-color: ${colorsDeprecated.warning};
 
     &:hover,
     &:focus {
-      border-color: ${colors.warning};
+      border-color: ${colorsDeprecated.warning};
     }
 
     &:focus {
-      box-shadow: 0 0 0 2px ${transparentize(0.75, colors.warning)};
-      border-color: ${colors.warning};
+      box-shadow: 0 0 0 2px ${transparentize(0.75, colorsDeprecated.warning)};
+      border-color: ${colorsDeprecated.warning};
     }`}
 
     ${({ multiline, resizable, fillAvailable }) =>

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -25,38 +25,38 @@ const styles = {
     }
 
     &${PREFIX}__toast--success {
-      background-color: ${theme.colors.foam};
-      color: ${theme.colors.success};
+      background-color: ${theme.colorsDeprecated.foam};
+      color: ${theme.colorsDeprecated.success};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colors.success};
+        background-color: ${theme.colorsDeprecated.success};
       }
     }
 
     &${PREFIX}__toast--info {
-      background-color: ${theme.colors.zumthor};
-      color: ${theme.colors.info};
+      background-color: ${theme.colorsDeprecated.zumthor};
+      color: ${theme.colorsDeprecated.info};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colors.info};
+        background-color: ${theme.colorsDeprecated.info};
       }
     }
 
     &${PREFIX}__toast--warning {
-      background-color: ${theme.colors.pippin};
-      color: ${theme.colors.warning};
+      background-color: ${theme.colorsDeprecated.pippin};
+      color: ${theme.colorsDeprecated.warning};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colors.warning};
+        background-color: ${theme.colorsDeprecated.warning};
       }
     }
 
     &${PREFIX}__toast--error {
-      background-color: ${theme.colors.pippin};
-      color: ${theme.colors.warning};
+      background-color: ${theme.colorsDeprecated.pippin};
+      color: ${theme.colorsDeprecated.warning};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colors.warning};
+        background-color: ${theme.colorsDeprecated.warning};
       }
     }
   `,

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -30,16 +30,18 @@ export type TooltipPlacement =
 
 const variants = {
   black: ({ theme }: { theme: Theme }) => css`
-    background-color: ${theme.colors.black};
-    color: ${theme.colors.white};
-    fill: ${theme.colors.black};
-    box-shadow: 0 2px 5px 5px ${transparentize(0.7, theme.colors.shadow)};
+    background-color: ${theme.colorsDeprecated.black};
+    color: ${theme.colorsDeprecated.white};
+    fill: ${theme.colorsDeprecated.black};
+    box-shadow: 0 2px 5px 5px
+      ${transparentize(0.7, theme.colorsDeprecated.shadow)};
   `,
   white: ({ theme }: { theme: Theme }) => css`
-    background-color: ${theme.colors.white};
-    color: ${theme.colors.black};
-    fill: ${theme.colors.white};
-    box-shadow: 0 2px 5px 5px ${transparentize(0.7, theme.colors.shadow)};
+    background-color: ${theme.colorsDeprecated.white};
+    color: ${theme.colorsDeprecated.black};
+    fill: ${theme.colorsDeprecated.white};
+    box-shadow: 0 2px 5px 5px
+      ${transparentize(0.7, theme.colorsDeprecated.shadow)};
   `,
 }
 

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -24,8 +24,8 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
   {
     badge: ({ theme }: StyleProps) =>
       css`
-        background-color: ${theme?.colors.gray100};
-        color: ${theme?.colors.gray700};
+        background-color: ${theme?.colorsDeprecated.gray100};
+        color: ${theme?.colorsDeprecated.gray700};
         text-transform: capitalize;
         letter-spacing: 1px;
         font-weight: 500;
@@ -36,25 +36,25 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
       `,
     bodyA: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray700};
+        color: ${theme?.colorsDeprecated.gray700};
         font-size: 16px;
         line-height: 24px;
       `,
     bodyB: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray550};
+        color: ${theme?.colorsDeprecated.gray550};
         font-size: 14px;
         line-height: 18px;
       `,
     bodyC: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray700};
+        color: ${theme?.colorsDeprecated.gray700};
         font-size: 14px;
         line-height: 22px;
       `,
     bodyD: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray700};
+        color: ${theme?.colorsDeprecated.gray700};
         font-size: 14px;
         line-height: 20px;
       `,
@@ -73,13 +73,13 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
         font-size: 13px;
         font-weight: 500;
         border-radius: ${theme?.radii.default};
-        color: ${theme?.colors.gray700};
-        background-color: ${theme?.colors.gray100};
+        color: ${theme?.colorsDeprecated.gray700};
+        background-color: ${theme?.colorsDeprecated.gray100};
         padding: 8px;
       `,
     description: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray950};
+        color: ${theme?.colorsDeprecated.gray950};
         font-size: 16px;
         line-height: 24px;
         font-weight: 500;
@@ -91,14 +91,14 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
     `,
     hero: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray950};
+        color: ${theme?.colorsDeprecated.gray950};
         font-size: 35px;
         line-height: 41px;
         margin-bottom: 72px;
       `,
     lead: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray950};
+        color: ${theme?.colorsDeprecated.gray950};
         font-size: 25px;
         line-height: 25px;
         margin-bottom: 0;
@@ -118,21 +118,21 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
     `,
     samplecode: ({ theme }: StyleProps) =>
       css`
-        background-color: ${theme?.colors.gray100};
-        color: ${theme?.colors.gray700};
+        background-color: ${theme?.colorsDeprecated.gray100};
+        color: ${theme?.colorsDeprecated.gray700};
         font-size: 12px;
         line-height: 16px;
         padding: 4px;
       `,
     tiny: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray550};
+        color: ${theme?.colorsDeprecated.gray550};
         font-size: 12px;
         line-height: 16px;
       `,
     title: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colors.gray950};
+        color: ${theme?.colorsDeprecated.gray950};
         font-size: 21px;
         line-height: 24px;
       `,
@@ -161,7 +161,7 @@ const variantTags = {
 const colorStyles = ({ theme, color }: { theme: Theme; color?: string }) =>
   color
     ? css`
-        color: ${theme.colors[color as Color] ?? color};
+        color: ${theme.colorsDeprecated[color as Color] ?? color};
       `
     : undefined
 
@@ -196,7 +196,7 @@ const StyledText = styled(Box, {
       prop.toString(),
     ),
 })<StyledTextProps>`
-  color: ${({ theme }) => theme?.colors.gray700};
+  color: ${({ theme }) => theme?.colorsDeprecated.gray700};
   font-weight: 400;
   margin-bottom: 0;
   margin-top: 0;

--- a/src/components/UnitInput/index.tsx
+++ b/src/components/UnitInput/index.tsx
@@ -22,8 +22,8 @@ const CustomTextBox = styled(TextBox)`
     &:hover,
     &:focus {
       text-decoration: none;
-      border-color: ${({ theme }) => theme.colors.primary};
-      border-right: 1px solid ${({ theme }) => theme.colors.primary};
+      border-color: ${({ theme }) => theme.colorsDeprecated.primary};
+      border-right: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
       z-index: 1;
       padding-right: 7px; // so it doesn't move rich select
     }
@@ -34,7 +34,7 @@ const CustomRichSelect = styled(RichSelect)`
   &:hover,
   &:focus {
     text-decoration: none;
-    border-color: ${({ theme }) => theme.colors.primary};
+    border-color: ${({ theme }) => theme.colorsDeprecated.primary};
     box-shadow: none;
   }
 `

--- a/src/components/VerificationCode/index.tsx
+++ b/src/components/VerificationCode/index.tsx
@@ -11,10 +11,10 @@ import React, {
 const StyledInput = styled.input`
   border: solid 1px
     ${({ 'aria-invalid': error, theme }) =>
-      error ? theme.colors.red : theme.colors.gray300};
+      error ? theme.colorsDeprecated.red : theme.colorsDeprecated.gray300};
   font-size: 24px;
   color: ${({ 'aria-invalid': error, theme }) =>
-    error ? theme.colors.red : theme.colors.gray700};
+    error ? theme.colorsDeprecated.red : theme.colorsDeprecated.gray700};
   text-align: center;
   border-radius: 4px;
   margin-right: 8px;
@@ -26,7 +26,7 @@ const StyledInput = styled.input`
   }
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.gray300};
+    color: ${({ theme }) => theme.colorsDeprecated.gray300};
   }
 `
 

--- a/src/components/VolumeSize/index.tsx
+++ b/src/components/VolumeSize/index.tsx
@@ -46,7 +46,7 @@ const StyledValue = styled('span', {
 })<{ hasError?: boolean }>`
   font-weight: 800;
   color: ${({ hasError, theme }) =>
-    hasError ? theme.colors.orange : theme.colors.gray950};
+    hasError ? theme.colorsDeprecated.orange : theme.colorsDeprecated.gray950};
 `
 
 const StyledContainer = styled('div', {
@@ -63,7 +63,7 @@ const StyledContainer = styled('div', {
 const StyledVolumeContainer = styled('div', {
   shouldForwardProp: prop => !['size'].includes(prop.toString()),
 })<StyleProps>`
-  background-color: ${({ theme }) => theme.colors.gray200};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray200};
   border-radius: 3px;
   position: relative;
 
@@ -76,7 +76,7 @@ const StyledVolume = styled('span', {
     !['percentUsed', 'hasError'].includes(prop.toString()),
 })<StyleProps>`
   background-color: ${({ hasError, theme }) =>
-    hasError ? theme.colors.orange : theme.colors.green};
+    hasError ? theme.colorsDeprecated.orange : theme.colorsDeprecated.green};
   border-radius: ${({ percentUsed = 0 }) =>
     percentUsed >= 100 ? '3px' : '3px 0 0 3px'};
   position: absolute;
@@ -94,7 +94,7 @@ const StyledCursor = styled('div', {
   shouldForwardProp: prop =>
     !['size', 'hasMaxSize', 'isMaxSize'].includes(prop.toString()),
 })<StyleProps>`
-  background-color: ${({ theme }) => theme.colors.gray950};
+  background-color: ${({ theme }) => theme.colorsDeprecated.gray950};
   position: absolute;
   height: ${({ size = 'medium' }) => (sizes[size] || 1) * 15}px;
   width: ${({ size = 'medium' }) => (sizes[size] || 1) * 3}px;

--- a/src/helpers/legend.ts
+++ b/src/helpers/legend.ts
@@ -1,9 +1,9 @@
 import { Theme } from '@emotion/react'
 
 export const legendColors = (theme: Theme): string[] => [
-  theme.colors.chartGreen,
-  theme.colors.chartPurple,
-  theme.colors.gray350,
+  theme.colorsDeprecated.chartGreen,
+  theme.colorsDeprecated.chartPurple,
+  theme.colorsDeprecated.gray350,
 ]
 
 export const getLegendColor = (index: number, theme: Theme): string => {

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sort-keys */
-import colors from './colors'
+import colorsDeprecated from './colors'
 
 const radii = {
   none: '0',
@@ -40,7 +40,7 @@ const fonts = {
 } as const
 
 const theme = {
-  colors,
+  colorsDeprecated,
   fonts,
   space,
   screens,
@@ -53,4 +53,4 @@ type SCWUITheme = typeof theme & {
 
 export default theme
 
-export { colors, space, radii, fonts, screens, SCWUITheme }
+export { colorsDeprecated, space, radii, fonts, screens, SCWUITheme }


### PR DESCRIPTION
## Summary

## Type

- Refacto

### Summarise concisely:

#### What is expected?

In order to implement and create new colors tokens old tokens should be renamed as deprecated. Also it avoid conflicts between old and new tokens.

#### The following changes where made:

1. Renamed all `colors` into `colorsDeprecated`
