### PR TITLE
feat: migrate badge, barchart, barstack to new colors

### DIFF
--- a/src/components/BarChart/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/BarChart/__tests__/__snapshots__/index.tsx.snap
@@ -133,7 +133,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(66,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -141,7 +141,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -153,7 +153,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(178,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -161,7 +161,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -173,7 +173,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(290,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -181,7 +181,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -193,7 +193,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(402,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -201,7 +201,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -213,7 +213,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(514,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -221,7 +221,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -233,7 +233,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(626,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -241,7 +241,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -253,7 +253,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(738,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -261,7 +261,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -273,7 +273,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(850,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -281,7 +281,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -304,7 +304,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -312,7 +312,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -324,7 +324,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,360)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -332,7 +332,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -344,7 +344,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,320)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -352,7 +352,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -364,7 +364,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,280)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -372,7 +372,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -384,7 +384,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,240)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -392,7 +392,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -404,7 +404,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,200)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -412,7 +412,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -424,7 +424,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,160)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -432,7 +432,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -444,7 +444,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,120)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -452,7 +452,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -464,7 +464,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,80)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -472,7 +472,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -484,7 +484,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,40)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -492,7 +492,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -504,7 +504,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -512,7 +512,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -531,12 +531,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(15, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -545,12 +545,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(127, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -559,12 +559,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(239, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -573,12 +573,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(351, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -587,12 +587,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(463, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -601,12 +601,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(575, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -615,12 +615,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(687, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -629,12 +629,12 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
               transform="translate(799, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -744,7 +744,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(124,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -752,7 +752,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -764,7 +764,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(347,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -772,7 +772,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -784,7 +784,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(570,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -792,7 +792,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -804,7 +804,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(793,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -812,7 +812,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -835,7 +835,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -843,7 +843,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -855,7 +855,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,341)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -863,7 +863,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -875,7 +875,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,282)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -883,7 +883,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -895,7 +895,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,224)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -903,7 +903,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -915,7 +915,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,165)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -923,7 +923,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -935,7 +935,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,106)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -943,7 +943,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -955,7 +955,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,47)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -963,7 +963,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -982,12 +982,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(23, 282)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="118"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -996,12 +996,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(246, 165)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="235"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1010,12 +1010,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(469, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="400"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1024,12 +1024,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(692, 235)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="165"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1139,7 +1139,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(124,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1147,7 +1147,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1159,7 +1159,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(347,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1167,7 +1167,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1179,7 +1179,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(570,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1187,7 +1187,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1199,7 +1199,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(793,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1207,7 +1207,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1230,7 +1230,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1238,7 +1238,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1250,7 +1250,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,341)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1258,7 +1258,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1270,7 +1270,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,282)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1278,7 +1278,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1290,7 +1290,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,224)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1298,7 +1298,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1310,7 +1310,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,165)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1318,7 +1318,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1330,7 +1330,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,106)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1338,7 +1338,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1350,7 +1350,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,47)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1358,7 +1358,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1377,12 +1377,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(23, 282)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="118"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1391,12 +1391,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(246, 165)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="235"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1405,12 +1405,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(469, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="400"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1419,12 +1419,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(692, 235)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="165"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -1480,7 +1480,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(66,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1488,7 +1488,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1500,7 +1500,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(178,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1508,7 +1508,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1520,7 +1520,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(290,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1528,7 +1528,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1540,7 +1540,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(402,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1548,7 +1548,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1560,7 +1560,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(514,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1568,7 +1568,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1580,7 +1580,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(626,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1588,7 +1588,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1600,7 +1600,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(738,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1608,7 +1608,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1620,7 +1620,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(850,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1628,7 +1628,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1651,7 +1651,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(0,200)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1659,7 +1659,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1815,7 +1815,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(66,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1823,7 +1823,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1835,7 +1835,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(178,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1843,7 +1843,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1855,7 +1855,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(290,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1863,7 +1863,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1875,7 +1875,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(402,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1883,7 +1883,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1895,7 +1895,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(514,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1903,7 +1903,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1915,7 +1915,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(626,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1923,7 +1923,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1935,7 +1935,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(738,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1943,7 +1943,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1955,7 +1955,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(850,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1963,7 +1963,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1986,7 +1986,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1994,7 +1994,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2006,7 +2006,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,360)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2014,7 +2014,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2026,7 +2026,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,320)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2034,7 +2034,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2046,7 +2046,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,280)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2054,7 +2054,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2066,7 +2066,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,240)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2074,7 +2074,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2086,7 +2086,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,200)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2094,7 +2094,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2106,7 +2106,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,160)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2114,7 +2114,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2126,7 +2126,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,120)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2134,7 +2134,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2146,7 +2146,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,80)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2154,7 +2154,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2166,7 +2166,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,40)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2174,7 +2174,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2186,7 +2186,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,0)"
               >
                 <line
-                  style="stroke: #dce1eb; stroke-width: 1;"
+                  style="stroke: #f6f5f7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2194,7 +2194,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2213,12 +2213,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(15, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2227,12 +2227,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(127, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2241,12 +2241,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(239, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2255,12 +2255,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(351, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2269,12 +2269,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(463, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2283,12 +2283,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(575, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2297,12 +2297,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(687, 0)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />
@@ -2311,12 +2311,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(799, 200)"
             >
               <rect
-                fill="#33BBB3"
+                fill="#45d6b5"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#33BBB3"
+                stroke="#45d6b5"
                 stroke-width="0"
                 width="0"
               />

--- a/src/components/BarChart/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/BarChart/__tests__/__snapshots__/index.tsx.snap
@@ -133,7 +133,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(66,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -141,7 +141,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -153,7 +153,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(178,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -161,7 +161,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -173,7 +173,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(290,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -181,7 +181,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -193,7 +193,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(402,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -201,7 +201,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -213,7 +213,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(514,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -221,7 +221,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -233,7 +233,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(626,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -241,7 +241,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -253,7 +253,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(738,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -261,7 +261,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -273,7 +273,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(850,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -281,7 +281,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -304,7 +304,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -312,7 +312,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -324,7 +324,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,360)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -332,7 +332,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -344,7 +344,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,320)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -352,7 +352,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -364,7 +364,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,280)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -372,7 +372,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -384,7 +384,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,240)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -392,7 +392,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -404,7 +404,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,200)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -412,7 +412,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -424,7 +424,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,160)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -432,7 +432,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -444,7 +444,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,120)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -452,7 +452,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -464,7 +464,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,80)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -472,7 +472,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -484,7 +484,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,40)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -492,7 +492,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -504,7 +504,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 transform="translate(0,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -512,7 +512,7 @@ exports[`BarChart renders correctly with custom tooltip format 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -744,7 +744,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(124,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -752,7 +752,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -764,7 +764,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(347,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -772,7 +772,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -784,7 +784,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(570,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -792,7 +792,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -804,7 +804,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(793,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -812,7 +812,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -835,7 +835,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -843,7 +843,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -855,7 +855,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,341)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -863,7 +863,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -875,7 +875,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,282)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -883,7 +883,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -895,7 +895,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,224)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -903,7 +903,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -915,7 +915,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,165)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -923,7 +923,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -935,7 +935,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,106)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -943,7 +943,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -955,7 +955,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 transform="translate(0,47)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -963,7 +963,7 @@ exports[`BarChart renders correctly with data 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1139,7 +1139,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(124,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1147,7 +1147,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1159,7 +1159,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(347,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1167,7 +1167,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1179,7 +1179,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(570,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1187,7 +1187,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1199,7 +1199,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(793,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1207,7 +1207,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1230,7 +1230,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1238,7 +1238,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1250,7 +1250,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,341)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1258,7 +1258,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1270,7 +1270,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,282)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1278,7 +1278,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1290,7 +1290,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,224)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1298,7 +1298,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1310,7 +1310,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,165)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1318,7 +1318,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1330,7 +1330,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,106)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1338,7 +1338,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1350,7 +1350,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 transform="translate(0,47)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1358,7 +1358,7 @@ exports[`BarChart renders correctly with data transformer 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1480,7 +1480,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(66,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1488,7 +1488,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1500,7 +1500,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(178,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1508,7 +1508,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1520,7 +1520,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(290,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1528,7 +1528,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1540,7 +1540,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(402,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1548,7 +1548,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1560,7 +1560,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(514,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1568,7 +1568,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1580,7 +1580,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(626,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1588,7 +1588,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1600,7 +1600,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(738,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1608,7 +1608,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1620,7 +1620,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(850,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1628,7 +1628,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1651,7 +1651,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 transform="translate(0,200)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1659,7 +1659,7 @@ exports[`BarChart renders correctly with multiple series 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -1815,7 +1815,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(66,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1823,7 +1823,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1835,7 +1835,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(178,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1843,7 +1843,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1855,7 +1855,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(290,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1863,7 +1863,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1875,7 +1875,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(402,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1883,7 +1883,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1895,7 +1895,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(514,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1903,7 +1903,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1915,7 +1915,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(626,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1923,7 +1923,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1935,7 +1935,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(738,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1943,7 +1943,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1955,7 +1955,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(850,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="0"
                   y1="0"
@@ -1963,7 +1963,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="text-before-edge"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="middle"
                   transform="translate(0,10) rotate(0)"
                 >
@@ -1986,7 +1986,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,400)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -1994,7 +1994,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2006,7 +2006,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,360)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2014,7 +2014,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2026,7 +2026,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,320)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2034,7 +2034,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2046,7 +2046,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,280)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2054,7 +2054,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2066,7 +2066,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,240)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2074,7 +2074,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2086,7 +2086,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,200)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2094,7 +2094,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2106,7 +2106,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,160)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2114,7 +2114,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2126,7 +2126,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,120)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2134,7 +2134,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2146,7 +2146,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,80)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2154,7 +2154,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2166,7 +2166,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,40)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2174,7 +2174,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >
@@ -2186,7 +2186,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 transform="translate(0,0)"
               >
                 <line
-                  style="stroke: #f6f5f7; stroke-width: 1;"
+                  style="stroke: #d4dae7; stroke-width: 1;"
                   x1="0"
                   x2="-5"
                   y1="0"
@@ -2194,7 +2194,7 @@ exports[`BarChart renders correctly with negative values 1`] = `
                 />
                 <text
                   dominant-baseline="central"
-                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #d4dae7;"
+                  style="font-family: Asap, System, sans-serif; font-size: 12px; fill: #b2b6c3;"
                   text-anchor="end"
                   transform="translate(-10,0) rotate(0)"
                 >

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -70,7 +70,7 @@ const BarChart: FunctionComponent<BarChartProps> = ({
     },
     fontFamily: theme.fonts.sansSerif,
     fontSize: 12,
-    textColor: theme.colors.neutral.text,
+    textColor: theme.colors.neutral.textWeak,
   }
 
   const tooltip = useCallback(

--- a/src/components/BarChart/index.tsx
+++ b/src/components/BarChart/index.tsx
@@ -63,14 +63,14 @@ const BarChart: FunctionComponent<BarChartProps> = ({
     axis: {
       ticks: {
         line: {
-          stroke: theme.colorsDeprecated.gray300,
+          stroke: theme.colors.neutral.background,
           strokeWidth: 1,
         },
       },
     },
     fontFamily: theme.fonts.sansSerif,
     fontSize: 12,
-    textColor: theme.colorsDeprecated.gray550,
+    textColor: theme.colors.neutral.text,
   }
 
   const tooltip = useCallback(

--- a/src/components/BarStack/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/BarStack/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,19 +2,19 @@
 
 exports[`BarStack should render correctly 1`] = `
 <DocumentFragment>
-  .cache-47n9td {
+  .cache-q2zvqm {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: #f6f5f7;
+  background-color: #fff;
   border-radius: 4px;
-  box-shadow: inset 0px 0px 0px 1px #dce1eb;
+  box-shadow: inset 0px 0px 0px 1px #f6f5f7;
   overflow: hidden;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+1) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+1) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
         #4f0599 25%, #4f0599 50%,
         rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #4f0599
@@ -24,24 +24,29 @@ exports[`BarStack should render correctly 1`] = `
   background-color: #4f0599;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+2) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+2) {
   background-color: #6907ca;
   background-image: linear-gradient(
           135deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           225deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           45deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           315deg,
-          rgba(255,255,255,0.25) 25%,
-          #6907ca 25%
+          rgba(255,255,255,0.25)
+            25%,
+          #6907ca
+            25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -50,34 +55,38 @@ exports[`BarStack should render correctly 1`] = `
   background-repeat: repeat;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+3) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+3) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
-        #a365f6 25%, #a365f6 50%,
-        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #a365f6
+        #ae5df6 25%, #ae5df6 50%,
+        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #ae5df6
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #6b0ee7;
+  background-color: #7d0ce1;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+4) {
-  background-color: #a365f6;
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+4) {
+  background-color: #ae5df6;
   background-image: linear-gradient(
           135deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           225deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           45deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           315deg,
-          rgba(255,255,255,0.2) 25%,
-          #a365f6 25%
+          rgba(255,255,255,0.2)
+            25%,
+          #ae5df6 25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -86,14 +95,14 @@ exports[`BarStack should render correctly 1`] = `
   background-repeat: repeat;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+5) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+5) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.2) 25%,
-        #c095f9 25%, #c095f9 50%,
-        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c095f9
+        #c68df9 25%, #c68df9 50%,
+        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c68df9
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #c095f9;
+  background-color: #c68df9;
 }
 
 .cache-1mc9zcp {
@@ -103,7 +112,7 @@ exports[`BarStack should render correctly 1`] = `
   background-color: #fff;
 }
 
-.cache-1323kwc {
+.cache-1qm6m3g {
   height: 50px;
   font-weight: 600;
   color: #fff;
@@ -120,18 +129,18 @@ exports[`BarStack should render correctly 1`] = `
   width: 100%;
   white-space: nowrap;
   overflow: hidden;
-  text-shadow: -1px 0 rgba(0,0,0,0.3),0 1px rgba(0,0,0,0.3),1px 0 rgba(0,0,0,0.3),0 -1px rgba(0,0,0,0.3);
+  text-shadow: -1px 0 rgba(74,79,98,0.3),0 1px rgba(74,79,98,0.3),1px 0 rgba(74,79,98,0.3),0 -1px rgba(74,79,98,0.3);
 }
 
 <div
-    class="cache-47n9td e17nk4tl0"
+    class="cache-q2zvqm e17nk4tl0"
   >
     <div
       class="cache-1mc9zcp e17nk4tl2"
       style="width: 10.638297872340425%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Hello
       </div>
@@ -141,7 +150,7 @@ exports[`BarStack should render correctly 1`] = `
       style="width: 22.340425531914892%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       />
     </div>
     <div
@@ -149,7 +158,7 @@ exports[`BarStack should render correctly 1`] = `
       style="width: 22.340425531914892%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Encore
       </div>
@@ -159,7 +168,7 @@ exports[`BarStack should render correctly 1`] = `
       style="width: 22.340425531914892%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Next
       </div>
@@ -169,7 +178,7 @@ exports[`BarStack should render correctly 1`] = `
       style="width: 22.340425531914892%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Bye bye
       </div>
@@ -180,19 +189,19 @@ exports[`BarStack should render correctly 1`] = `
 
 exports[`BarStack should render correctly with event handlers 1`] = `
 <DocumentFragment>
-  .cache-47n9td {
+  .cache-q2zvqm {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: #f6f5f7;
+  background-color: #fff;
   border-radius: 4px;
-  box-shadow: inset 0px 0px 0px 1px #dce1eb;
+  box-shadow: inset 0px 0px 0px 1px #f6f5f7;
   overflow: hidden;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+1) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+1) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
         #4f0599 25%, #4f0599 50%,
         rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #4f0599
@@ -202,24 +211,29 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-color: #4f0599;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+2) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+2) {
   background-color: #6907ca;
   background-image: linear-gradient(
           135deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           225deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           45deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           315deg,
-          rgba(255,255,255,0.25) 25%,
-          #6907ca 25%
+          rgba(255,255,255,0.25)
+            25%,
+          #6907ca
+            25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -228,34 +242,38 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-repeat: repeat;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+3) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+3) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
-        #a365f6 25%, #a365f6 50%,
-        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #a365f6
+        #ae5df6 25%, #ae5df6 50%,
+        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #ae5df6
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #6b0ee7;
+  background-color: #7d0ce1;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+4) {
-  background-color: #a365f6;
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+4) {
+  background-color: #ae5df6;
   background-image: linear-gradient(
           135deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           225deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           45deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           315deg,
-          rgba(255,255,255,0.2) 25%,
-          #a365f6 25%
+          rgba(255,255,255,0.2)
+            25%,
+          #ae5df6 25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -264,14 +282,14 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-repeat: repeat;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+5) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+5) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.2) 25%,
-        #c095f9 25%, #c095f9 50%,
-        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c095f9
+        #c68df9 25%, #c68df9 50%,
+        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c68df9
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #c095f9;
+  background-color: #c68df9;
 }
 
 .cache-1mc9zcp {
@@ -281,7 +299,7 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-color: #fff;
 }
 
-.cache-1323kwc {
+.cache-1qm6m3g {
   height: 50px;
   font-weight: 600;
   color: #fff;
@@ -298,18 +316,18 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   width: 100%;
   white-space: nowrap;
   overflow: hidden;
-  text-shadow: -1px 0 rgba(0,0,0,0.3),0 1px rgba(0,0,0,0.3),1px 0 rgba(0,0,0,0.3),0 -1px rgba(0,0,0,0.3);
+  text-shadow: -1px 0 rgba(74,79,98,0.3),0 1px rgba(74,79,98,0.3),1px 0 rgba(74,79,98,0.3),0 -1px rgba(74,79,98,0.3);
 }
 
 <div
-    class="cache-47n9td e17nk4tl0"
+    class="cache-q2zvqm e17nk4tl0"
   >
     <div
       class="cache-1mc9zcp e17nk4tl2"
       style="width: 100%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Hello
       </div>
@@ -320,19 +338,19 @@ exports[`BarStack should render correctly with event handlers 1`] = `
 
 exports[`BarStack should render correctly with total 1`] = `
 <DocumentFragment>
-  .cache-47n9td {
+  .cache-q2zvqm {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: #f6f5f7;
+  background-color: #fff;
   border-radius: 4px;
-  box-shadow: inset 0px 0px 0px 1px #dce1eb;
+  box-shadow: inset 0px 0px 0px 1px #f6f5f7;
   overflow: hidden;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+1) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+1) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
         #4f0599 25%, #4f0599 50%,
         rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #4f0599
@@ -342,24 +360,29 @@ exports[`BarStack should render correctly with total 1`] = `
   background-color: #4f0599;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+2) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+2) {
   background-color: #6907ca;
   background-image: linear-gradient(
           135deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           225deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           45deg,
-          rgba(255,255,255,0.25) 25%,
+          rgba(255,255,255,0.25)
+            25%,
           transparent 25%
         ),linear-gradient(
           315deg,
-          rgba(255,255,255,0.25) 25%,
-          #6907ca 25%
+          rgba(255,255,255,0.25)
+            25%,
+          #6907ca
+            25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -368,34 +391,38 @@ exports[`BarStack should render correctly with total 1`] = `
   background-repeat: repeat;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+3) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+3) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
-        #a365f6 25%, #a365f6 50%,
-        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #a365f6
+        #ae5df6 25%, #ae5df6 50%,
+        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #ae5df6
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #6b0ee7;
+  background-color: #7d0ce1;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+4) {
-  background-color: #a365f6;
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+4) {
+  background-color: #ae5df6;
   background-image: linear-gradient(
           135deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           225deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           45deg,
-          rgba(255,255,255,0.2) 25%,
+          rgba(255,255,255,0.2)
+            25%,
           transparent 25%
         ),linear-gradient(
           315deg,
-          rgba(255,255,255,0.2) 25%,
-          #a365f6 25%
+          rgba(255,255,255,0.2)
+            25%,
+          #ae5df6 25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -404,14 +431,14 @@ exports[`BarStack should render correctly with total 1`] = `
   background-repeat: repeat;
 }
 
-.cache-47n9td .e17nk4tl2:nth-child(5n+5) {
+.cache-q2zvqm .e17nk4tl2:nth-child(5n+5) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.2) 25%,
-        #c095f9 25%, #c095f9 50%,
-        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c095f9
+        #c68df9 25%, #c68df9 50%,
+        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c68df9
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #c095f9;
+  background-color: #c68df9;
 }
 
 .cache-1mc9zcp {
@@ -421,7 +448,7 @@ exports[`BarStack should render correctly with total 1`] = `
   background-color: #fff;
 }
 
-.cache-1323kwc {
+.cache-1qm6m3g {
   height: 50px;
   font-weight: 600;
   color: #fff;
@@ -438,18 +465,18 @@ exports[`BarStack should render correctly with total 1`] = `
   width: 100%;
   white-space: nowrap;
   overflow: hidden;
-  text-shadow: -1px 0 rgba(0,0,0,0.3),0 1px rgba(0,0,0,0.3),1px 0 rgba(0,0,0,0.3),0 -1px rgba(0,0,0,0.3);
+  text-shadow: -1px 0 rgba(74,79,98,0.3),0 1px rgba(74,79,98,0.3),1px 0 rgba(74,79,98,0.3),0 -1px rgba(74,79,98,0.3);
 }
 
 <div
-    class="cache-47n9td e17nk4tl0"
+    class="cache-q2zvqm e17nk4tl0"
   >
     <div
       class="cache-1mc9zcp e17nk4tl2"
       style="width: 2%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Hello
       </div>
@@ -459,7 +486,7 @@ exports[`BarStack should render correctly with total 1`] = `
       style="width: 4.2%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       />
     </div>
     <div
@@ -467,7 +494,7 @@ exports[`BarStack should render correctly with total 1`] = `
       style="width: 4.2%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Encore
       </div>
@@ -477,7 +504,7 @@ exports[`BarStack should render correctly with total 1`] = `
       style="width: 4.2%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Next
       </div>
@@ -487,7 +514,7 @@ exports[`BarStack should render correctly with total 1`] = `
       style="width: 4.2%;"
     >
       <div
-        class="cache-1323kwc e17nk4tl1"
+        class="cache-1qm6m3g e17nk4tl1"
       >
         Bye bye
       </div>

--- a/src/components/BarStack/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/BarStack/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`BarStack should render correctly 1`] = `
 <DocumentFragment>
-  .cache-q2zvqm {
+  .cache-dth6f7 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -10,11 +10,11 @@ exports[`BarStack should render correctly 1`] = `
   display: flex;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: inset 0px 0px 0px 1px #f6f5f7;
+  box-shadow: inset 0px 0px 0px 1px #d4dae7;
   overflow: hidden;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+1) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+1) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
         #4f0599 25%, #4f0599 50%,
         rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #4f0599
@@ -24,7 +24,7 @@ exports[`BarStack should render correctly 1`] = `
   background-color: #4f0599;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+2) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+2) {
   background-color: #6907ca;
   background-image: linear-gradient(
           135deg,
@@ -55,18 +55,18 @@ exports[`BarStack should render correctly 1`] = `
   background-repeat: repeat;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+3) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+3) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
-        #ae5df6 25%, #ae5df6 50%,
-        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #ae5df6
+        #a365f6 25%, #a365f6 50%,
+        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #a365f6
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #7d0ce1;
+  background-color: #6b0ee7;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+4) {
-  background-color: #ae5df6;
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+4) {
+  background-color: #a365f6;
   background-image: linear-gradient(
           135deg,
           rgba(255,255,255,0.2)
@@ -86,7 +86,7 @@ exports[`BarStack should render correctly 1`] = `
           315deg,
           rgba(255,255,255,0.2)
             25%,
-          #ae5df6 25%
+          #a365f6 25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -95,14 +95,14 @@ exports[`BarStack should render correctly 1`] = `
   background-repeat: repeat;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+5) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+5) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.2) 25%,
-        #c68df9 25%, #c68df9 50%,
-        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c68df9
+        #c095f9 25%, #c095f9 50%,
+        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c095f9
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #c68df9;
+  background-color: #c095f9;
 }
 
 .cache-1mc9zcp {
@@ -133,7 +133,7 @@ exports[`BarStack should render correctly 1`] = `
 }
 
 <div
-    class="cache-q2zvqm e17nk4tl0"
+    class="cache-dth6f7 e17nk4tl0"
   >
     <div
       class="cache-1mc9zcp e17nk4tl2"
@@ -189,7 +189,7 @@ exports[`BarStack should render correctly 1`] = `
 
 exports[`BarStack should render correctly with event handlers 1`] = `
 <DocumentFragment>
-  .cache-q2zvqm {
+  .cache-dth6f7 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -197,11 +197,11 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   display: flex;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: inset 0px 0px 0px 1px #f6f5f7;
+  box-shadow: inset 0px 0px 0px 1px #d4dae7;
   overflow: hidden;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+1) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+1) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
         #4f0599 25%, #4f0599 50%,
         rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #4f0599
@@ -211,7 +211,7 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-color: #4f0599;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+2) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+2) {
   background-color: #6907ca;
   background-image: linear-gradient(
           135deg,
@@ -242,18 +242,18 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-repeat: repeat;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+3) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+3) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
-        #ae5df6 25%, #ae5df6 50%,
-        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #ae5df6
+        #a365f6 25%, #a365f6 50%,
+        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #a365f6
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #7d0ce1;
+  background-color: #6b0ee7;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+4) {
-  background-color: #ae5df6;
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+4) {
+  background-color: #a365f6;
   background-image: linear-gradient(
           135deg,
           rgba(255,255,255,0.2)
@@ -273,7 +273,7 @@ exports[`BarStack should render correctly with event handlers 1`] = `
           315deg,
           rgba(255,255,255,0.2)
             25%,
-          #ae5df6 25%
+          #a365f6 25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -282,14 +282,14 @@ exports[`BarStack should render correctly with event handlers 1`] = `
   background-repeat: repeat;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+5) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+5) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.2) 25%,
-        #c68df9 25%, #c68df9 50%,
-        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c68df9
+        #c095f9 25%, #c095f9 50%,
+        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c095f9
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #c68df9;
+  background-color: #c095f9;
 }
 
 .cache-1mc9zcp {
@@ -320,7 +320,7 @@ exports[`BarStack should render correctly with event handlers 1`] = `
 }
 
 <div
-    class="cache-q2zvqm e17nk4tl0"
+    class="cache-dth6f7 e17nk4tl0"
   >
     <div
       class="cache-1mc9zcp e17nk4tl2"
@@ -338,7 +338,7 @@ exports[`BarStack should render correctly with event handlers 1`] = `
 
 exports[`BarStack should render correctly with total 1`] = `
 <DocumentFragment>
-  .cache-q2zvqm {
+  .cache-dth6f7 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -346,11 +346,11 @@ exports[`BarStack should render correctly with total 1`] = `
   display: flex;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: inset 0px 0px 0px 1px #f6f5f7;
+  box-shadow: inset 0px 0px 0px 1px #d4dae7;
   overflow: hidden;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+1) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+1) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
         #4f0599 25%, #4f0599 50%,
         rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #4f0599
@@ -360,7 +360,7 @@ exports[`BarStack should render correctly with total 1`] = `
   background-color: #4f0599;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+2) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+2) {
   background-color: #6907ca;
   background-image: linear-gradient(
           135deg,
@@ -391,18 +391,18 @@ exports[`BarStack should render correctly with total 1`] = `
   background-repeat: repeat;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+3) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+3) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.1) 25%,
-        #ae5df6 25%, #ae5df6 50%,
-        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #ae5df6
+        #a365f6 25%, #a365f6 50%,
+        rgba(255,255,255,0.1) 50%, rgba(255,255,255,0.1) 75%, #a365f6
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #7d0ce1;
+  background-color: #6b0ee7;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+4) {
-  background-color: #ae5df6;
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+4) {
+  background-color: #a365f6;
   background-image: linear-gradient(
           135deg,
           rgba(255,255,255,0.2)
@@ -422,7 +422,7 @@ exports[`BarStack should render correctly with total 1`] = `
           315deg,
           rgba(255,255,255,0.2)
             25%,
-          #ae5df6 25%
+          #a365f6 25%
         );
   -webkit-background-position: 10px 0,10px 0,0 0,0 0;
   background-position: 10px 0,10px 0,0 0,0 0;
@@ -431,14 +431,14 @@ exports[`BarStack should render correctly with total 1`] = `
   background-repeat: repeat;
 }
 
-.cache-q2zvqm .e17nk4tl2:nth-child(5n+5) {
+.cache-dth6f7 .e17nk4tl2:nth-child(5n+5) {
   background: linear-gradient(-45deg, rgba(255,255,255,0.2) 25%,
-        #c68df9 25%, #c68df9 50%,
-        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c68df9
+        #c095f9 25%, #c095f9 50%,
+        rgba(255,255,255,0.2) 50%, rgba(255,255,255,0.2) 75%, #c095f9
          75%);
   -webkit-background-size: 30px 30px;
   background-size: 30px 30px;
-  background-color: #c68df9;
+  background-color: #c095f9;
 }
 
 .cache-1mc9zcp {
@@ -469,7 +469,7 @@ exports[`BarStack should render correctly with total 1`] = `
 }
 
 <div
-    class="cache-q2zvqm e17nk4tl0"
+    class="cache-dth6f7 e17nk4tl0"
   >
     <div
       class="cache-1mc9zcp e17nk4tl2"

--- a/src/components/BarStack/index.tsx
+++ b/src/components/BarStack/index.tsx
@@ -134,8 +134,8 @@ const StyledContainer = styled.div`
       0.9,
       theme.colors.neutral.backgroundWeak,
     )} 25%,
-      ${theme.colors.secondary.background} 25%, ${
-      theme.colors.secondary.background
+      ${theme.colors.secondary.backgroundStrong} 25%, ${
+      theme.colors.secondary.backgroundStrong
     } 50%,
       ${transparentize(
         0.9,
@@ -143,15 +143,15 @@ const StyledContainer = styled.div`
       )} 50%, ${transparentize(
       0.9,
       theme.colors.neutral.backgroundWeak,
-    )} 75%, ${theme.colors.secondary.background}
+    )} 75%, ${theme.colors.secondary.backgroundStrong}
        75%);`}
     background-size: 30px 30px;
     background-color: ${({ theme }) =>
-      darken(0.2, theme.colors.secondary.background)};
+      darken(0.2, theme.colors.secondary.backgroundStrong)};
   }
 
   ${StyledBarWrapper}:nth-child(5n+4) {
-    background-color: ${({ theme }) => theme.colors.secondary.background};
+    background-color: ${({ theme }) => theme.colors.secondary.backgroundStrong};
 
     background-image: linear-gradient(
         135deg,
@@ -179,7 +179,7 @@ const StyledContainer = styled.div`
         ${({ theme }) =>
             transparentize(0.8, theme.colors.neutral.backgroundWeak)}
           25%,
-        ${({ theme }) => theme.colors.secondary.background} 25%
+        ${({ theme }) => theme.colors.secondary.backgroundStrong} 25%
       );
     background-position: 10px 0, 10px 0, 0 0, 0 0;
     background-size: 10px 10px;
@@ -191,9 +191,9 @@ const StyledContainer = styled.div`
       0.8,
       theme.colors.neutral.backgroundWeak,
     )} 25%,
-      ${lighten(0.1, theme.colors.secondary.background)} 25%, ${lighten(
+      ${lighten(0.1, theme.colors.secondary.backgroundStrong)} 25%, ${lighten(
       0.1,
-      theme.colors.secondary.background,
+      theme.colors.secondary.backgroundStrong,
     )} 50%,
       ${transparentize(
         0.8,
@@ -201,11 +201,11 @@ const StyledContainer = styled.div`
       )} 50%, ${transparentize(
       0.8,
       theme.colors.neutral.backgroundWeak,
-    )} 75%, ${lighten(0.1, theme.colors.secondary.background)}
+    )} 75%, ${lighten(0.1, theme.colors.secondary.backgroundStrong)}
        75%);`}
     background-size: 30px 30px;
     background-color: ${({ theme }) =>
-      lighten(0.1, theme.colors.secondary.background)};
+      lighten(0.1, theme.colors.secondary.backgroundStrong)};
   }
 `
 

--- a/src/components/BarStack/index.tsx
+++ b/src/components/BarStack/index.tsx
@@ -36,13 +36,13 @@ interface BarStackProps {
 const StyledBarWrapper = styled.div`
   width: 0px;
   transition: width 500ms;
-  background-color: ${({ theme }) => theme.colorsDeprecated.white};
+  background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
 `
 
 const StyledBar = styled.div`
   height: 50px;
   font-weight: 600;
-  color: ${({ theme }) => theme.colorsDeprecated.white};
+  color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
   font-size: 14px;
   display: flex;
   align-items: center;
@@ -51,63 +51,78 @@ const StyledBar = styled.div`
   white-space: nowrap;
   overflow: hidden;
   text-shadow: -1px 0
-      ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)},
-    0 1px ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)},
-    1px 0 ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)},
-    0 -1px ${({ theme }) => transparentize(0.7, theme.colorsDeprecated.black)};
+      ${({ theme }) =>
+        transparentize(0.7, theme.colors.neutral.backgroundStrong)},
+    0 1px
+      ${({ theme }) =>
+        transparentize(0.7, theme.colors.neutral.backgroundStrong)},
+    1px 0
+      ${({ theme }) =>
+        transparentize(0.7, theme.colors.neutral.backgroundStrong)},
+    0 -1px ${({ theme }) => transparentize(0.7, theme.colors.neutral.backgroundStrong)};
 `
 
 const StyledContainer = styled.div`
   width: 100%;
   display: flex;
-  background-color: ${({ theme }) => theme.colorsDeprecated.gray100};
+  background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
   border-radius: ${({ theme }) => theme.radii.default};
   box-shadow: inset 0px 0px 0px 1px
-    ${({ theme }) => theme.colorsDeprecated.gray300};
+    ${({ theme }) => theme.colors.neutral.background};
   overflow: hidden;
 
   ${StyledBarWrapper}:nth-child(5n+1) {
     ${({ theme }) => `background: linear-gradient(-45deg, ${transparentize(
       0.9,
-      theme.colorsDeprecated.white,
+      theme.colors.neutral.backgroundWeak,
     )} 25%,
-      ${theme.colorsDeprecated.primary} 25%, ${
-      theme.colorsDeprecated.primary
+      ${theme.colors.primary.backgroundStrong} 25%, ${
+      theme.colors.primary.backgroundStrong
     } 50%,
       ${transparentize(
         0.9,
-        theme.colorsDeprecated.white,
-      )} 50%, ${transparentize(0.9, theme.colorsDeprecated.white)} 75%, ${
-      theme.colorsDeprecated.primary
-    }
+        theme.colors.neutral.backgroundWeak,
+      )} 50%, ${transparentize(
+      0.9,
+      theme.colors.neutral.backgroundWeak,
+    )} 75%, ${theme.colors.primary.backgroundStrong}
        75%);`}
     background-size: 30px 30px;
-    background-color: ${({ theme }) => theme.colorsDeprecated.primary};
+    background-color: ${({ theme }) => theme.colors.primary.backgroundStrong};
   }
 
   ${StyledBarWrapper}:nth-child(5n+2) {
     background-color: ${({ theme }) =>
-      lighten(0.1, theme.colorsDeprecated.primary)};
+      lighten(0.1, theme.colors.primary.backgroundStrong)};
 
     background-image: linear-gradient(
         135deg,
-        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) =>
+            transparentize(0.75, theme.colors.neutral.backgroundWeak)}
+          25%,
         transparent 25%
       ),
       linear-gradient(
         225deg,
-        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) =>
+            transparentize(0.75, theme.colors.neutral.backgroundWeak)}
+          25%,
         transparent 25%
       ),
       linear-gradient(
         45deg,
-        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) =>
+            transparentize(0.75, theme.colors.neutral.backgroundWeak)}
+          25%,
         transparent 25%
       ),
       linear-gradient(
         315deg,
-        ${({ theme }) => transparentize(0.75, theme.colorsDeprecated.white)} 25%,
-        ${({ theme }) => lighten(0.1, theme.colorsDeprecated.primary)} 25%
+        ${({ theme }) =>
+            transparentize(0.75, theme.colors.neutral.backgroundWeak)}
+          25%,
+        ${({ theme }) => lighten(0.1, theme.colors.primary.backgroundStrong)}
+          25%
       );
     background-position: 10px 0, 10px 0, 0 0, 0 0;
     background-size: 10px 10px;
@@ -117,45 +132,54 @@ const StyledContainer = styled.div`
   ${StyledBarWrapper}:nth-child(5n+3) {
     ${({ theme }) => `background: linear-gradient(-45deg, ${transparentize(
       0.9,
-      theme.colorsDeprecated.white,
+      theme.colors.neutral.backgroundWeak,
     )} 25%,
-      ${theme.colorsDeprecated.lightViolet} 25%, ${
-      theme.colorsDeprecated.lightViolet
+      ${theme.colors.secondary.background} 25%, ${
+      theme.colors.secondary.background
     } 50%,
       ${transparentize(
         0.9,
-        theme.colorsDeprecated.white,
-      )} 50%, ${transparentize(0.9, theme.colorsDeprecated.white)} 75%, ${
-      theme.colorsDeprecated.lightViolet
-    }
+        theme.colors.neutral.backgroundWeak,
+      )} 50%, ${transparentize(
+      0.9,
+      theme.colors.neutral.backgroundWeak,
+    )} 75%, ${theme.colors.secondary.background}
        75%);`}
     background-size: 30px 30px;
     background-color: ${({ theme }) =>
-      darken(0.2, theme.colorsDeprecated.lightViolet)};
+      darken(0.2, theme.colors.secondary.background)};
   }
 
   ${StyledBarWrapper}:nth-child(5n+4) {
-    background-color: ${({ theme }) => theme.colorsDeprecated.lightViolet};
+    background-color: ${({ theme }) => theme.colors.secondary.background};
 
     background-image: linear-gradient(
         135deg,
-        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) =>
+            transparentize(0.8, theme.colors.neutral.backgroundWeak)}
+          25%,
         transparent 25%
       ),
       linear-gradient(
         225deg,
-        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) =>
+            transparentize(0.8, theme.colors.neutral.backgroundWeak)}
+          25%,
         transparent 25%
       ),
       linear-gradient(
         45deg,
-        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
+        ${({ theme }) =>
+            transparentize(0.8, theme.colors.neutral.backgroundWeak)}
+          25%,
         transparent 25%
       ),
       linear-gradient(
         315deg,
-        ${({ theme }) => transparentize(0.8, theme.colorsDeprecated.white)} 25%,
-        ${({ theme }) => theme.colorsDeprecated.lightViolet} 25%
+        ${({ theme }) =>
+            transparentize(0.8, theme.colors.neutral.backgroundWeak)}
+          25%,
+        ${({ theme }) => theme.colors.secondary.background} 25%
       );
     background-position: 10px 0, 10px 0, 0 0, 0 0;
     background-size: 10px 10px;
@@ -165,23 +189,23 @@ const StyledContainer = styled.div`
   ${StyledBarWrapper}:nth-child(5n+5) {
     ${({ theme }) => `background: linear-gradient(-45deg, ${transparentize(
       0.8,
-      theme.colorsDeprecated.white,
+      theme.colors.neutral.backgroundWeak,
     )} 25%,
-      ${lighten(0.1, theme.colorsDeprecated.lightViolet)} 25%, ${lighten(
+      ${lighten(0.1, theme.colors.secondary.background)} 25%, ${lighten(
       0.1,
-      theme.colorsDeprecated.lightViolet,
+      theme.colors.secondary.background,
     )} 50%,
       ${transparentize(
         0.8,
-        theme.colorsDeprecated.white,
+        theme.colors.neutral.backgroundWeak,
       )} 50%, ${transparentize(
       0.8,
-      theme.colorsDeprecated.white,
-    )} 75%, ${lighten(0.1, theme.colorsDeprecated.lightViolet)}
+      theme.colors.neutral.backgroundWeak,
+    )} 75%, ${lighten(0.1, theme.colors.secondary.background)}
        75%);`}
     background-size: 30px 30px;
     background-color: ${({ theme }) =>
-      lighten(0.1, theme.colorsDeprecated.lightViolet)};
+      lighten(0.1, theme.colors.secondary.background)};
   }
 `
 

--- a/src/components/LineChart/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/LineChart/__tests__/__snapshots__/index.tsx.snap
@@ -603,7 +603,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -612,7 +612,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -624,7 +624,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -636,7 +636,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -648,7 +648,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -660,7 +660,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -823,11 +823,11 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
   color: #4a4f62;
 }
 
-.cache-1wwhcz7-CustomLegend {
+.cache-1yism2d-CustomLegend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #33BBB3;
+  background-color: #45d6b5;
 }
 
 .cache-1w6vxon {
@@ -948,7 +948,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                     line chart values
                   </p>
                   <div
-                    class="cache-1wwhcz7-CustomLegend"
+                    class="cache-1yism2d-CustomLegend"
                   />
                 </div>
               </div>
@@ -1744,11 +1744,11 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
   color: #4a4f62;
 }
 
-.cache-1wwhcz7-CustomLegend {
+.cache-1yism2d-CustomLegend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #33BBB3;
+  background-color: #45d6b5;
 }
 
 .cache-1w6vxon {
@@ -1869,7 +1869,7 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
                     line chart values
                   </p>
                   <div
-                    class="cache-1wwhcz7-CustomLegend"
+                    class="cache-1yism2d-CustomLegend"
                   />
                 </div>
               </div>
@@ -2512,7 +2512,7 @@ exports[`LineChart renders correctly with data 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -2521,7 +2521,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2533,7 +2533,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2545,7 +2545,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2557,7 +2557,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2569,7 +2569,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3197,7 +3197,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -3206,7 +3206,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3218,7 +3218,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3230,7 +3230,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3242,7 +3242,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3254,7 +3254,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3882,7 +3882,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -3891,7 +3891,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3903,7 +3903,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3915,7 +3915,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3927,7 +3927,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -3939,7 +3939,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4102,11 +4102,11 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
   color: #4a4f62;
 }
 
-.cache-1wwhcz7-CustomLegend {
+.cache-1yism2d-CustomLegend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #33BBB3;
+  background-color: #45d6b5;
 }
 
 .cache-1w6vxon {
@@ -4227,7 +4227,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                     line chart values
                   </p>
                   <div
-                    class="cache-1wwhcz7-CustomLegend"
+                    class="cache-1yism2d-CustomLegend"
                   />
                 </div>
               </div>
@@ -4928,13 +4928,13 @@ exports[`LineChart renders correctly with multiple series 1`] = `
             <path
               d="M915,322C915,322,915,346,915,346C915,346,915,309,915,309C915,309,915,388,915,388C915,388,915,404,915,404C915,404,915,33,915,33C915,33,915,206,915,206C915,206,915,285,915,285C915,285,915,346,915,346"
               fill="none"
-              stroke="#9B83F9"
+              stroke="#a365f6"
               stroke-width="2"
             />
             <path
               d="M915,280C915,280,915,305,915,305C915,305,915,384,915,384C915,384,915,351,915,351C915,351,915,363,915,363C915,363,915,157,915,157C915,157,915,289,915,289C915,289,915,120,915,120C915,120,915,297,915,297C915,297,915,346,915,346"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -4943,7 +4943,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4955,7 +4955,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4967,7 +4967,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4979,7 +4979,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4991,7 +4991,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5003,7 +5003,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5015,7 +5015,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5027,7 +5027,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 285)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5039,7 +5039,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 206)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5051,7 +5051,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 33)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5063,7 +5063,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 404)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5075,7 +5075,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 388)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5087,7 +5087,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 309)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5099,7 +5099,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5111,7 +5111,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 322)"
               >
                 <circle
-                  fill="#9B83F9"
+                  fill="#a365f6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5123,7 +5123,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5135,7 +5135,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5147,7 +5147,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5159,7 +5159,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5171,7 +5171,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5183,7 +5183,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5195,7 +5195,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 297)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5207,7 +5207,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 120)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5219,7 +5219,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 289)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5231,7 +5231,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 157)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5243,7 +5243,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 363)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5255,7 +5255,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 351)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5267,7 +5267,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 384)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5279,7 +5279,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 305)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5291,7 +5291,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 280)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5454,11 +5454,11 @@ exports[`LineChart renders correctly with multiple series 1`] = `
   color: #4a4f62;
 }
 
-.cache-1wwhcz7-CustomLegend {
+.cache-1yism2d-CustomLegend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #33BBB3;
+  background-color: #45d6b5;
 }
 
 .cache-1w6vxon {
@@ -5503,11 +5503,11 @@ exports[`LineChart renders correctly with multiple series 1`] = `
   text-align: right;
 }
 
-.cache-8hr9vu-CustomLegend {
+.cache-pcs2og-CustomLegend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #9B83F9;
+  background-color: #a365f6;
 }
 
 <div
@@ -5586,7 +5586,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                     Serie 1
                   </p>
                   <div
-                    class="cache-1wwhcz7-CustomLegend"
+                    class="cache-1yism2d-CustomLegend"
                   />
                 </div>
               </div>
@@ -5662,7 +5662,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                     Serie 2
                   </p>
                   <div
-                    class="cache-8hr9vu-CustomLegend"
+                    class="cache-pcs2og-CustomLegend"
                   />
                 </div>
               </div>
@@ -6305,7 +6305,7 @@ exports[`LineChart renders correctly with point formater 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -6314,7 +6314,7 @@ exports[`LineChart renders correctly with point formater 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6326,7 +6326,7 @@ exports[`LineChart renders correctly with point formater 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6338,7 +6338,7 @@ exports[`LineChart renders correctly with point formater 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6350,7 +6350,7 @@ exports[`LineChart renders correctly with point formater 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6362,7 +6362,7 @@ exports[`LineChart renders correctly with point formater 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7048,7 +7048,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
             <path
               d="M915,322C915,322,915,346,915,346C915,346,915,309,915,309C915,309,915,388,915,388C915,388,915,404,915,404C915,404,915,33,915,33C915,33,915,206,915,206C915,206,915,285,915,285C915,285,915,346,915,346"
               fill="none"
-              stroke="#33BBB3"
+              stroke="#45d6b5"
               stroke-width="2"
             />
             <g>
@@ -7057,7 +7057,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7069,7 +7069,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7081,7 +7081,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7093,7 +7093,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7105,7 +7105,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7117,7 +7117,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7129,7 +7129,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7141,7 +7141,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 285)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7153,7 +7153,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 206)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7165,7 +7165,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 33)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7177,7 +7177,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 404)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7189,7 +7189,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 388)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7201,7 +7201,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 309)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7213,7 +7213,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7225,7 +7225,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 322)"
               >
                 <circle
-                  fill="#33BBB3"
+                  fill="#45d6b5"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7388,11 +7388,11 @@ exports[`LineChart renders correctly with timeline data 1`] = `
   color: #4a4f62;
 }
 
-.cache-1wwhcz7-CustomLegend {
+.cache-1yism2d-CustomLegend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #33BBB3;
+  background-color: #45d6b5;
 }
 
 .cache-1w6vxon {
@@ -7513,7 +7513,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                     line chart hours values
                   </p>
                   <div
-                    class="cache-1wwhcz7-CustomLegend"
+                    class="cache-1yism2d-CustomLegend"
                   />
                 </div>
               </div>

--- a/src/helpers/legend.ts
+++ b/src/helpers/legend.ts
@@ -1,9 +1,9 @@
 import { Theme } from '@emotion/react'
 
 export const legendColors = (theme: Theme): string[] => [
-  theme.colorsDeprecated.chartGreen,
-  theme.colorsDeprecated.chartPurple,
-  theme.colorsDeprecated.gray350,
+  theme.colors.success.backgroundStrong,
+  theme.colors.primary.backgroundStrong,
+  theme.colors.neutral.background,
 ]
 
 export const getLegendColor = (index: number, theme: Theme): string => {

--- a/src/helpers/legend.ts
+++ b/src/helpers/legend.ts
@@ -2,7 +2,7 @@ import { Theme } from '@emotion/react'
 
 export const legendColors = (theme: Theme): string[] => [
   theme.colors.success.backgroundStrong,
-  theme.colors.primary.backgroundStrong,
+  theme.colors.secondary.backgroundStrong,
   theme.colors.neutral.background,
 ]
 


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Migrate Badge, Barchart, BarStack with new theme

#### The following changes where made:

1. Update colors to use new theme

2. Drop chartColors

## Relevant logs and/or screenshots

| Page |   Before   |  After  |
| :---: | :--------: |:---------: |
| BarChart  | <img width="1059" alt="Capture d’écran 2021-12-13 à 11 18 47" src="https://user-images.githubusercontent.com/24531136/145794381-84e9efc3-b10a-4c8d-b1d9-b4ae095f5a19.png"> | <img width="1029" alt="Capture d’écran 2021-12-13 à 11 19 14" src="https://user-images.githubusercontent.com/24531136/145794482-31cab608-35d5-40ef-8189-d688c5ac6cc1.png"> |
| BarStack  | <img width="1025" alt="Capture d’écran 2021-12-13 à 11 20 18" src="https://user-images.githubusercontent.com/24531136/145794623-abe9b396-28e6-4ce0-983a-ee506183eaeb.png"> | <img width="1038" alt="Capture d’écran 2021-12-13 à 11 20 42" src="https://user-images.githubusercontent.com/24531136/145794660-ad7ff900-cdcc-4b9f-b69a-f476db8653ad.png"> |
