### PR TITLE
fix(tooltip): pointer event on tooltip arrow

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -72,6 +72,7 @@ const StyledTooltip = styled.div<{
     border-style: solid;
     border-color: ${({ theme }) => theme.colors.neutral.backgroundStronger}
       transparent transparent transparent;
+    pointer-events: none;
   }
 `
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There is an issue when you hover the tooltip arrow while the tooltip is closed, this is due to pointer events of the arrow.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | https://user-images.githubusercontent.com/15812968/176184504-fb92b038-31c0-47fb-b7ef-ef68455bb667.mov | https://user-images.githubusercontent.com/15812968/176184572-9f9d3d73-1478-40be-a60f-9d7915ebb48b.mov |
