### PR TITLE
fix(menu): add className to menu component

### DIFF
--- a/src/components/Menu/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Menu/__tests__/__snapshots__/index.tsx.snap
@@ -598,7 +598,7 @@ exports[`Menu placement renders "bottom" 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1ryynli-Popper {
+.cache-1w278hq {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -618,8 +618,10 @@ exports[`Menu placement renders "bottom" 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -629,16 +631,16 @@ exports[`Menu placement renders "bottom" 1`] = `
   pointer-events: none;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -646,23 +648,17 @@ exports[`Menu placement renders "bottom" 1`] = `
   transform: translateX(-50%);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   bottom: 100%;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -765,7 +761,7 @@ exports[`Menu placement renders "bottom" 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1ryynli-Popper"
+      class="cache-1w278hq epli4kt0"
       role="menu"
     >
       <button
@@ -803,7 +799,7 @@ exports[`Menu placement renders "bottom-end" 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1mwl1uh-Popper {
+.cache-14buoy1 {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -823,8 +819,10 @@ exports[`Menu placement renders "bottom-end" 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1mwl1uh-Popper:after,
-.cache-1mwl1uh-Popper:before {
+.cache-14buoy1:after,
+.cache-14buoy1:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -834,41 +832,35 @@ exports[`Menu placement renders "bottom-end" 1`] = `
   pointer-events: none;
 }
 
-.cache-1mwl1uh-Popper:after {
+.cache-14buoy1:after {
   border-color: transparent;
 }
 
-.cache-1mwl1uh-Popper:before {
+.cache-14buoy1:before {
   border-color: transparent;
 }
 
-.cache-1mwl1uh-Popper:after {
+.cache-14buoy1:after {
   margin-left: -9px;
   right: 24px;
 }
 
-.cache-1mwl1uh-Popper:before {
+.cache-14buoy1:before {
   margin-left: -11px;
   right: 24px;
 }
 
-.cache-1mwl1uh-Popper:after,
-.cache-1mwl1uh-Popper:before {
+.cache-14buoy1:after,
+.cache-14buoy1:before {
   bottom: 100%;
 }
 
-.cache-1mwl1uh-Popper:after {
+.cache-14buoy1:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-1mwl1uh-Popper:before {
+.cache-14buoy1:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1mwl1uh-Popper:after,
-.cache-1mwl1uh-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -971,7 +963,7 @@ exports[`Menu placement renders "bottom-end" 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1mwl1uh-Popper"
+      class="cache-14buoy1 epli4kt0"
       role="menu"
     >
       <button
@@ -1009,7 +1001,7 @@ exports[`Menu placement renders "bottom-start" 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-6hhpgn-Popper {
+.cache-bhm1in {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1029,8 +1021,10 @@ exports[`Menu placement renders "bottom-start" 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-6hhpgn-Popper:after,
-.cache-6hhpgn-Popper:before {
+.cache-bhm1in:after,
+.cache-bhm1in:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -1040,41 +1034,35 @@ exports[`Menu placement renders "bottom-start" 1`] = `
   pointer-events: none;
 }
 
-.cache-6hhpgn-Popper:after {
+.cache-bhm1in:after {
   border-color: transparent;
 }
 
-.cache-6hhpgn-Popper:before {
+.cache-bhm1in:before {
   border-color: transparent;
 }
 
-.cache-6hhpgn-Popper:after {
+.cache-bhm1in:after {
   margin-right: -9px;
   left: 24px;
 }
 
-.cache-6hhpgn-Popper:before {
+.cache-bhm1in:before {
   margin-right: -11px;
   left: 24px;
 }
 
-.cache-6hhpgn-Popper:after,
-.cache-6hhpgn-Popper:before {
+.cache-bhm1in:after,
+.cache-bhm1in:before {
   bottom: 100%;
 }
 
-.cache-6hhpgn-Popper:after {
+.cache-bhm1in:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-6hhpgn-Popper:before {
+.cache-bhm1in:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-6hhpgn-Popper:after,
-.cache-6hhpgn-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -1177,7 +1165,7 @@ exports[`Menu placement renders "bottom-start" 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-6hhpgn-Popper"
+      class="cache-bhm1in epli4kt0"
       role="menu"
     >
       <button
@@ -1215,7 +1203,7 @@ exports[`Menu placement renders "top" 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1vzyxvq-Popper {
+.cache-1wyumja {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1235,8 +1223,10 @@ exports[`Menu placement renders "top" 1`] = `
   box-shadow: 0 1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1vzyxvq-Popper:after,
-.cache-1vzyxvq-Popper:before {
+.cache-1wyumja:after,
+.cache-1wyumja:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -1246,16 +1236,16 @@ exports[`Menu placement renders "top" 1`] = `
   pointer-events: none;
 }
 
-.cache-1vzyxvq-Popper:after {
+.cache-1wyumja:after {
   border-color: transparent;
 }
 
-.cache-1vzyxvq-Popper:before {
+.cache-1wyumja:before {
   border-color: transparent;
 }
 
-.cache-1vzyxvq-Popper:after,
-.cache-1vzyxvq-Popper:before {
+.cache-1wyumja:after,
+.cache-1wyumja:before {
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -1263,23 +1253,17 @@ exports[`Menu placement renders "top" 1`] = `
   transform: translateX(-50%);
 }
 
-.cache-1vzyxvq-Popper:after,
-.cache-1vzyxvq-Popper:before {
+.cache-1wyumja:after,
+.cache-1wyumja:before {
   top: 100%;
 }
 
-.cache-1vzyxvq-Popper:after {
+.cache-1wyumja:after {
   border-top-color: #eeeeff;
 }
 
-.cache-1vzyxvq-Popper:before {
+.cache-1wyumja:before {
   border-top-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1vzyxvq-Popper:after,
-.cache-1vzyxvq-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -1382,7 +1366,7 @@ exports[`Menu placement renders "top" 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1vzyxvq-Popper"
+      class="cache-1wyumja epli4kt0"
       role="menu"
     >
       <button
@@ -1420,7 +1404,7 @@ exports[`Menu placement renders "top-end" 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-33fxg6-Popper {
+.cache-1hutdsy {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1440,8 +1424,10 @@ exports[`Menu placement renders "top-end" 1`] = `
   box-shadow: 0 1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-33fxg6-Popper:after,
-.cache-33fxg6-Popper:before {
+.cache-1hutdsy:after,
+.cache-1hutdsy:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -1451,41 +1437,35 @@ exports[`Menu placement renders "top-end" 1`] = `
   pointer-events: none;
 }
 
-.cache-33fxg6-Popper:after {
+.cache-1hutdsy:after {
   border-color: transparent;
 }
 
-.cache-33fxg6-Popper:before {
+.cache-1hutdsy:before {
   border-color: transparent;
 }
 
-.cache-33fxg6-Popper:after {
+.cache-1hutdsy:after {
   margin-left: -9px;
   right: 24px;
 }
 
-.cache-33fxg6-Popper:before {
+.cache-1hutdsy:before {
   margin-left: -11px;
   right: 24px;
 }
 
-.cache-33fxg6-Popper:after,
-.cache-33fxg6-Popper:before {
+.cache-1hutdsy:after,
+.cache-1hutdsy:before {
   top: 100%;
 }
 
-.cache-33fxg6-Popper:after {
+.cache-1hutdsy:after {
   border-top-color: #eeeeff;
 }
 
-.cache-33fxg6-Popper:before {
+.cache-1hutdsy:before {
   border-top-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-33fxg6-Popper:after,
-.cache-33fxg6-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -1588,7 +1568,7 @@ exports[`Menu placement renders "top-end" 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-33fxg6-Popper"
+      class="cache-1hutdsy epli4kt0"
       role="menu"
     >
       <button
@@ -1626,7 +1606,7 @@ exports[`Menu placement renders "top-start" 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1m3lko-Popper {
+.cache-2q9a45 {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1646,8 +1626,10 @@ exports[`Menu placement renders "top-start" 1`] = `
   box-shadow: 0 1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1m3lko-Popper:after,
-.cache-1m3lko-Popper:before {
+.cache-2q9a45:after,
+.cache-2q9a45:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -1657,41 +1639,35 @@ exports[`Menu placement renders "top-start" 1`] = `
   pointer-events: none;
 }
 
-.cache-1m3lko-Popper:after {
+.cache-2q9a45:after {
   border-color: transparent;
 }
 
-.cache-1m3lko-Popper:before {
+.cache-2q9a45:before {
   border-color: transparent;
 }
 
-.cache-1m3lko-Popper:after {
+.cache-2q9a45:after {
   margin-right: -9px;
   left: 24px;
 }
 
-.cache-1m3lko-Popper:before {
+.cache-2q9a45:before {
   margin-right: -11px;
   left: 24px;
 }
 
-.cache-1m3lko-Popper:after,
-.cache-1m3lko-Popper:before {
+.cache-2q9a45:after,
+.cache-2q9a45:before {
   top: 100%;
 }
 
-.cache-1m3lko-Popper:after {
+.cache-2q9a45:after {
   border-top-color: #eeeeff;
 }
 
-.cache-1m3lko-Popper:before {
+.cache-2q9a45:before {
   border-top-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1m3lko-Popper:after,
-.cache-1m3lko-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -1794,7 +1770,7 @@ exports[`Menu placement renders "top-start" 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1m3lko-Popper"
+      class="cache-2q9a45 epli4kt0"
       role="menu"
     >
       <button
@@ -1832,7 +1808,7 @@ exports[`Menu renders with Menu.Item 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1ryynli-Popper {
+.cache-1w278hq {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1852,8 +1828,10 @@ exports[`Menu renders with Menu.Item 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -1863,16 +1841,16 @@ exports[`Menu renders with Menu.Item 1`] = `
   pointer-events: none;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -1880,23 +1858,17 @@ exports[`Menu renders with Menu.Item 1`] = `
   transform: translateX(-50%);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   bottom: 100%;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -1999,7 +1971,7 @@ exports[`Menu renders with Menu.Item 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1ryynli-Popper"
+      class="cache-1w278hq epli4kt0"
       role="menu"
     >
       <button
@@ -2037,7 +2009,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1ryynli-Popper {
+.cache-1w278hq {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2057,8 +2029,10 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -2068,16 +2042,16 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   pointer-events: none;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -2085,23 +2059,17 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
   transform: translateX(-50%);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   bottom: 100%;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-17v6wgr-Item {
@@ -2223,7 +2191,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1ryynli-Popper"
+      class="cache-1w278hq epli4kt0"
       role="menu"
     >
       <button
@@ -2290,7 +2258,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1ryynli-Popper {
+.cache-1w278hq {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2310,8 +2278,10 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -2321,16 +2291,16 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   pointer-events: none;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -2338,23 +2308,17 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
   transform: translateX(-50%);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   bottom: 100%;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-42or70-Item {
@@ -2457,7 +2421,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1ryynli-Popper"
+      class="cache-1w278hq epli4kt0"
       role="menu"
     >
       <a
@@ -2495,7 +2459,7 @@ exports[`Menu renders with modal={false} 1`] = `
   box-shadow: 0 2px 5px 5px rgba(165,165,205,0.3);
 }
 
-.cache-1ryynli-Popper {
+.cache-1w278hq {
   background-color: #fcfcfd;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2515,8 +2479,10 @@ exports[`Menu renders with modal={false} 1`] = `
   box-shadow: 0 -1px 5px 3px rgba(246,246,248,0.15);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
+  left: 50%;
+  right: inherit;
   border: solid transparent;
   border-width: 9px;
   content: ' ';
@@ -2526,16 +2492,16 @@ exports[`Menu renders with modal={false} 1`] = `
   pointer-events: none;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-color: transparent;
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -2543,23 +2509,17 @@ exports[`Menu renders with modal={false} 1`] = `
   transform: translateX(-50%);
 }
 
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:after,
+.cache-1w278hq:before {
   bottom: 100%;
 }
 
-.cache-1ryynli-Popper:after {
+.cache-1w278hq:after {
   border-bottom-color: #ffffff;
 }
 
-.cache-1ryynli-Popper:before {
+.cache-1w278hq:before {
   border-bottom-color: rgba(165, 165, 205, 0.4);
-}
-
-.cache-1ryynli-Popper:after,
-.cache-1ryynli-Popper:before {
-  left: 50%;
-  right: inherit;
 }
 
 .cache-4z3b9a-Item {
@@ -2662,7 +2622,7 @@ exports[`Menu renders with modal={false} 1`] = `
     tabindex="-1"
   >
     <div
-      class="cache-1ryynli-Popper"
+      class="cache-1w278hq epli4kt0"
       role="menu"
     >
       <button

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,4 +1,5 @@
 import { Theme, css } from '@emotion/react'
+import styled from '@emotion/styled'
 import { transparentize } from 'polished'
 import PropTypes from 'prop-types'
 import React, { ComponentProps, FunctionComponent, ReactNode } from 'react'
@@ -89,7 +90,10 @@ const arrowPlacementStyles = {
 } as const
 
 type ArrowPlacement = keyof typeof arrowPlacementStyles
-
+type MenuListProps = {
+  align: AlignStyle
+  hasArrow: boolean
+}
 export const arrowPlacements = Object.keys(
   arrowPlacementStyles,
 ) as ArrowPlacement[]
@@ -99,43 +103,39 @@ type AlignStyle = {
   right?: string | null
 }
 
-const styles = {
-  align: (align: AlignStyle) => css`
-    &:after,
-    &:before {
-      left: ${align.left};
-      right: ${align.right};
-    }
-  `,
-  menu: (theme: Theme) => css`
-    background-color: ${theme.colors.neutral.backgroundWeak};
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-    justify-content: center;
-    color: ${theme.colors.neutral.text};
-    border-radius: 4px;
-    position: relative;
+const MenuList = styled.div<MenuListProps>`
+  &:after,
+  &:before {
+    left: ${({ align }) => align.left};
+    right: ${({ align }) => align.left};
+  }
+  background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.neutral.text};
+  border-radius: 4px;
+  position: relative;
 
-    &:after,
-    &:before {
-      border: solid transparent;
-      border-width: 9px;
-      content: ' ';
-      height: 0;
-      width: 0;
-      position: absolute;
-      pointer-events: none;
-    }
+  &:after,
+  &:before {
+    border: solid transparent;
+    border-width: 9px;
+    content: ' ';
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+  }
 
-    &:after {
-      border-color: transparent;
-    }
-    &:before {
-      border-color: transparent;
-    }
-  `,
-}
+  &:after {
+    border-color: transparent;
+  }
+  &:before {
+    border-color: transparent;
+  }
+`
 
 interface ChildrenProps {
   placement: ComponentProps<typeof Popper>['placement']
@@ -148,6 +148,7 @@ type MenuProps = Omit<ComponentProps<typeof Popper>, 'children'> & {
   ariaLabel?: string
   placement?: ArrowPlacement
   children?: ((props: ChildrenProps) => ReactNode) | ReactNode
+  className?: string
 }
 
 type MenuType = FunctionComponent<MenuProps> & { Item: typeof Item }
@@ -163,6 +164,7 @@ const Menu: MenuType = ({
   name = 'menu',
   placement = 'bottom',
   visible = false,
+  className = '',
 }) => (
   <Popper
     aria-label={ariaLabel}
@@ -173,21 +175,22 @@ const Menu: MenuType = ({
     name={name}
     placement={placement}
     visible={visible}
+    className={className}
   >
     {({ placement: localPlacement, toggle, visible: isOpen }) =>
       isOpen && (
-        <div
+        <MenuList
+          align={align}
+          hasArrow={hasArrow}
           role="menu"
-          css={[
-            styles.menu,
-            hasArrow && arrowPlacementStyles[localPlacement as ArrowPlacement],
-            styles.align(align),
-          ]}
+          css={
+            hasArrow && arrowPlacementStyles[localPlacement as ArrowPlacement]
+          }
         >
           {typeof children === 'function'
             ? children({ placement: localPlacement, toggle, visible })
             : children}
-        </div>
+        </MenuList>
       )
     }
   </Popper>
@@ -201,6 +204,7 @@ Menu.propTypes = {
   ariaLabel: PropTypes.string,
   baseId: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
+  className: PropTypes.string,
   disclosure: PropTypes.func.isRequired,
   hasArrow: PropTypes.bool,
   modal: PropTypes.bool,

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,3 +1,4 @@
+import { Theme, css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { transparentize } from 'polished'
 import PropTypes from 'prop-types'
@@ -5,7 +6,6 @@ import React, { ComponentProps, FunctionComponent, ReactNode } from 'react'
 import Popper from '../Popper'
 import Item from './Item'
 
-<<<<<<< HEAD
 const bottomStyles = (theme: Theme) => css`
   box-shadow: 0 -1px 5px 3px ${transparentize(0.85, theme.colors.neutral.backgroundStrong)};
   &:after,
@@ -90,20 +90,14 @@ const arrowPlacementStyles = {
 } as const
 
 type ArrowPlacement = keyof typeof arrowPlacementStyles
-=======
-type ArrowPlacement =
-  | 'bottom'
-  | 'bottom-end'
-  | 'bottom-start'
-  | 'top'
-  | 'top-end'
-  | 'top-start'
->>>>>>> 7f5c4ff1 (fix: nuke css attribute)
 type MenuListProps = {
   align: AlignStyle
   hasArrow: boolean
   placement: ArrowPlacement
 }
+export const arrowPlacements = Object.keys(
+  arrowPlacementStyles,
+) as ArrowPlacement[]
 
 type AlignStyle = {
   left?: string | null
@@ -139,37 +133,13 @@ const MenuList = styled.div<MenuListProps>`
     width: 0;
     position: absolute;
     pointer-events: none;
-    bottom: ${({ placement }) => (placement.includes('bottom') ? '100%' : '')};
-    top: ${({ placement }) => (placement.includes('top') ? '100%' : '')};
-    left: ${({ placement }) =>
-      !placement.includes('start') && !placement.includes('end') ? '50%' : ''};
-    transform: ${({ placement }) =>
-      !placement.includes('start') && !placement.includes('end')
-        ? 'translateX(-50%)'
-        : ''};
   }
 
   &:after {
     border-color: transparent;
-    border-bottom-color: ${({ theme, placement }) =>
-      placement.includes('bottom') && theme.colors.primary.borderStrong};
-    border-top-color: ${({ theme, placement }) =>
-      placement.includes('top') && theme.colors.primary.borderStrong};
-    margin-left: ${({ placement }) => placement.includes('end') && '-9px'};
-    right: ${({ placement }) => placement.includes('end') && '24px'};
-    margin-right: ${({ placement }) => placement.includes('start') && '-9px'};
-    left: ${({ placement }) => placement.includes('start') && '24px'};
   }
   &:before {
     border-color: transparent;
-    border-bottom-color: ${({ placement }) =>
-      placement.includes('bottom') && 'rgba(165, 165, 205, 0.4)'};
-    border-top-color: ${({ placement }) =>
-      placement.includes('top') && 'rgba(165, 165, 205, 0.4)'};
-    margin-left: ${({ placement }) => placement.includes('end') && '-11px'};
-    right: ${({ placement }) => placement.includes('end') && '24px'};
-    margin-right: ${({ placement }) => placement.includes('start') && '-11px'};
-    left: ${({ placement }) => placement.includes('start') && '24px'};
   }
   background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
   display: flex;
@@ -179,14 +149,8 @@ const MenuList = styled.div<MenuListProps>`
   color: ${({ theme }) => theme.colors.neutral.text};
   border-radius: 4px;
   position: relative;
-  box-shadow: ${({ placement, theme }) =>
-    placement.includes('bottom') &&
-    '0 -1px 5px 3px' +
-      `${transparentize(0.85, theme.colors.neutral.background)}`};
-  box-shadow: ${({ placement, theme }) =>
-    placement.includes('top') &&
-    '0 1px 5px 3px' +
-      `${transparentize(0.85, theme.colors.neutral.background)}`};
+  ${({ placement, theme }) =>
+    placement && arrowPlacementStyles[placement](theme)}
 `
 
 const Menu: MenuType = ({
@@ -243,14 +207,7 @@ Menu.propTypes = {
   hasArrow: PropTypes.bool,
   modal: PropTypes.bool,
   name: PropTypes.string,
-  placement: PropTypes.oneOf([
-    'bottom',
-    'top',
-    'bottom-end',
-    'bottom-start',
-    'top-end',
-    'top-start',
-  ]),
+  placement: PropTypes.oneOf<ArrowPlacement>(arrowPlacements),
   visible: PropTypes.bool,
 }
 

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -149,8 +149,8 @@ const MenuList = styled.div<MenuListProps>`
   color: ${({ theme }) => theme.colors.neutral.text};
   border-radius: 4px;
   position: relative;
-  ${({ placement, theme }) =>
-    placement && arrowPlacementStyles[placement](theme)}
+  ${({ placement, theme, hasArrow }) =>
+    hasArrow && arrowPlacementStyles[placement]?.(theme)}
 `
 
 const Menu: MenuType = ({
@@ -178,18 +178,18 @@ const Menu: MenuType = ({
     className={className}
   >
     {({ placement: localPlacement, toggle, visible: isOpen }) =>
-      isOpen && (
+      isOpen ? (
         <MenuList
           align={align}
           hasArrow={hasArrow}
-          placement={placement}
+          placement={localPlacement as ArrowPlacement}
           role="menu"
         >
           {typeof children === 'function'
             ? children({ placement: localPlacement, toggle, visible })
             : children}
         </MenuList>
-      )
+      ) : null
     }
   </Popper>
 )

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,4 +1,3 @@
-import { Theme, css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { transparentize } from 'polished'
 import PropTypes from 'prop-types'
@@ -6,6 +5,7 @@ import React, { ComponentProps, FunctionComponent, ReactNode } from 'react'
 import Popper from '../Popper'
 import Item from './Item'
 
+<<<<<<< HEAD
 const bottomStyles = (theme: Theme) => css`
   box-shadow: 0 -1px 5px 3px ${transparentize(0.85, theme.colors.neutral.backgroundStrong)};
   &:after,
@@ -90,52 +90,25 @@ const arrowPlacementStyles = {
 } as const
 
 type ArrowPlacement = keyof typeof arrowPlacementStyles
+=======
+type ArrowPlacement =
+  | 'bottom'
+  | 'bottom-end'
+  | 'bottom-start'
+  | 'top'
+  | 'top-end'
+  | 'top-start'
+>>>>>>> 7f5c4ff1 (fix: nuke css attribute)
 type MenuListProps = {
   align: AlignStyle
   hasArrow: boolean
+  placement: ArrowPlacement
 }
-export const arrowPlacements = Object.keys(
-  arrowPlacementStyles,
-) as ArrowPlacement[]
 
 type AlignStyle = {
   left?: string | null
   right?: string | null
 }
-
-const MenuList = styled.div<MenuListProps>`
-  &:after,
-  &:before {
-    left: ${({ align }) => align.left};
-    right: ${({ align }) => align.left};
-  }
-  background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
-  display: flex;
-  flex-direction: column;
-  text-align: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.colors.neutral.text};
-  border-radius: 4px;
-  position: relative;
-
-  &:after,
-  &:before {
-    border: solid transparent;
-    border-width: 9px;
-    content: ' ';
-    height: 0;
-    width: 0;
-    position: absolute;
-    pointer-events: none;
-  }
-
-  &:after {
-    border-color: transparent;
-  }
-  &:before {
-    border-color: transparent;
-  }
-`
 
 interface ChildrenProps {
   placement: ComponentProps<typeof Popper>['placement']
@@ -153,6 +126,69 @@ type MenuProps = Omit<ComponentProps<typeof Popper>, 'children'> & {
 
 type MenuType = FunctionComponent<MenuProps> & { Item: typeof Item }
 
+const MenuList = styled.div<MenuListProps>`
+  &:after,
+  &:before {
+    left: ${({ align }) => align.left};
+    right: ${({ align }) => align.right};
+
+    border: solid transparent;
+    border-width: 9px;
+    content: ' ';
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+    bottom: ${({ placement }) => (placement.includes('bottom') ? '100%' : '')};
+    top: ${({ placement }) => (placement.includes('top') ? '100%' : '')};
+    left: ${({ placement }) =>
+      !placement.includes('start') && !placement.includes('end') ? '50%' : ''};
+    transform: ${({ placement }) =>
+      !placement.includes('start') && !placement.includes('end')
+        ? 'translateX(-50%)'
+        : ''};
+  }
+
+  &:after {
+    border-color: transparent;
+    border-bottom-color: ${({ theme, placement }) =>
+      placement.includes('bottom') && theme.colors.primary.borderStrong};
+    border-top-color: ${({ theme, placement }) =>
+      placement.includes('top') && theme.colors.primary.borderStrong};
+    margin-left: ${({ placement }) => placement.includes('end') && '-9px'};
+    right: ${({ placement }) => placement.includes('end') && '24px'};
+    margin-right: ${({ placement }) => placement.includes('start') && '-9px'};
+    left: ${({ placement }) => placement.includes('start') && '24px'};
+  }
+  &:before {
+    border-color: transparent;
+    border-bottom-color: ${({ placement }) =>
+      placement.includes('bottom') && 'rgba(165, 165, 205, 0.4)'};
+    border-top-color: ${({ placement }) =>
+      placement.includes('top') && 'rgba(165, 165, 205, 0.4)'};
+    margin-left: ${({ placement }) => placement.includes('end') && '-11px'};
+    right: ${({ placement }) => placement.includes('end') && '24px'};
+    margin-right: ${({ placement }) => placement.includes('start') && '-11px'};
+    left: ${({ placement }) => placement.includes('start') && '24px'};
+  }
+  background-color: ${({ theme }) => theme.colors.neutral.backgroundWeak};
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.neutral.text};
+  border-radius: 4px;
+  position: relative;
+  box-shadow: ${({ placement, theme }) =>
+    placement.includes('bottom') &&
+    '0 -1px 5px 3px' +
+      `${transparentize(0.85, theme.colors.neutral.background)}`};
+  box-shadow: ${({ placement, theme }) =>
+    placement.includes('top') &&
+    '0 1px 5px 3px' +
+      `${transparentize(0.85, theme.colors.neutral.background)}`};
+`
+
 const Menu: MenuType = ({
   align = { left: '50%', right: 'inherit' },
   ariaLabel = 'menu',
@@ -164,7 +200,7 @@ const Menu: MenuType = ({
   name = 'menu',
   placement = 'bottom',
   visible = false,
-  className = '',
+  className,
 }) => (
   <Popper
     aria-label={ariaLabel}
@@ -182,10 +218,8 @@ const Menu: MenuType = ({
         <MenuList
           align={align}
           hasArrow={hasArrow}
+          placement={placement}
           role="menu"
-          css={
-            hasArrow && arrowPlacementStyles[localPlacement as ArrowPlacement]
-          }
         >
           {typeof children === 'function'
             ? children({ placement: localPlacement, toggle, visible })
@@ -209,7 +243,14 @@ Menu.propTypes = {
   hasArrow: PropTypes.bool,
   modal: PropTypes.bool,
   name: PropTypes.string,
-  placement: PropTypes.oneOf<ArrowPlacement>(arrowPlacements),
+  placement: PropTypes.oneOf([
+    'bottom',
+    'top',
+    'bottom-end',
+    'bottom-start',
+    'top-end',
+    'top-start',
+  ]),
   visible: PropTypes.bool,
 }
 


### PR DESCRIPTION
## Type

- Bug

### Summarise concisely:

#### What is expected?

Ability to add styled to  `<Menu>` component  ex: ```styled(Menu) more style here```

#### The following changes where made:

(Describe what you did)

1. add className to menu props

2. pass className to Popper inside the Menu

3.apply styled on menuList instead of css attribute

