### PR TITLE
fix(badge): default size if wrong value is given

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -131,7 +131,7 @@ const Badge: FunctionComponent<BadgeProps> = ({
     [prominence, theme],
   )
 
-  const sizeValue = SIZES[size]
+  const sizeValue = SIZES[size] || SIZES.medium
 
   return (
     <StyledBox


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

If prop given doesn't exists we still set as medium as default size to avoid strange behavior.
