### PR TITLE
fix(type): allow extends of XstyledProps into scaleway form package

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -9,7 +9,7 @@ import React, {
   forwardRef,
 } from 'react'
 
-export interface XStyledProps {
+export type XStyledProps = {
   align?: string
   alignItems?: string
   alignSelf?: string


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

When we try to use directly type from component using Xstyled props  we have an issue on generated type

```
./src/index.ts → dist/index.d.ts...
src/components/TextBoxField/index.tsx(52,7): error TS4023: Exported variable 'TextBoxField' has or is using name 'XStyledProps' from external module "/root/dev/scaleway/team-console/scaleway-form/node_modules/@scaleway/ui/dist/index" but cannot be named.
src/components/CheckboxField/index.tsx(42,7): error TS4023: Exported variable 'CheckboxField' has or is using name 'XStyledProps' from external module "/root/dev/scaleway/team-console/scaleway-form/node_modules/@scaleway/ui/dist/index" but cannot be named.

[!] (plugin dts) Error: Failed to compile. Check the logs above.
src/index.ts
Error: Failed to compile. Check the logs above.
    at error (/root/dev/scaleway/team-console/scaleway-form/node_modules/rollup/dist/shared/rollup.js:160:30)
    at throwPluginError (/root/dev/scaleway/team-console/scaleway-form/node_modules/rollup/dist/shared/rollup.js:21831:12)
    at Object.error (/root/dev/scaleway/team-console/scaleway-form/node_modules/rollup/dist/shared/rollup.js:22556:20)
    at Object.error (/root/dev/scaleway/team-console/scaleway-form/node_modules/rollup/dist/shared/rollup.js:22008:42)
    at Object.transform (file:///root/dev/scaleway/team-console/scaleway-form/node_modules/rollup-plugin-dts/dist/rollup-plugin-dts.mjs:1572:26)
    at /root/dev/scaleway/team-console/scaleway-form/node_modules/rollup/dist/shared/rollup.js:22801:37
```

#### The following changes where made:

1. Interface seem to not support Partial Pick

This will allow to support Partial Pick on this https://github.com/scaleway/scaleway-form/pull/86

