### PR TITLE
refactor(tags): add a11y

### DIFF
--- a/src/__tests__/a11y.test.tsx
+++ b/src/__tests__/a11y.test.tsx
@@ -18,6 +18,8 @@ const testedComponents = [
   'StealthCopiable',
   'Toaster',
   'TooltipIcon',
+  'Tag',
+  'Tags',
 ]
 
 const foundFiles: string[] = []

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -114,6 +114,7 @@ const Tag: FunctionComponent<TagProps> = ({
         onClick={!isLoading ? onClose : undefined}
         variant={variant}
         disabled={disabled}
+        aria-label="Close tag"
       >
         {isLoading ? (
           <ActivityIndicator active size={16} />

--- a/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
@@ -2168,7 +2168,7 @@ exports[`Tags renders correctly when variant = bordered 1`] = `
       <button
         aria-disabled="false"
         aria-label="Close tag"
-        class="e1vt8sjg0 e1kgqxfn0 cache-1ntajoh e7ah3bn0"
+        class="e1vt8sjg0 e1kgqxfn0 cache-pdpx4q e7ah3bn0"
         type="button"
       >
         <svg
@@ -2192,12 +2192,8 @@ exports[`Tags renders correctly when variant = bordered 1`] = `
       </span>
       <button
         aria-disabled="false"
-<<<<<<< HEAD
-        class="e1vt8sjg0 e1kgqxfn0 cache-pdpx4q e7ah3bn0"
-=======
         aria-label="Close tag"
-        class="e1vt8sjg0 e1kgqxfn0 cache-1ntajoh e7ah3bn0"
->>>>>>> 3226b63a (fix: update snapshots)
+        class="e1vt8sjg0 e1kgqxfn0 cache-pdpx4q e7ah3bn0"
         type="button"
       >
         <svg

--- a/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
@@ -149,6 +149,7 @@ exports[`Tags add tag from input 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -173,6 +174,7 @@ exports[`Tags add tag from input 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -197,6 +199,7 @@ exports[`Tags add tag from input 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -371,6 +374,7 @@ exports[`Tags add tag from input with error 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -395,6 +399,7 @@ exports[`Tags add tag from input with error 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -569,6 +574,7 @@ exports[`Tags add tag on paste 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -593,6 +599,7 @@ exports[`Tags add tag on paste 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -617,6 +624,7 @@ exports[`Tags add tag on paste 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -791,6 +799,7 @@ exports[`Tags add tag on paste with error 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -815,6 +824,7 @@ exports[`Tags add tag on paste with error 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -989,6 +999,7 @@ exports[`Tags delete tag 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1163,6 +1174,7 @@ exports[`Tags delete tag with backspace 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1365,6 +1377,7 @@ exports[`Tags delete tag with error 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1389,6 +1402,7 @@ exports[`Tags delete tag with error 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1587,6 +1601,7 @@ exports[`Tags renders correctly when disabled 1`] = `
       </span>
       <button
         aria-disabled="true"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         disabled=""
         type="button"
@@ -1612,6 +1627,7 @@ exports[`Tags renders correctly when disabled 1`] = `
       </span>
       <button
         aria-disabled="true"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         disabled=""
         type="button"
@@ -1755,6 +1771,7 @@ exports[`Tags renders correctly when manualInput is disabled 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1779,6 +1796,7 @@ exports[`Tags renders correctly when manualInput is disabled 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1945,6 +1963,7 @@ exports[`Tags renders correctly when variant = base 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -1969,6 +1988,7 @@ exports[`Tags renders correctly when variant = base 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2147,7 +2167,8 @@ exports[`Tags renders correctly when variant = bordered 1`] = `
       </span>
       <button
         aria-disabled="false"
-        class="e1vt8sjg0 e1kgqxfn0 cache-pdpx4q e7ah3bn0"
+        aria-label="Close tag"
+        class="e1vt8sjg0 e1kgqxfn0 cache-1ntajoh e7ah3bn0"
         type="button"
       >
         <svg
@@ -2171,7 +2192,12 @@ exports[`Tags renders correctly when variant = bordered 1`] = `
       </span>
       <button
         aria-disabled="false"
+<<<<<<< HEAD
         class="e1vt8sjg0 e1kgqxfn0 cache-pdpx4q e7ah3bn0"
+=======
+        aria-label="Close tag"
+        class="e1vt8sjg0 e1kgqxfn0 cache-1ntajoh e7ah3bn0"
+>>>>>>> 3226b63a (fix: update snapshots)
         type="button"
       >
         <svg
@@ -2341,6 +2367,7 @@ exports[`Tags renders correctly when variant = no-border 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2365,6 +2392,7 @@ exports[`Tags renders correctly when variant = no-border 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2601,6 +2629,7 @@ exports[`Tags renders correctly with some tags 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2625,6 +2654,7 @@ exports[`Tags renders correctly with some tags 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2798,6 +2828,7 @@ exports[`Tags renders correctly with some tags 2`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2822,6 +2853,7 @@ exports[`Tags renders correctly with some tags 2`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -2995,6 +3027,7 @@ exports[`Tags renders correctly with some tags as objects 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -3019,6 +3052,7 @@ exports[`Tags renders correctly with some tags as objects 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -3192,6 +3226,7 @@ exports[`Tags renders correctly with some tags objects 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >
@@ -3216,6 +3251,7 @@ exports[`Tags renders correctly with some tags objects 1`] = `
       </span>
       <button
         aria-disabled="false"
+        aria-label="Close tag"
         class="e1vt8sjg0 e1kgqxfn0 cache-1ndoc0x e7ah3bn0"
         type="button"
       >

--- a/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Tags/__tests__/__snapshots__/index.tsx.snap
@@ -214,6 +214,7 @@ exports[`Tags add tag from input 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -414,6 +415,7 @@ exports[`Tags add tag from input with error 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -639,6 +641,7 @@ exports[`Tags add tag on paste 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -839,6 +842,7 @@ exports[`Tags add tag on paste with error 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -1014,6 +1018,7 @@ exports[`Tags delete tag 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -1189,6 +1194,7 @@ exports[`Tags delete tag with backspace 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -1463,6 +1469,7 @@ exports[`Tags delete tag with error 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       id="test"
       name="radio"
@@ -2003,6 +2010,7 @@ exports[`Tags renders correctly when variant = base 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""
@@ -2207,6 +2215,7 @@ exports[`Tags renders correctly when variant = bordered 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""
@@ -2403,6 +2412,7 @@ exports[`Tags renders correctly when variant = no-border 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""
@@ -2466,6 +2476,7 @@ exports[`Tags renders correctly with base props 1`] = `
     class="cache-qibkhh"
   >
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder="Tags..."
@@ -2665,6 +2676,7 @@ exports[`Tags renders correctly with some tags 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""
@@ -2864,6 +2876,7 @@ exports[`Tags renders correctly with some tags 2`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""
@@ -3063,6 +3076,7 @@ exports[`Tags renders correctly with some tags as objects 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""
@@ -3262,6 +3276,7 @@ exports[`Tags renders correctly with some tags objects 1`] = `
       </button>
     </div>
     <input
+      aria-label="radio"
       class="cache-1qk78jd"
       name="radio"
       placeholder=""

--- a/src/components/Tags/index.tsx
+++ b/src/components/Tags/index.tsx
@@ -258,6 +258,7 @@ const Tags: VoidFunctionComponent<TagsProps> = ({
         <StyledInput
           id={id}
           name={name}
+          aria-label={name}
           type="text"
           placeholder={!tagsState.length ? placeholder : ''}
           value={input}


### PR DESCRIPTION
## Summary

## Type

- Migration

### Summarise concisely:

#### The following changes where made:

Add `aria-label` to the close button on `Tag` and `Tags`.
I asked @ iManu, no need to add the name of the tag in the `aria-label`.
