### PR TITLE
build(rollup): add `preserveSymlinks` option

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -30,6 +30,7 @@ const external = id =>
 
 export default [{
   external,
+  preserveSymlinks: true,
   input: './src/index.ts',
   output: {
     dir: 'dist',


### PR DESCRIPTION
## Summary

## Type

- Build

### Summarise concisely:

Add `preserveSymlinks` to rollup