### PR TITLE
fix: accessibility compatibility button & checkbox

### DIFF
--- a/src/__tests__/a11y.test.tsx
+++ b/src/__tests__/a11y.test.tsx
@@ -14,6 +14,8 @@ const testedComponents = [
   'Badge',
   'Bullet',
   'Counter',
+  'Button',
+  'Checkbox',
   'MarkDown',
   'Placeholder',
   'Reminder',
@@ -53,7 +55,6 @@ const searchFileFromDir = (startPath: string, filter: string) => {
     }
   }
 }
-
 // Check if a path was given as input argument, if not we check all stories
 if (process.argv[4]) {
   searchFileFromDir(process.argv[4], '.stories.tsx')

--- a/src/components/Button/__stories__/index.stories.tsx
+++ b/src/components/Button/__stories__/index.stories.tsx
@@ -24,7 +24,7 @@ Variants.decorators = [
   () => (
     <div style={{ display: 'flex', gap: 16 }}>
       {buttonVariants.map(variant => (
-        <Button key={variant} variant={variant}>
+        <Button ariaLabel="test" key={variant} variant={variant}>
           {variant}
         </Button>
       ))}
@@ -43,7 +43,9 @@ Sizes.decorators = [
     <div style={{ alignItems: 'center', display: 'flex', gap: 16 }}>
       {buttonSizes.map(size => (
         <div key={size}>
-          <Button size={size}>{size}</Button>
+          <Button ariaLabel="test" size={size}>
+            {size}
+          </Button>
         </div>
       ))}
     </div>
@@ -56,7 +58,13 @@ Disabled.parameters = {
     storyDescription: 'Set `disabled` using disabled property.',
   },
 }
-Disabled.decorators = [() => <Button disabled>Disabled</Button>]
+Disabled.decorators = [
+  () => (
+    <Button ariaLabel="test" disabled>
+      Disabled
+    </Button>
+  ),
+]
 
 export const Progress = Template.bind({})
 Progress.parameters = {
@@ -68,8 +76,12 @@ Progress.parameters = {
 Progress.decorators = [
   () => (
     <div style={{ display: 'flex', gap: 16 }}>
-      <Button progress="left">left progress</Button>
-      <Button progress="right">right progress</Button>
+      <Button ariaLabel="test" progress="left">
+        left progress
+      </Button>
+      <Button ariaLabel="test" progress="right">
+        right progress
+      </Button>
     </div>
   ),
 ]
@@ -84,8 +96,10 @@ Icons.parameters = {
 Icons.decorators = [
   () => (
     <div style={{ display: 'flex', gap: 16 }}>
-      <Button icon="lock" />
-      <Button icon="lock">With text</Button>
+      <Button ariaLabel="test" icon="lock" />
+      <Button ariaLabel="test" icon="lock">
+        With text
+      </Button>
     </div>
   ),
 ]
@@ -101,8 +115,8 @@ IconsSizes.decorators = [
     <div style={{ display: 'flex', gap: 16 }}>
       {[10, 18, 24, 32].map(size => (
         <Fragment key={size}>
-          <Button icon="lock" iconSize={size} />
-          <Button icon="lock" iconSize={size}>
+          <Button ariaLabel="test" icon="lock" iconSize={size} />
+          <Button ariaLabel="test" icon="lock" iconSize={size}>
             With text
           </Button>
         </Fragment>
@@ -121,10 +135,10 @@ IconsPositions.parameters = {
 IconsPositions.decorators = [
   () => (
     <div style={{ display: 'flex', gap: 16 }}>
-      <Button iconPosition="left" icon="lock">
+      <Button ariaLabel="test" iconPosition="left" icon="lock">
         Left
       </Button>
-      <Button iconPosition="right" icon="lock">
+      <Button ariaLabel="test" iconPosition="right" icon="lock">
         Right
       </Button>
     </div>
@@ -141,13 +155,25 @@ Action.decorators = [
   () => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px' }}>
       {icons.map(icon => (
-        <Button action key={icon} icon={icon} />
+        <Button ariaLabel="test" action key={icon} icon={icon} />
       ))}
       {buttonVariants.map(variant => (
-        <Button action icon="lock" key={variant} variant={variant} />
+        <Button
+          ariaLabel="test"
+          action
+          icon="lock"
+          key={variant}
+          variant={variant}
+        />
       ))}
       {buttonVariants.map(variant => (
-        <Button action="rounded" icon="lock" key={variant} variant={variant} />
+        <Button
+          ariaLabel="test"
+          action="rounded"
+          icon="lock"
+          key={variant}
+          variant={variant}
+        />
       ))}
     </div>
   ),
@@ -162,7 +188,7 @@ Extend.parameters = {
 }
 Extend.decorators = [
   () => (
-    <Button extend icon="plus">
+    <Button ariaLabel="test" extend icon="plus">
       Extend
     </Button>
   ),
@@ -175,7 +201,9 @@ Download.parameters = {
       'Use `download` prop if you want to make it a downloadable button.',
   },
 }
-Download.decorators = [() => <Button download icon="download" />]
+Download.decorators = [
+  () => <Button ariaLabel="test" download icon="download" />,
+]
 
 export const LinkDelegation = Template.bind({})
 LinkDelegation.parameters = {
@@ -186,7 +214,7 @@ LinkDelegation.parameters = {
 }
 LinkDelegation.decorators = [
   () => (
-    <Button to="https://scaleway.com" target="_blank">
+    <Button ariaLabel="test" to="https://scaleway.com" target="_blank">
       Scaleway
     </Button>
   ),
@@ -202,9 +230,25 @@ Tooltip.parameters = {
 Tooltip.decorators = [
   () => (
     <div style={{ display: 'flex', gap: 16 }}>
-      <Button action icon="lock" variant="primary" tooltip="I am locked" />
-      <Button icon="lock" variant="primary" tooltip="I am locked" />
-      <Button icon="lock" variant="primary" tooltip="I am locked">
+      <Button
+        ariaLabel="test"
+        action
+        icon="lock"
+        variant="primary"
+        tooltip="I am locked"
+      />
+      <Button
+        ariaLabel="test"
+        icon="lock"
+        variant="primary"
+        tooltip="I am locked"
+      />
+      <Button
+        ariaLabel="test"
+        icon="lock"
+        variant="primary"
+        tooltip="I am locked"
+      >
         Hover Me
       </Button>
     </div>

--- a/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -108,7 +108,9 @@ exports[`Button should render correctly loading 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -273,7 +275,9 @@ exports[`Button should render correctly loading with an icon 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -430,8 +434,10 @@ exports[`Button should render correctly when acting as Link 1`] = `
 
 <a
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1qc3a0r-StyledButton"
     href="/"
+    role="button"
   >
     <div
       class="cache-m245rk-StyledContent em6gco81"
@@ -521,8 +527,10 @@ exports[`Button should render correctly when acting as Link with disabled props 
 
 <button
     aria-disabled="true"
+    aria-label="test"
     class="em6gco80 cache-1xobvbf-StyledButton"
     disabled=""
+    role="button"
     to="/"
     type="button"
   >
@@ -608,8 +616,10 @@ exports[`Button should render correctly when acting as dom link 1`] = `
 
 <a
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
     href="/"
+    role="button"
   >
     <div
       class="cache-m245rk-StyledContent em6gco81"
@@ -699,8 +709,10 @@ exports[`Button should render correctly when disabled 1`] = `
 
 <button
     aria-disabled="true"
+    aria-label="test"
     class="em6gco80 cache-1xobvbf-StyledButton"
     disabled=""
+    role="button"
     type="button"
   >
     <div
@@ -805,7 +817,9 @@ exports[`Button should render correctly when extendable 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1ao361y-StyledButton-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -931,7 +945,9 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-itpguj-StyledButton-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1020,7 +1036,9 @@ exports[`Button should render correctly with a custom Icon 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1120,7 +1138,9 @@ exports[`Button should render correctly with a rounded action button 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1ccd12a-StyledButton-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1238,7 +1258,9 @@ exports[`Button should render correctly with a tooltip 1`] = `
     <button
       aria-describedby="test"
       aria-disabled="false"
+      aria-label="test"
       class="em6gco80 cache-uc00d9-StyledButton"
+      role="button"
       type="button"
     >
       <div
@@ -1350,7 +1372,9 @@ exports[`Button should render correctly with an action button 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1p64bz2-StyledButton-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1463,7 +1487,9 @@ exports[`Button should render correctly with an icon on the right 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1544,7 +1570,9 @@ exports[`Button should render correctly without a children 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   />
 </DocumentFragment>
@@ -1627,7 +1655,9 @@ exports[`Button should render correctly without a children and an icon 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1719,7 +1749,9 @@ exports[`Button size render large 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1803,7 +1835,9 @@ exports[`Button size render medium 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-65mvt1-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1887,7 +1921,9 @@ exports[`Button size render small 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-f7nmgp-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -1971,7 +2007,9 @@ exports[`Button size render xsmall 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-4qmceh-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2053,7 +2091,9 @@ exports[`Button size render xxsmall 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-6qy56i-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2138,7 +2178,9 @@ exports[`Button variant render info 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1khlqq0-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2235,7 +2277,9 @@ exports[`Button variant render info-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-gmdlxe-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2320,7 +2364,9 @@ exports[`Button variant render link 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-17m6xr9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2405,7 +2451,9 @@ exports[`Button variant render primary 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-uc00d9-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2502,7 +2550,9 @@ exports[`Button variant render primary-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-193295s-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2599,7 +2649,9 @@ exports[`Button variant render primary-soft-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1fupxmd-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2684,7 +2736,9 @@ exports[`Button variant render secondary 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-6ce20m-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2781,7 +2835,9 @@ exports[`Button variant render secondary-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1fupxmd-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2866,7 +2922,9 @@ exports[`Button variant render success 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1ec1kwm-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -2963,7 +3021,9 @@ exports[`Button variant render success-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-ktzlbq-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -3060,7 +3120,9 @@ exports[`Button variant render success-soft-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-epa6lq-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -3135,7 +3197,9 @@ exports[`Button variant render transparent 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1norfxg-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -3220,7 +3284,9 @@ exports[`Button variant render warning 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1kcayaw-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -3317,7 +3383,9 @@ exports[`Button variant render warning-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-1ritj0t-StyledButton"
+    role="button"
     type="button"
   >
     <div
@@ -3414,7 +3482,9 @@ exports[`Button variant render warning-soft-bordered 1`] = `
 
 <button
     aria-disabled="false"
+    aria-label="test"
     class="em6gco80 cache-147kb1l-StyledButton"
+    role="button"
     type="button"
   >
     <div

--- a/src/components/Button/__tests__/index.tsx
+++ b/src/components/Button/__tests__/index.tsx
@@ -15,78 +15,111 @@ describe('Button', () => {
   describe('variant', () => {
     buttonVariants.forEach(variant => {
       test(`render ${variant}`, () =>
-        shouldMatchEmotionSnapshot(<Button variant={variant}>Hello</Button>))
+        shouldMatchEmotionSnapshot(
+          <Button ariaLabel="test" variant={variant}>
+            Hello
+          </Button>,
+        ))
     })
   })
 
   describe('size', () => {
     buttonSizes.forEach(size => {
       test(`render ${size}`, () =>
-        shouldMatchEmotionSnapshot(<Button size={size}>Hello</Button>))
+        shouldMatchEmotionSnapshot(
+          <Button ariaLabel="test" size={size}>
+            Hello
+          </Button>,
+        ))
     })
   })
 
   test(`should render correctly when disabled`, () =>
-    shouldMatchEmotionSnapshot(<Button disabled>Hello</Button>))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" disabled>
+        Hello
+      </Button>,
+    ))
 
   test(`should render correctly without a children`, () =>
-    shouldMatchEmotionSnapshot(<Button />))
+    shouldMatchEmotionSnapshot(<Button ariaLabel="test" />))
 
   test(`should render correctly without a children and an icon`, () =>
-    shouldMatchEmotionSnapshot(<Button icon="check" />))
+    shouldMatchEmotionSnapshot(<Button ariaLabel="test" icon="check" />))
 
   test(`should render correctly with a custom Icon`, () =>
-    shouldMatchEmotionSnapshot(<Button icon={<SampleIcon />} />))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" icon={<SampleIcon />} />,
+    ))
 
   test(`should render correctly when acting as Link`, () =>
-    shouldMatchEmotionSnapshot(<Button to="/">Hello</Button>))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" to="/">
+        Hello
+      </Button>,
+    ))
 
   test(`should render correctly when acting as Link with disabled props`, () =>
     shouldMatchEmotionSnapshot(
-      <Button to="/" disabled>
+      <Button ariaLabel="test" to="/" disabled>
         Hello
       </Button>,
     ))
 
   test(`should render correctly when acting as dom link`, () =>
-    shouldMatchEmotionSnapshot(<Button href="/">Hello</Button>))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" href="/">
+        Hello
+      </Button>,
+    ))
 
   test(`should render correctly when extendable`, () =>
-    shouldMatchEmotionSnapshot(<Button extend>Hello</Button>))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" extend>
+        Hello
+      </Button>,
+    ))
 
   test(`should render correctly when extendable with an icon`, () =>
     shouldMatchEmotionSnapshot(
-      <Button extend icon="check">
+      <Button ariaLabel="test" extend icon="check">
         Hello
       </Button>,
     ))
 
   test(`should render correctly loading`, () =>
-    shouldMatchEmotionSnapshot(<Button progress>Hello</Button>))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" progress>
+        Hello
+      </Button>,
+    ))
 
   test(`should render correctly loading with an icon`, () =>
     shouldMatchEmotionSnapshot(
-      <Button progress icon="check" iconPosition="right">
+      <Button ariaLabel="test" progress icon="check" iconPosition="right">
         Hello
       </Button>,
     ))
 
   test(`should render correctly with an icon on the right`, () =>
     shouldMatchEmotionSnapshot(
-      <Button icon="check" iconPosition="right">
+      <Button ariaLabel="test" icon="check" iconPosition="right">
         Hello
       </Button>,
     ))
 
   test(`should render correctly with an action button`, () =>
-    shouldMatchEmotionSnapshot(<Button action icon="check" />))
+    shouldMatchEmotionSnapshot(<Button ariaLabel="test" action icon="check" />))
 
   test(`should render correctly with a rounded action button`, () =>
-    shouldMatchEmotionSnapshot(<Button action="rounded" icon="check" />))
+    shouldMatchEmotionSnapshot(
+      <Button ariaLabel="test" action="rounded" icon="check" />,
+    ))
 
   test(`should render correctly with a tooltip`, () =>
     shouldMatchEmotionSnapshot(
       <Button
+        ariaLabel="test"
         icon="check"
         tooltipBaseId="test"
         tooltip="world"

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -357,6 +357,7 @@ type ButtonProps = Omit<StyledButtonProps, 'variant' | 'size' | 'download'> & {
   innerRef: Ref<Element>
   size?: ButtonSize
   download?: boolean | string
+  ariaLabel: string
 }
 
 const FwdButton = ({
@@ -374,6 +375,7 @@ const FwdButton = ({
   to,
   tooltip,
   tooltipBaseId,
+  ariaLabel,
   type: elementType = 'button',
   variant = 'primary',
   ...props
@@ -397,6 +399,8 @@ const FwdButton = ({
         {...props}
         href={href}
         to={to}
+        aria-label={ariaLabel}
+        role="button"
         download={download}
         ref={innerRef}
         as={as}

--- a/src/components/ExtendedReminder/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/ExtendedReminder/__tests__/__snapshots__/index.tsx.snap
@@ -412,6 +412,7 @@ exports[`ExtendedReminder renders correctly with default values 1`] = `
       aria-disabled="false"
       class="edgwu7l0 em6gco80 cache-1y87d4u-StyledButton-StyledButtonLink"
       href="/"
+      role="button"
     >
       <div
         class="cache-i4evwh-StyledIconContainer em6gco82"
@@ -694,6 +695,7 @@ exports[`ExtendedReminder renders correctly with error variant 1`] = `
       aria-disabled="false"
       class="edgwu7l0 em6gco80 cache-1y87d4u-StyledButton-StyledButtonLink"
       href="/"
+      role="button"
     >
       <div
         class="cache-i4evwh-StyledIconContainer em6gco82"
@@ -976,6 +978,7 @@ exports[`ExtendedReminder renders correctly with success variant 1`] = `
       aria-disabled="false"
       class="edgwu7l0 em6gco80 cache-1y87d4u-StyledButton-StyledButtonLink"
       href="/"
+      role="button"
     >
       <div
         class="cache-i4evwh-StyledIconContainer em6gco82"
@@ -1258,6 +1261,7 @@ exports[`ExtendedReminder renders correctly with warning variant 1`] = `
       aria-disabled="false"
       class="edgwu7l0 em6gco80 cache-1y87d4u-StyledButton-StyledButtonLink"
       href="/"
+      role="button"
     >
       <div
         class="cache-i4evwh-StyledIconContainer em6gco82"

--- a/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -27647,9 +27647,9 @@ exports[`List should render correctly with pagination 1`] = `
         <div>
           <button
             aria-disabled="true"
-            aria-label="First"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -27660,9 +27660,9 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Back"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -27673,8 +27673,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 1"
             class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -27685,8 +27685,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 2"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -27697,8 +27697,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 3"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -27709,8 +27709,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 4"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -27721,8 +27721,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 5"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -27733,8 +27733,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Next"
             class="em6gco80 cache-1p88unn-StyledButton"
+            role="button"
             type="button"
           >
             <div
@@ -27745,8 +27745,8 @@ exports[`List should render correctly with pagination 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Last"
             class="em6gco80 cache-uc00d9-StyledButton"
+            role="button"
             type="button"
           >
             <div
@@ -28599,9 +28599,9 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
         <div>
           <button
             aria-disabled="true"
-            aria-label="First"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -28612,9 +28612,9 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Back"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -28625,8 +28625,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 1"
             class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -28637,8 +28637,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 2"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -28649,8 +28649,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 3"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -28661,8 +28661,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 4"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -28673,8 +28673,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Page 5"
             class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+            role="button"
             type="button"
           >
             <div
@@ -28685,8 +28685,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Next"
             class="em6gco80 cache-1p88unn-StyledButton"
+            role="button"
             type="button"
           >
             <div
@@ -28697,8 +28697,8 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
           </button>
           <button
             aria-disabled="false"
-            aria-label="Last"
             class="em6gco80 cache-uc00d9-StyledButton"
+            role="button"
             type="button"
           >
             <div
@@ -29259,9 +29259,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
         <div>
           <button
             aria-disabled="true"
-            aria-label="First"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29272,9 +29272,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Back"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29285,9 +29285,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Page 1"
             class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29298,9 +29298,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Page 2"
             class="equt9o85 em6gco80 cache-a3hlc7-StyledButton-StyledPageButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29311,9 +29311,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Page 3"
             class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29324,9 +29324,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Page 4"
             class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29337,9 +29337,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Page 5"
             class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29350,9 +29350,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Next"
             class="em6gco80 cache-177ogp4-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div
@@ -29363,9 +29363,9 @@ exports[`List should render correctly with pagination and page loading 1`] = `
           </button>
           <button
             aria-disabled="true"
-            aria-label="Last"
             class="em6gco80 cache-1xobvbf-StyledButton"
             disabled=""
+            role="button"
             type="button"
           >
             <div

--- a/src/components/Menu/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Menu/__tests__/__snapshots__/index.tsx.snap
@@ -95,7 +95,7 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
 <button
     aria-disabled="false"
     class="em6gco80 cache-1q5v645-StyledButton-item-borderless-Item"
-    role="menuitem"
+    role="button"
     type="button"
   >
     <div
@@ -201,7 +201,7 @@ exports[`Menu Menu.Item render with default props 1`] = `
 <button
     aria-disabled="false"
     class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-    role="menuitem"
+    role="button"
     type="button"
   >
     <div
@@ -327,7 +327,7 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
     aria-disabled="true"
     class="em6gco80 cache-wgur7r-StyledButton-item-disabled-Item"
     disabled=""
-    role="menuitem"
+    role="button"
     type="button"
   >
     <div
@@ -448,7 +448,7 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
 <button
     aria-disabled="false"
     class="em6gco80 cache-1j6j4sq-StyledButton-item-danger-Item"
-    role="menuitem"
+    role="button"
     type="button"
   >
     <div
@@ -568,7 +568,7 @@ exports[`Menu Menu.Item render with variant nav 1`] = `
     aria-disabled="false"
     class="em6gco80 cache-1xr3k58-StyledButton-item-nav-Item"
     href="/test"
-    role="menuitem"
+    role="button"
   >
     <div
       class="cache-m245rk-StyledContent em6gco81"
@@ -766,7 +766,7 @@ exports[`Menu placement renders "bottom" 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -968,7 +968,7 @@ exports[`Menu placement renders "bottom-end" 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -1170,7 +1170,7 @@ exports[`Menu placement renders "bottom-start" 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -1371,7 +1371,7 @@ exports[`Menu placement renders "top" 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -1573,7 +1573,7 @@ exports[`Menu placement renders "top-end" 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -1775,7 +1775,7 @@ exports[`Menu placement renders "top-start" 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -1976,7 +1976,7 @@ exports[`Menu renders with Menu.Item 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -2197,7 +2197,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         aria-disabled="true"
         class="em6gco80 cache-wgur7r-StyledButton-item-disabled-Item"
         disabled=""
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -2210,7 +2210,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         aria-disabled="true"
         class="em6gco80 cache-wgur7r-StyledButton-item-disabled-Item"
         disabled=""
-        role="menuitem"
+        role="button"
         to="/link"
         type="button"
       >
@@ -2225,7 +2225,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         class="em6gco80 cache-wgur7r-StyledButton-item-disabled-Item"
         disabled=""
         href="https://link"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div
@@ -2427,7 +2427,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
         aria-disabled="false"
         class="em6gco80 cache-1jzzjdz-StyledButton-item-Item"
         href="/link"
-        role="menuitem"
+        role="button"
       >
         <div
           class="cache-m245rk-StyledContent em6gco81"
@@ -2627,7 +2627,7 @@ exports[`Menu renders with modal={false} 1`] = `
       <button
         aria-disabled="false"
         class="em6gco80 cache-1fbex2w-StyledButton-item-Item"
-        role="menuitem"
+        role="button"
         type="button"
       >
         <div

--- a/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -378,9 +378,9 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -391,9 +391,9 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -404,8 +404,8 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -416,8 +416,8 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -428,8 +428,8 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -440,8 +440,8 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -858,9 +858,9 @@ exports[`Pagination should render correctly component 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -871,9 +871,9 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -884,8 +884,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -896,8 +896,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -908,8 +908,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -920,8 +920,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -932,8 +932,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -944,8 +944,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -956,8 +956,8 @@ exports[`Pagination should render correctly component 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -1374,9 +1374,9 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -1387,9 +1387,9 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -1400,8 +1400,8 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1412,8 +1412,8 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1424,8 +1424,8 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1436,8 +1436,8 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -1448,8 +1448,8 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -1818,8 +1818,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
       <div>
         <button
           aria-disabled="false"
-          aria-label="First"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -1830,8 +1830,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Back"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -1842,8 +1842,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1854,8 +1854,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1866,8 +1866,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1878,8 +1878,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1890,8 +1890,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -1902,8 +1902,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -1914,8 +1914,8 @@ exports[`Pagination should render correctly controlled with page 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -2563,9 +2563,9 @@ exports[`Pagination should render correctly function 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -2576,9 +2576,9 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -2589,8 +2589,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -2601,8 +2601,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -2613,8 +2613,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -2625,8 +2625,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -2637,8 +2637,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -2649,8 +2649,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -2661,8 +2661,8 @@ exports[`Pagination should render correctly function 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -3034,9 +3034,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3047,9 +3047,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3060,9 +3060,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-a3hlc7-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3073,9 +3073,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3086,9 +3086,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3453,9 +3453,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3466,9 +3466,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3479,9 +3479,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3492,9 +3492,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -3505,9 +3505,9 @@ exports[`Pagination should render correctly loadable with no data and initial pa
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -4382,9 +4382,9 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -4395,9 +4395,9 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -4408,8 +4408,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4420,8 +4420,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4432,8 +4432,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4444,8 +4444,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4456,8 +4456,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4468,8 +4468,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -4480,8 +4480,8 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -4898,9 +4898,9 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -4911,9 +4911,9 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -4924,8 +4924,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4936,8 +4936,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4948,8 +4948,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4960,8 +4960,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4972,8 +4972,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -4984,8 +4984,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -4996,8 +4996,8 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -5441,9 +5441,9 @@ exports[`Pagination should render correctly perPage 0 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -5454,9 +5454,9 @@ exports[`Pagination should render correctly perPage 0 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -5467,8 +5467,8 @@ exports[`Pagination should render correctly perPage 0 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -5479,9 +5479,9 @@ exports[`Pagination should render correctly perPage 0 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -5492,9 +5492,9 @@ exports[`Pagination should render correctly perPage 0 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -5971,9 +5971,9 @@ exports[`Pagination should render correctly with controlled 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -5984,9 +5984,9 @@ exports[`Pagination should render correctly with controlled 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -5997,8 +5997,8 @@ exports[`Pagination should render correctly with controlled 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -6009,8 +6009,8 @@ exports[`Pagination should render correctly with controlled 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -6021,8 +6021,8 @@ exports[`Pagination should render correctly with controlled 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -6033,8 +6033,8 @@ exports[`Pagination should render correctly with controlled 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -6343,9 +6343,9 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6356,9 +6356,9 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6369,8 +6369,8 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -6381,9 +6381,9 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6394,9 +6394,9 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6689,9 +6689,9 @@ exports[`Pagination should render correctly with empty data 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6702,9 +6702,9 @@ exports[`Pagination should render correctly with empty data 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6715,8 +6715,8 @@ exports[`Pagination should render correctly with empty data 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -6727,9 +6727,9 @@ exports[`Pagination should render correctly with empty data 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -6740,9 +6740,9 @@ exports[`Pagination should render correctly with empty data 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -7035,9 +7035,9 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -7048,9 +7048,9 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -7061,8 +7061,8 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -7073,9 +7073,9 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -7086,9 +7086,9 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -7511,8 +7511,8 @@ exports[`Pagination should render correctly with initial page greater than max a
       <div>
         <button
           aria-disabled="false"
-          aria-label="First"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -7523,8 +7523,8 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="false"
-          aria-label="Back"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -7535,8 +7535,8 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 6"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -7547,8 +7547,8 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 7"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -7559,8 +7559,8 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 8"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -7571,8 +7571,8 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 9"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -7583,8 +7583,8 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 10"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -7595,9 +7595,9 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -7608,9 +7608,9 @@ exports[`Pagination should render correctly with initial page greater than max a
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8027,9 +8027,9 @@ exports[`Pagination should render correctly with initial page less than 1 and no
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8040,9 +8040,9 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8053,8 +8053,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -8065,8 +8065,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -8077,8 +8077,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -8089,8 +8089,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -8101,8 +8101,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -8113,8 +8113,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -8125,8 +8125,8 @@ exports[`Pagination should render correctly with initial page less than 1 and no
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -8942,9 +8942,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8955,9 +8955,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8968,9 +8968,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 6"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8981,9 +8981,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 7"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -8994,9 +8994,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 8"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9007,9 +9007,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 9"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9020,9 +9020,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 10"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9033,9 +9033,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9046,9 +9046,9 @@ exports[`Pagination should render correctly with pageClick and load and empty re
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9413,9 +9413,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9426,9 +9426,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9439,9 +9439,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 6"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9452,9 +9452,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 7"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9465,9 +9465,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 8"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9478,9 +9478,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 9"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9491,9 +9491,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Page 10"
           class="equt9o85 em6gco80 cache-1fsgl2j-StyledButton-StyledPageButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9504,9 +9504,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9517,9 +9517,9 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -9926,8 +9926,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
       <div>
         <button
           aria-disabled="false"
-          aria-label="First"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -9938,8 +9938,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Back"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -9950,8 +9950,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 46"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -9962,8 +9962,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 47"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -9974,8 +9974,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 48"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -9986,8 +9986,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 49"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -9998,8 +9998,8 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 50"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -10010,9 +10010,9 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Next"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -10023,9 +10023,9 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Last"
           class="em6gco80 cache-1xobvbf-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -10430,9 +10430,9 @@ exports[`Pagination should render correctly with setPageData 1`] = `
       <div>
         <button
           aria-disabled="true"
-          aria-label="First"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -10443,9 +10443,9 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="true"
-          aria-label="Back"
           class="em6gco80 cache-177ogp4-StyledButton"
           disabled=""
+          role="button"
           type="button"
         >
           <div
@@ -10456,8 +10456,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 1"
           class="equt9o85 em6gco80 cache-utetaf-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -10468,8 +10468,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 2"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -10480,8 +10480,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 3"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -10492,8 +10492,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 4"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -10504,8 +10504,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Page 5"
           class="equt9o85 em6gco80 cache-1p6jjrv-StyledButton-StyledPageButton"
+          role="button"
           type="button"
         >
           <div
@@ -10516,8 +10516,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Next"
           class="em6gco80 cache-1p88unn-StyledButton"
+          role="button"
           type="button"
         >
           <div
@@ -10528,8 +10528,8 @@ exports[`Pagination should render correctly with setPageData 1`] = `
         </button>
         <button
           aria-disabled="false"
-          aria-label="Last"
           class="em6gco80 cache-uc00d9-StyledButton"
+          role="button"
           type="button"
         >
           <div


### PR DESCRIPTION
## Summary

## Type

- Feature
- Refactor

### Summarise concisely:

#### What is expected?

In order to continue accessibility compatibility, we should re-check Button and Checkbox to make them accessible.

I've run a11y tests on those components and error went out of it, then solve them.

To test run ` pnpm test:a11y `
## Relevant logs and/or screenshots

