### PR TITLE
fix(Switch): avoid event bubbling on label click

### DIFF
--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -260,6 +260,7 @@ const Switch = ({
         width={width}
         aria-checked={checked}
         aria-disabled={disabled}
+        onClick={evt => evt.stopPropagation()}
       >
         {labeled === 'left' ? (
           <StyledLabelContent


### PR DESCRIPTION
## Summary

Clicking on label trigger an event which is bubbled up, we don't want that, event is already handled by the checkbox :)

## Type

- Bug
