### PR TITLE
refactor(theme): migration colors of Typography, VerificationCode, VolumeSize

### DIFF
--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -12,7 +12,8 @@ import React, {
   useCallback,
 } from 'react'
 import recursivelyGetChildrenString from '../../helpers/recursivelyGetChildrenString'
-import { ColorDeprecated as Color } from '../../theme/deprecated/colors'
+import { Color } from '../../theme'
+import { ColorDeprecated } from '../../theme/deprecated/colors'
 import Box, { XStyledProps } from '../Box'
 import Tooltip from '../Tooltip'
 
@@ -25,8 +26,8 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
   {
     badge: ({ theme }: StyleProps) =>
       css`
-        background-color: ${theme?.colorsDeprecated.gray100};
-        color: ${theme?.colorsDeprecated.gray700};
+        background-color: ${theme?.colors.neutral.background};
+        color: ${theme?.colors.neutral.text};
         text-transform: capitalize;
         letter-spacing: 1px;
         font-weight: 500;
@@ -37,25 +38,25 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
       `,
     bodyA: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray700};
+        color: ${theme?.colors.neutral.text};
         font-size: 16px;
         line-height: 24px;
       `,
     bodyB: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray550};
+        color: ${theme?.colors.neutral.textWeak};
         font-size: 14px;
         line-height: 18px;
       `,
     bodyC: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray700};
+        color: ${theme?.colors.neutral.text};
         font-size: 14px;
         line-height: 22px;
       `,
     bodyD: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray700};
+        color: ${theme?.colors.neutral.text};
         font-size: 14px;
         line-height: 20px;
       `,
@@ -74,13 +75,13 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
         font-size: 13px;
         font-weight: 500;
         border-radius: ${theme?.radii.default};
-        color: ${theme?.colorsDeprecated.gray700};
-        background-color: ${theme?.colorsDeprecated.gray100};
+        color: ${theme?.colors.neutral.text};
+        background-color: ${theme?.colors.neutral.backgroundDisabled};
         padding: 8px;
       `,
     description: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray950};
+        color: ${theme?.colors.neutral.textHover};
         font-size: 16px;
         line-height: 24px;
         font-weight: 500;
@@ -92,14 +93,14 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
     `,
     hero: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray950};
+        color: ${theme?.colors.neutral.textHover};
         font-size: 35px;
         line-height: 41px;
         margin-bottom: 72px;
       `,
     lead: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray950};
+        color: ${theme?.colors.neutral.textHover};
         font-size: 25px;
         line-height: 25px;
         margin-bottom: 0;
@@ -119,21 +120,21 @@ const styles: Record<string, (props: StyleProps) => SerializedStyles | string> =
     `,
     samplecode: ({ theme }: StyleProps) =>
       css`
-        background-color: ${theme?.colorsDeprecated.gray100};
-        color: ${theme?.colorsDeprecated.gray700};
+        background-color: ${theme?.colors.neutral.backgroundDisabled};
+        color: ${theme?.colors.neutral.text};
         font-size: 12px;
         line-height: 16px;
         padding: 4px;
       `,
     tiny: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray550};
+        color: ${theme?.colors.neutral.textWeak};
         font-size: 12px;
         line-height: 16px;
       `,
     title: ({ theme }: StyleProps) =>
       css`
-        color: ${theme?.colorsDeprecated.gray950};
+        color: ${theme?.colors.neutral.textHover};
         font-size: 21px;
         line-height: 24px;
       `,
@@ -162,7 +163,9 @@ const variantTags = {
 const colorStyles = ({ theme, color }: { theme: Theme; color?: string }) =>
   color
     ? css`
-        color: ${theme.colorsDeprecated[color as Color] ?? color};
+        color: ${theme.colors[color as Color]?.text ??
+        theme.colorsDeprecated[color as ColorDeprecated] ??
+        color};
       `
     : undefined
 
@@ -197,7 +200,7 @@ const StyledText = styled(Box, {
       prop.toString(),
     ),
 })<StyledTextProps>`
-  color: ${({ theme }) => theme?.colorsDeprecated.gray700};
+  color: ${({ theme }) => theme?.colors.neutral.text};
   font-weight: 400;
   margin-bottom: 0;
   margin-top: 0;

--- a/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`VerificationCode renders correctly with default values 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -13,30 +13,30 @@ exports[`VerificationCode renders correctly with default values 1`] = `
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -46,7 +46,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -56,7 +56,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -66,7 +66,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -80,8 +80,8 @@ exports[`VerificationCode renders correctly with default values 1`] = `
 
 exports[`VerificationCode renders correctly with initial value and placeholder and 6 fields 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -91,30 +91,30 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -124,7 +124,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -134,7 +134,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -144,7 +144,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -154,7 +154,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="4"
       id="verification-code-4"
       pattern="[0-9]*"
@@ -164,7 +164,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="5"
       id="verification-code-5"
       pattern="[0-9]*"
@@ -178,8 +178,8 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
 
 exports[`VerificationCode should handle and replace non number with "" when type is number 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -189,30 +189,30 @@ exports[`VerificationCode should handle and replace non number with "" when type
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -222,7 +222,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -232,7 +232,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -242,7 +242,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -256,8 +256,8 @@ exports[`VerificationCode should handle and replace non number with "" when type
 
 exports[`VerificationCode should handle paste when type is not number 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -267,30 +267,30 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       placeholder=""
@@ -299,7 +299,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       placeholder=""
@@ -308,7 +308,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       placeholder=""
@@ -317,7 +317,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       placeholder=""
@@ -326,7 +326,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="4"
       id="verification-code-4"
       placeholder=""
@@ -335,7 +335,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="5"
       id="verification-code-5"
       placeholder=""
@@ -348,8 +348,8 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
 
 exports[`VerificationCode should handle paste with no overflowing values 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -359,30 +359,30 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -392,7 +392,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -402,7 +402,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -412,7 +412,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -426,8 +426,8 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
 
 exports[`VerificationCode should handle paste with overflowing values 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -437,30 +437,30 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -470,7 +470,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -480,7 +480,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -490,7 +490,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -504,8 +504,8 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
 
 exports[`VerificationCode should handle paste with overflowing values at different index than 0 1`] = `
 <DocumentFragment>
-  .cache-15e247j-VerificationCode {
-  border: solid 1px #dce1eb;
+  .cache-ve85h4-VerificationCode {
+  border: solid 1px #d4dae7;
   font-size: 24px;
   color: #4a4f62;
   text-align: center;
@@ -515,30 +515,30 @@ exports[`VerificationCode should handle paste with overflowing values at differe
   height: 64px;
 }
 
-.cache-15e247j-VerificationCode:last-child {
+.cache-ve85h4-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-15e247j-VerificationCode::-webkit-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-webkit-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::-moz-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::-moz-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode:-ms-input-placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode:-ms-input-placeholder {
+  color: #b2b6c3;
 }
 
-.cache-15e247j-VerificationCode::placeholder {
-  color: #dce1eb;
+.cache-ve85h4-VerificationCode::placeholder {
+  color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -548,7 +548,7 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -558,7 +558,7 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -568,7 +568,7 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
-      class="cache-15e247j-VerificationCode e1odpyad0"
+      class="cache-ve85h4-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"

--- a/src/components/VerificationCode/index.tsx
+++ b/src/components/VerificationCode/index.tsx
@@ -11,10 +11,10 @@ import React, {
 const StyledInput = styled.input`
   border: solid 1px
     ${({ 'aria-invalid': error, theme }) =>
-      error ? theme.colorsDeprecated.red : theme.colorsDeprecated.gray300};
+      error ? theme.colors.danger.borderWeak : theme.colors.neutral.borderWeak};
   font-size: 24px;
   color: ${({ 'aria-invalid': error, theme }) =>
-    error ? theme.colorsDeprecated.red : theme.colorsDeprecated.gray700};
+    error ? theme.colors.danger.textWeak : theme.colors.neutral.text};
   text-align: center;
   border-radius: 4px;
   margin-right: 8px;
@@ -26,7 +26,7 @@ const StyledInput = styled.input`
   }
 
   &::placeholder {
-    color: ${({ theme }) => theme.colorsDeprecated.gray300};
+    color: ${({ theme }) => theme.colors.neutral.textWeak};
   }
 `
 

--- a/src/components/VolumeSize/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/VolumeSize/__tests__/__snapshots__/index.tsx.snap
@@ -65,9 +65,9 @@ exports[`VolumeSize renders correctly with all props 1`] = `
   margin-right: 5px;
 }
 
-.cache-143mwpp {
+.cache-1rs4nfs {
   font-weight: 800;
-  color: #151a2d;
+  color: #4a4f62;
 }
 
 .cache-1nn49go {
@@ -122,8 +122,8 @@ exports[`VolumeSize renders correctly with all props 1`] = `
   animation: animation-0 1.2s ease backwards;
 }
 
-.cache-bj2ss9 {
-  background-color: #151a2d;
+.cache-rd7h08 {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -164,8 +164,8 @@ exports[`VolumeSize renders correctly with all props 1`] = `
   line-height: 22px;
 }
 
-.cache-w7q5zf {
-  background-color: #151a2d;
+.cache-1qpjbs8 {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -207,7 +207,7 @@ exports[`VolumeSize renders correctly with all props 1`] = `
           Test
         </span>
         <span
-          class="cache-143mwpp e21aiwm8"
+          class="cache-1rs4nfs e21aiwm8"
         >
           15 GB
         </span>
@@ -232,7 +232,7 @@ exports[`VolumeSize renders correctly with all props 1`] = `
         />
       </div>
       <div
-        class="cache-bj2ss9 e21aiwm4"
+        class="cache-rd7h08 e21aiwm4"
       >
         <div
           class="cache-1mxpzd8 e21aiwm3"
@@ -250,7 +250,7 @@ exports[`VolumeSize renders correctly with all props 1`] = `
         </div>
       </div>
       <div
-        class="cache-w7q5zf e21aiwm4"
+        class="cache-1qpjbs8 e21aiwm4"
       >
         <div
           class="cache-d4wpn5 e21aiwm3"
@@ -323,9 +323,9 @@ exports[`VolumeSize renders correctly with minimal props 1`] = `
   margin-right: 5px;
 }
 
-.cache-143mwpp {
+.cache-1rs4nfs {
   font-weight: 800;
-  color: #151a2d;
+  color: #4a4f62;
 }
 
 .cache-1nn49go {
@@ -380,8 +380,8 @@ exports[`VolumeSize renders correctly with minimal props 1`] = `
   animation: animation-0 1.2s ease backwards;
 }
 
-.cache-va7ax2 {
-  background-color: #151a2d;
+.cache-1u1skqp {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -435,7 +435,7 @@ exports[`VolumeSize renders correctly with minimal props 1`] = `
           class="cache-1693thf e21aiwm9"
         />
         <span
-          class="cache-143mwpp e21aiwm8"
+          class="cache-1rs4nfs e21aiwm8"
         >
           5 GB
         </span>
@@ -460,7 +460,7 @@ exports[`VolumeSize renders correctly with minimal props 1`] = `
         />
       </div>
       <div
-        class="cache-va7ax2 e21aiwm4"
+        class="cache-1u1skqp e21aiwm4"
       >
         <div
           class="cache-1mxpzd8 e21aiwm3"
@@ -561,9 +561,9 @@ exports[`VolumeSize renders correctly with non modifiable value 1`] = `
   margin-right: 5px;
 }
 
-.cache-143mwpp {
+.cache-1rs4nfs {
   font-weight: 800;
-  color: #151a2d;
+  color: #4a4f62;
 }
 
 .cache-1nn49go {
@@ -618,8 +618,8 @@ exports[`VolumeSize renders correctly with non modifiable value 1`] = `
   animation: animation-0 1.2s ease backwards;
 }
 
-.cache-bj2ss9 {
-  background-color: #151a2d;
+.cache-rd7h08 {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -660,8 +660,8 @@ exports[`VolumeSize renders correctly with non modifiable value 1`] = `
   line-height: 22px;
 }
 
-.cache-w7q5zf {
-  background-color: #151a2d;
+.cache-1qpjbs8 {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -703,7 +703,7 @@ exports[`VolumeSize renders correctly with non modifiable value 1`] = `
           Test
         </span>
         <span
-          class="cache-143mwpp e21aiwm8"
+          class="cache-1rs4nfs e21aiwm8"
         >
           15 GB
         </span>
@@ -728,7 +728,7 @@ exports[`VolumeSize renders correctly with non modifiable value 1`] = `
         />
       </div>
       <div
-        class="cache-bj2ss9 e21aiwm4"
+        class="cache-rd7h08 e21aiwm4"
       >
         <div
           class="cache-1mxpzd8 e21aiwm3"
@@ -746,7 +746,7 @@ exports[`VolumeSize renders correctly with non modifiable value 1`] = `
         </div>
       </div>
       <div
-        class="cache-w7q5zf e21aiwm4"
+        class="cache-1qpjbs8 e21aiwm4"
       >
         <div
           class="cache-d4wpn5 e21aiwm3"
@@ -861,9 +861,9 @@ exports[`VolumeSize renders correctly without maxSize 1`] = `
   margin-right: 5px;
 }
 
-.cache-143mwpp {
+.cache-1rs4nfs {
   font-weight: 800;
-  color: #151a2d;
+  color: #4a4f62;
 }
 
 .cache-1nn49go {
@@ -918,8 +918,8 @@ exports[`VolumeSize renders correctly without maxSize 1`] = `
   animation: animation-0 1.2s ease backwards;
 }
 
-.cache-va7ax2 {
-  background-color: #151a2d;
+.cache-1u1skqp {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -975,7 +975,7 @@ exports[`VolumeSize renders correctly without maxSize 1`] = `
           Test
         </span>
         <span
-          class="cache-143mwpp e21aiwm8"
+          class="cache-1rs4nfs e21aiwm8"
         >
           15 GB
         </span>
@@ -1000,7 +1000,7 @@ exports[`VolumeSize renders correctly without maxSize 1`] = `
         />
       </div>
       <div
-        class="cache-va7ax2 e21aiwm4"
+        class="cache-1u1skqp e21aiwm4"
       >
         <div
           class="cache-1mxpzd8 e21aiwm3"
@@ -1211,8 +1211,8 @@ exports[`VolumeSize should display too big error 1`] = `
   animation: animation-0 1.2s ease backwards;
 }
 
-.cache-bj2ss9 {
-  background-color: #151a2d;
+.cache-rd7h08 {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -1253,8 +1253,8 @@ exports[`VolumeSize should display too big error 1`] = `
   line-height: 22px;
 }
 
-.cache-w7q5zf {
-  background-color: #151a2d;
+.cache-1qpjbs8 {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -1326,7 +1326,7 @@ exports[`VolumeSize should display too big error 1`] = `
         />
       </div>
       <div
-        class="cache-bj2ss9 e21aiwm4"
+        class="cache-rd7h08 e21aiwm4"
       >
         <div
           class="cache-1mxpzd8 e21aiwm3"
@@ -1344,7 +1344,7 @@ exports[`VolumeSize should display too big error 1`] = `
         </div>
       </div>
       <div
-        class="cache-w7q5zf e21aiwm4"
+        class="cache-1qpjbs8 e21aiwm4"
       >
         <div
           class="cache-d4wpn5 e21aiwm3"
@@ -1541,8 +1541,8 @@ exports[`VolumeSize should display too small error 1`] = `
   animation: animation-0 1.2s ease backwards;
 }
 
-.cache-va7ax2 {
-  background-color: #151a2d;
+.cache-1u1skqp {
+  background-color: #4a4f62;
   position: absolute;
   height: 15px;
   width: 3px;
@@ -1628,7 +1628,7 @@ exports[`VolumeSize should display too small error 1`] = `
         />
       </div>
       <div
-        class="cache-va7ax2 e21aiwm4"
+        class="cache-1u1skqp e21aiwm4"
       >
         <div
           class="cache-1mxpzd8 e21aiwm3"

--- a/src/components/VolumeSize/index.tsx
+++ b/src/components/VolumeSize/index.tsx
@@ -46,7 +46,7 @@ const StyledValue = styled('span', {
 })<{ hasError?: boolean }>`
   font-weight: 800;
   color: ${({ hasError, theme }) =>
-    hasError ? theme.colorsDeprecated.orange : theme.colorsDeprecated.gray950};
+    hasError ? theme.colors.warning.textWeak : theme.colors.neutral.text};
 `
 
 const StyledContainer = styled('div', {
@@ -63,7 +63,7 @@ const StyledContainer = styled('div', {
 const StyledVolumeContainer = styled('div', {
   shouldForwardProp: prop => !['size'].includes(prop.toString()),
 })<StyleProps>`
-  background-color: ${({ theme }) => theme.colorsDeprecated.gray200};
+  background-color: ${({ theme }) => theme.colors.primary.background};
   border-radius: 3px;
   position: relative;
 
@@ -76,7 +76,9 @@ const StyledVolume = styled('span', {
     !['percentUsed', 'hasError'].includes(prop.toString()),
 })<StyleProps>`
   background-color: ${({ hasError, theme }) =>
-    hasError ? theme.colorsDeprecated.orange : theme.colorsDeprecated.green};
+    hasError
+      ? theme.colors.warning.backgroundStrong
+      : theme.colors.success.backgroundStrong};
   border-radius: ${({ percentUsed = 0 }) =>
     percentUsed >= 100 ? '3px' : '3px 0 0 3px'};
   position: absolute;
@@ -94,7 +96,8 @@ const StyledCursor = styled('div', {
   shouldForwardProp: prop =>
     !['size', 'hasMaxSize', 'isMaxSize'].includes(prop.toString()),
 })<StyleProps>`
-  background-color: ${({ theme }) => theme.colorsDeprecated.gray950};
+  background-color: ${({ theme }) =>
+    theme.colors.neutral.backgroundStrongHover};
   position: absolute;
   height: ${({ size = 'medium' }) => (sizes[size] || 1) * 15}px;
   width: ${({ size = 'medium' }) => (sizes[size] || 1) * 3}px;


### PR DESCRIPTION
## Summary

## Type

- Migration

### Summarise concisely:

#### What is expected?

Migration of:

- Typography
- VerificationCode
- VolumeSize

⚠️ Component Typography couldn't be fully migrated as we are using a lot of:

```js
<Typography color="gray550">
```

we still need to be retro-compatible until all typography usage have been changes.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| Typography  | ![Screenshot 2021-12-14 at 18 01 54](https://user-images.githubusercontent.com/15812968/146045629-4f3519db-8329-4dc3-af46-dd338ba567d2.png) | ![Screenshot 2021-12-14 at 18 02 00](https://user-images.githubusercontent.com/15812968/146045644-6b259d12-c670-4cef-8d31-6701f8a059be.png) |
| VerificationCode  | ![Screenshot 2021-12-14 at 18 02 26](https://user-images.githubusercontent.com/15812968/146045732-0a12e25d-701c-4e90-984b-4c42d9f1e9b3.png) | ![Screenshot 2021-12-14 at 18 02 31](https://user-images.githubusercontent.com/15812968/146045780-94779f3f-aca1-439f-8169-8177dab8e89a.png) |
| VolumeSize  | ![Screenshot 2021-12-14 at 18 02 52](https://user-images.githubusercontent.com/15812968/146045808-3113afa3-1b64-4209-a1ed-abcf7b34426e.png) | ![Screenshot 2021-12-14 at 18 03 02](https://user-images.githubusercontent.com/15812968/146045837-ecee8a05-d09c-45eb-99fb-943c6078b003.png) |
