### PR TITLE
docs: fixed description to bodyStrong migration

### DIFF
--- a/src/components/Typography/__stories__/migration.stories.mdx
+++ b/src/components/Typography/__stories__/migration.stories.mdx
@@ -58,7 +58,7 @@ const MyComponent = () => (
   - `bodyD` &rarr; `bodySmall`
   - `command` &rarr; *No equivalent*
   - `default` &rarr; `body`
-  - `description` &rarr; `bodySmallStronger`
+  - `description` &rarr; `bodyStrong`
   - `hero` &rarr; `headingLarge`
   - `lead` &rarr; `heading`
   - `lead-block` &rarr; `heading`


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Made a mistake in documentation for migration of `Typography` to `Text`: `description` should become `bodyStrong`