### PR TITLE
chore: 🤖 update visual testings cmds and related ci process

### DIFF
--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -2,7 +2,7 @@ name: Visual
 
 on:
   pull_request:
-    types: ["opened", "edited", "reopened", "synchronize"]
+    types: ['opened', 'edited', 'reopened', 'synchronize']
 
 jobs:
   build-storybook:
@@ -25,7 +25,7 @@ jobs:
     needs: [build-storybook]
     strategy:
       matrix:
-        filter: ["[A-C]", "D", "[E-Z]"]
+        filter: ['[A-C]', 'D', '[E-Z]']
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3.0.0
@@ -34,14 +34,14 @@ jobs:
         uses: actions/setup-node@v3.1.1
         with:
           node-version: 17
-          cache: "pnpm"
+          cache: 'pnpm'
       - run: pnpm install
       - uses: actions/cache@v3
         id: restore-build-visual
         with:
           path: ./*
           key: ${{ github.sha }}
-      - run: pnpm run test:visual -- --storiesFilter ^Components/${{ matrix.filter }}
+      - run: pnpm run test:visual:nobuild -- --storiesFilter ^Components/${{ matrix.filter }}
       - name: Archive screenshots
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ $ pnpm run lint
 $ pnpm run lint:fix
 ```
 
+#### Visual
+
+```sh
+$ pnpm run test:visual #Build the storybook and launch visual tests
+$ pnpm run test:visual:update #Build the storybook, launch visual tests and update screenshots
+$ pnpm run test:visual:nobuild # Launch visual tests without (re)building the storybook
+```
+
 ### Build
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
     "test:unit:watch": "pnpm run test:unit -- --watch",
     "test:unit:update": "pnpm run test:unit -- --updateSnapshot",
     "test:a11y": "LC_ALL=en_US.UTF-8 jest --config .jest/a11y.config.ts",
+    "test:visual": "pnpm run build:storybook-visual && pnpm loki test",
     "test:visual:update": "pnpm run build:storybook-visual && pnpm loki update",
-    "test:visual": "pnpm loki test",
+    "test:visual:nobuild": "pnpm loki test",
     "prepare": "husky install",
     "size": "pnpm run build && size-limit",
     "tokens:update": "./scripts/figma-synchronise-tokens.sh https://raw.githubusercontent.com/scaleway/design-tokens/main/tokens.json && pnpm prettier --write src/theme/tokens"


### PR DESCRIPTION
## Summary

## Type

- Chore
- Documentation

### Summarise concisely:

Clarify

#### What is expected?

`yarn test:visual` should build storybook in visual mode before launching test
CI should works as usual using `yarn test:visual:nobuild`

#### The following changes where made:

1. Update package.json test visual's scripts

2. Update CI to keep current behavior

3. Update documentation 