### PR TITLE
refactor(theme): migrate colors for Toaster, Tooltip, TooltipIcon, UnitInput

### DIFF
--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -25,38 +25,38 @@ const styles = {
     }
 
     &${PREFIX}__toast--success {
-      background-color: ${theme.colorsDeprecated.foam};
-      color: ${theme.colorsDeprecated.success};
+      background-color: ${theme.colors.success.background};
+      color: ${theme.colors.success.text};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colorsDeprecated.success};
+        background-color: ${theme.colors.success.backgroundStrong};
       }
     }
 
     &${PREFIX}__toast--info {
-      background-color: ${theme.colorsDeprecated.zumthor};
-      color: ${theme.colorsDeprecated.info};
+      background-color: ${theme.colors.info.background};
+      color: ${theme.colors.info.text};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colorsDeprecated.info};
+        background-color: ${theme.colors.info.backgroundStrong};
       }
     }
 
     &${PREFIX}__toast--warning {
-      background-color: ${theme.colorsDeprecated.pippin};
-      color: ${theme.colorsDeprecated.warning};
+      background-color: ${theme.colors.danger.background};
+      color: ${theme.colors.danger.text};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colorsDeprecated.warning};
+        background-color: ${theme.colors.danger.backgroundStrong};
       }
     }
 
     &${PREFIX}__toast--error {
-      background-color: ${theme.colorsDeprecated.pippin};
-      color: ${theme.colorsDeprecated.warning};
+      background-color: ${theme.colors.danger.background};
+      color: ${theme.colors.danger.text};
 
       ${PREFIX}__progress-bar {
-        background-color: ${theme.colorsDeprecated.warning};
+        background-color: ${theme.colors.danger.backgroundStrong};
       }
     }
   `,

--- a/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Tooltip render variant white 1`] = `
       Test
     </button>
   </div>
-  .cache-16ttv10 {
+  .cache-aseiph {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -30,12 +30,12 @@ exports[`Tooltip render variant white 1`] = `
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
   background-color: #fff;
-  color: #000;
+  color: #4a4f62;
   fill: #fff;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-16ttv10 {
+[data-enter] .cache-aseiph {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -53,7 +53,7 @@ exports[`Tooltip render variant white 1`] = `
       style="display: none; position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-16ttv10 e7ah3bn0"
+        class="ep3agpf0 cache-aseiph e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
@@ -93,7 +93,7 @@ exports[`Tooltip renders when child has a disabled props 1`] = `
       Test
     </button>
   </div>
-  .cache-1dtlim6 {
+  .cache-yh7xp3 {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -109,13 +109,13 @@ exports[`Tooltip renders when child has a disabled props 1`] = `
   -moz-transform: translate3d(0, -4px, 0);
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
-  background-color: #000;
+  background-color: #000000;
   color: #fff;
-  fill: #000;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  fill: #000000;
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-1dtlim6 {
+[data-enter] .cache-yh7xp3 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -132,7 +132,7 @@ exports[`Tooltip renders when child has a disabled props 1`] = `
       style="position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-1dtlim6 e7ah3bn0"
+        class="ep3agpf0 cache-yh7xp3 e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
@@ -166,7 +166,7 @@ exports[`Tooltip renders when child is a function 1`] = `
   >
     Test
   </button>
-  .cache-1dtlim6 {
+  .cache-yh7xp3 {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -182,13 +182,13 @@ exports[`Tooltip renders when child is a function 1`] = `
   -moz-transform: translate3d(0, -4px, 0);
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
-  background-color: #000;
+  background-color: #000000;
   color: #fff;
-  fill: #000;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  fill: #000000;
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-1dtlim6 {
+[data-enter] .cache-yh7xp3 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -205,7 +205,7 @@ exports[`Tooltip renders when child is a function 1`] = `
       style="position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-1dtlim6 e7ah3bn0"
+        class="ep3agpf0 cache-yh7xp3 e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
@@ -239,7 +239,7 @@ exports[`Tooltip renders when child is a string 1`] = `
   >
     Test
   </div>
-  .cache-1dtlim6 {
+  .cache-yh7xp3 {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -255,13 +255,13 @@ exports[`Tooltip renders when child is a string 1`] = `
   -moz-transform: translate3d(0, -4px, 0);
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
-  background-color: #000;
+  background-color: #000000;
   color: #fff;
-  fill: #000;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  fill: #000000;
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-1dtlim6 {
+[data-enter] .cache-yh7xp3 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -278,7 +278,7 @@ exports[`Tooltip renders when child is a string 1`] = `
       style="position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-1dtlim6 e7ah3bn0"
+        class="ep3agpf0 cache-yh7xp3 e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
@@ -328,7 +328,7 @@ exports[`Tooltip renders with visible=false 1`] = `
       Test
     </button>
   </div>
-  .cache-1dtlim6 {
+  .cache-yh7xp3 {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -344,13 +344,13 @@ exports[`Tooltip renders with visible=false 1`] = `
   -moz-transform: translate3d(0, -4px, 0);
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
-  background-color: #000;
+  background-color: #000000;
   color: #fff;
-  fill: #000;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  fill: #000000;
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-1dtlim6 {
+[data-enter] .cache-yh7xp3 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -368,7 +368,7 @@ exports[`Tooltip renders with visible=false 1`] = `
       style="display: none; position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-1dtlim6 e7ah3bn0"
+        class="ep3agpf0 cache-yh7xp3 e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"
@@ -407,7 +407,7 @@ exports[`Tooltip renders with visible=true 1`] = `
       Test
     </button>
   </div>
-  .cache-1dtlim6 {
+  .cache-yh7xp3 {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -423,13 +423,13 @@ exports[`Tooltip renders with visible=true 1`] = `
   -moz-transform: translate3d(0, -4px, 0);
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
-  background-color: #000;
+  background-color: #000000;
   color: #fff;
-  fill: #000;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  fill: #000000;
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-1dtlim6 {
+[data-enter] .cache-yh7xp3 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -446,7 +446,7 @@ exports[`Tooltip renders with visible=true 1`] = `
       style="position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-1dtlim6 e7ah3bn0"
+        class="ep3agpf0 cache-yh7xp3 e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -30,18 +30,18 @@ type TooltipPlacement =
 
 const variants = {
   black: ({ theme }: { theme: Theme }) => css`
-    background-color: ${theme.colorsDeprecated.black};
-    color: ${theme.colorsDeprecated.white};
-    fill: ${theme.colorsDeprecated.black};
+    background-color: ${theme.colors.neutral.backgroundStrongHover};
+    color: ${theme.colors.neutral.textStrong};
+    fill: ${theme.colors.neutral.backgroundStrongHover};
     box-shadow: 0 2px 5px 5px
-      ${transparentize(0.7, theme.colorsDeprecated.shadow)};
+      ${transparentize(0.7, theme.colors.neutral.border)};
   `,
   white: ({ theme }: { theme: Theme }) => css`
-    background-color: ${theme.colorsDeprecated.white};
-    color: ${theme.colorsDeprecated.black};
-    fill: ${theme.colorsDeprecated.white};
+    background-color: ${theme.colors.neutral.backgroundWeak};
+    color: ${theme.colors.neutral.text};
+    fill: ${theme.colors.neutral.backgroundWeak};
     box-shadow: 0 2px 5px 5px
-      ${transparentize(0.7, theme.colorsDeprecated.shadow)};
+      ${transparentize(0.7, theme.colors.neutral.border)};
   `,
 }
 

--- a/src/components/TooltipIcon/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/TooltipIcon/__tests__/__snapshots__/index.tsx.snap
@@ -27,7 +27,7 @@ exports[`TooltipIcon renders with default props 1`] = `
       />
     </svg>
   </div>
-  .cache-1dtlim6 {
+  .cache-yh7xp3 {
   border-radius: 4px;
   opacity: 0;
   font-size: 0.8rem;
@@ -43,13 +43,13 @@ exports[`TooltipIcon renders with default props 1`] = `
   -moz-transform: translate3d(0, -4px, 0);
   -ms-transform: translate3d(0, -4px, 0);
   transform: translate3d(0, -4px, 0);
-  background-color: #000;
+  background-color: #000000;
   color: #fff;
-  fill: #000;
-  box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
+  fill: #000000;
+  box-shadow: 0 2px 5px 5px rgba(246,246,248,0.3);
 }
 
-[data-enter] .cache-1dtlim6 {
+[data-enter] .cache-yh7xp3 {
   opacity: 1;
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);
@@ -67,7 +67,7 @@ exports[`TooltipIcon renders with default props 1`] = `
       style="display: none; position: fixed; left: 100%; top: 100%; pointer-events: none;"
     >
       <div
-        class="ep3agpf0 cache-1dtlim6 e7ah3bn0"
+        class="ep3agpf0 cache-yh7xp3 e7ah3bn0"
       >
         <div
           style="font-size: 16px; width: 1em; height: 1em; pointer-events: none; top: 100%;"

--- a/src/components/UnitInput/index.tsx
+++ b/src/components/UnitInput/index.tsx
@@ -20,8 +20,8 @@ const CustomTextBox = styled(TextBox)`
     &:hover,
     &:focus {
       text-decoration: none;
-      border-color: ${({ theme }) => theme.colors.primary.border};
-      border-right: 1px solid ${({ theme }) => theme.colors.primary.border};
+      border-color: ${({ theme }) => theme.colors.primary.borderWeak};
+      border-right: 1px solid ${({ theme }) => theme.colors.primary.borderWeak};
       z-index: 1;
       padding-right: 7px; // so it doesn't move rich select
     }
@@ -32,7 +32,7 @@ const CustomRichSelect = styled(RichSelect)`
   &:hover,
   &:focus {
     text-decoration: none;
-    border-color: ${({ theme }) => theme.colors.primary.border};
+    border-color: ${({ theme }) => theme.colors.primary.borderWeak};
     box-shadow: none;
   }
 `

--- a/src/components/UnitInput/index.tsx
+++ b/src/components/UnitInput/index.tsx
@@ -20,8 +20,8 @@ const CustomTextBox = styled(TextBox)`
     &:hover,
     &:focus {
       text-decoration: none;
-      border-color: ${({ theme }) => theme.colorsDeprecated.primary};
-      border-right: 1px solid ${({ theme }) => theme.colorsDeprecated.primary};
+      border-color: ${({ theme }) => theme.colors.primary.border};
+      border-right: 1px solid ${({ theme }) => theme.colors.primary.border};
       z-index: 1;
       padding-right: 7px; // so it doesn't move rich select
     }
@@ -32,7 +32,7 @@ const CustomRichSelect = styled(RichSelect)`
   &:hover,
   &:focus {
     text-decoration: none;
-    border-color: ${({ theme }) => theme.colorsDeprecated.primary};
+    border-color: ${({ theme }) => theme.colors.primary.border};
     box-shadow: none;
   }
 `

--- a/src/theme/__tests__/index.ts
+++ b/src/theme/__tests__/index.ts
@@ -94,7 +94,7 @@ describe('createTheme', () => {
           backgroundWeakHover: '#4a4f62',
           backgroundWeakDisabled: '#ff0000',
           backgroundStrong: '#4a4f62',
-          backgroundStrongHover: '#4a4f62',
+          backgroundStrongHover: '#ff0000',
           backgroundStrongDisabled: '#b2b6c3',
           text: '#4a4f62',
           textHover: '#151a2d',

--- a/src/theme/colors/index.ts
+++ b/src/theme/colors/index.ts
@@ -38,7 +38,7 @@ const generateTokens = ({
       backgroundWeakHover: contrast[800],
       backgroundWeakDisabled: contrast[100],
       backgroundStrong: contrast[800],
-      backgroundStrongHover: contrast[800],
+      backgroundStrongHover: contrast[1000],
       backgroundStrongDisabled: contrast[700],
 
       // Text


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### The following changes where made:

Refactor Toaster, Tooltip, TooltipIcon, UnitInput to use the new colors.
As discussed with @matthprost, I had to change `backgroundStrongHover` to a pure black for tooltips background.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| Tooltip  | ![Screenshot 2021-12-20 at 14 44 28](https://user-images.githubusercontent.com/43268759/146776561-f4ccc052-efda-4cd2-891f-247e46ac4e16.png) | ![Screenshot 2021-12-20 at 14 44 04](https://user-images.githubusercontent.com/43268759/146776478-9610afb1-f221-41de-98bc-f623bff1359a.png) |
| Toaster  | ![Screenshot 2021-12-20 at 14 45 18](https://user-images.githubusercontent.com/43268759/146776675-d694ac0f-aaa5-4b52-bf76-9c4735f60158.png) | ![Screenshot 2021-12-20 at 14 45 00](https://user-images.githubusercontent.com/43268759/146776629-ea699acd-3b95-4703-a2c7-ff2fe2bca6e9.png) |
| UnitInput | ![Screenshot 2021-12-20 at 14 46 05](https://user-images.githubusercontent.com/43268759/146776785-a167eb66-c604-4ade-bea5-9c603bf91934.png) | ![Screenshot 2021-12-20 at 14 45 49](https://user-images.githubusercontent.com/43268759/146776748-eee88c7f-7482-4ed7-9c8b-306e458a6b08.png) |