### PR TITLE
fix(link): correct wrong behavior

### DIFF
--- a/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Breadcrumbs/__tests__/__snapshots__/index.tsx.snap
@@ -101,9 +101,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1"
         >
-          <span>
-            Step 1
-          </span>
+          Step 1
         </a>
       </li>
       <li
@@ -114,9 +112,7 @@ exports[`Breadcrumbs renders correctly with default values 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1/step2"
         >
-          <span>
-            I'm a very long... long long step
-          </span>
+          I'm a very long... long long step
         </a>
       </li>
       <li
@@ -274,9 +270,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1"
         >
-          <span>
-            Step 1
-          </span>
+          Step 1
         </a>
       </li>
       <li
@@ -287,9 +281,7 @@ exports[`Breadcrumbs renders correctly with onClick 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1/step2"
         >
-          <span>
-            I'm a very long... long long step
-          </span>
+          I'm a very long... long long step
         </a>
       </li>
       <li
@@ -583,9 +575,7 @@ exports[`Breadcrumbs renders correctly with onClick on bubble variant 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1"
         >
-          <span>
-            Step 1
-          </span>
+          Step 1
         </a>
       </li>
       <li
@@ -596,9 +586,7 @@ exports[`Breadcrumbs renders correctly with onClick on bubble variant 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1/step2"
         >
-          <span>
-            I'm a very long... long long step
-          </span>
+          I'm a very long... long long step
         </a>
       </li>
       <li
@@ -714,9 +702,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1"
         >
-          <span>
-            Step 1
-          </span>
+          Step 1
         </a>
       </li>
       <li
@@ -728,9 +714,7 @@ exports[`Breadcrumbs renders correctly with selected item 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1/step2"
         >
-          <span>
-            I'm a very long... long long step
-          </span>
+          I'm a very long... long long step
         </a>
       </li>
       <li
@@ -925,9 +909,7 @@ exports[`Breadcrumbs renders correctly with variant bubble 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1"
         >
-          <span>
-            Step 1
-          </span>
+          Step 1
         </a>
       </li>
       <li
@@ -938,9 +920,7 @@ exports[`Breadcrumbs renders correctly with variant bubble 1`] = `
           class="cache-mlmgzv-StyledLink e4bq1r50"
           href="/step1/step2"
         >
-          <span>
-            I'm a very long... long long step
-          </span>
+          I'm a very long... long long step
         </a>
       </li>
       <li

--- a/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -148,7 +148,7 @@ exports[`Button should render correctly loading 1`] = `
       </svg>
     </div>
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -325,7 +325,7 @@ exports[`Button should render correctly loading with an icon 1`] = `
       </svg>
     </div>
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -347,7 +347,7 @@ exports[`Button should render correctly loading with an icon 1`] = `
 
 exports[`Button should render correctly when acting as Link 1`] = `
 <DocumentFragment>
-  .cache-h512rj-StyledLink-StyledButton {
+  .cache-1dcnir3-StyledLink-StyledLink-StyledButton {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -419,12 +419,12 @@ exports[`Button should render correctly when acting as Link 1`] = `
   color: #ffffff;
 }
 
-.cache-h512rj-StyledLink-StyledButton>* {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton>* {
   pointer-events: none;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover,
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   gap: 4px;
   outline: none;
   -webkit-text-decoration: underline;
@@ -434,28 +434,33 @@ exports[`Button should render correctly when acting as Link 1`] = `
   text-decoration-color: #390171;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover::after,
-.cache-h512rj-StyledLink-StyledButton:focus::after {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover::after,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus::after {
   background-color: #390171;
 }
 
-.cache-h512rj-StyledLink-StyledButton:active {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:active {
   text-decoration-thickness: 2px;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover,
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
+  gap: 8px;
+}
+
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover,
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   box-shadow: 0 0 0 2px rgba(57,1,113,0.25);
 }
 
@@ -476,23 +481,21 @@ exports[`Button should render correctly when acting as Link 1`] = `
 }
 
 <a
-    class="em6gco80 cache-h512rj-StyledLink-StyledButton e4bq1r50"
+    class="em6gco80 em6gco82 cache-1dcnir3-StyledLink-StyledLink-StyledButton e4bq1r50"
     href="/"
   >
-    <span>
-      <div
-        class="cache-m245rk-StyledContent em6gco82"
-      >
-        Hello
-      </div>
-    </span>
+    <div
+      class="cache-m245rk-StyledContent em6gco83"
+    >
+      Hello
+    </div>
   </a>
 </DocumentFragment>
 `;
 
 exports[`Button should render correctly when acting as Link 2`] = `
 <DocumentFragment>
-  .cache-1s4uy8p-StyledLink-StyledButton {
+  .cache-qcmowc-StyledLink-StyledLink-StyledButton {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -564,12 +567,12 @@ exports[`Button should render correctly when acting as Link 2`] = `
   color: #ffffff;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton>* {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton>* {
   pointer-events: none;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton:hover,
-.cache-1s4uy8p-StyledLink-StyledButton:focus {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:hover,
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:focus {
   gap: 4px;
   outline: none;
   -webkit-text-decoration: underline;
@@ -579,29 +582,34 @@ exports[`Button should render correctly when acting as Link 2`] = `
   text-decoration-color: #390171;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton:hover::after,
-.cache-1s4uy8p-StyledLink-StyledButton:focus::after {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:hover::after,
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:focus::after {
   background-color: #390171;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton:active {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:active {
   text-decoration-thickness: 2px;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton:hover,
-.cache-1s4uy8p-StyledLink-StyledButton:focus {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:hover,
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:focus {
+  gap: 8px;
+}
+
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:hover,
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   gap: 8px;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton:hover,
-.cache-1s4uy8p-StyledLink-StyledButton:focus {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:hover,
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-1s4uy8p-StyledLink-StyledButton:focus {
+.cache-qcmowc-StyledLink-StyledLink-StyledButton:focus {
   box-shadow: 0 0 0 2px rgba(57,1,113,0.25);
 }
 
@@ -642,18 +650,16 @@ exports[`Button should render correctly when acting as Link 2`] = `
 }
 
 <a
-    class="em6gco80 cache-1s4uy8p-StyledLink-StyledButton e4bq1r50"
+    class="em6gco80 em6gco82 cache-qcmowc-StyledLink-StyledLink-StyledButton e4bq1r50"
     href="/"
     rel="noopener noreferrer"
     target="_blank"
   >
-    <span>
-      <div
-        class="cache-m245rk-StyledContent em6gco82"
-      >
-        Hello
-      </div>
-    </span>
+    <div
+      class="cache-m245rk-StyledContent em6gco83"
+    >
+      Hello
+    </div>
     <span
       class="cache-1tang38-StyledExternalIconContainer e4bq1r51"
     >
@@ -755,7 +761,7 @@ exports[`Button should render correctly when acting as Link with disabled props 
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -765,7 +771,7 @@ exports[`Button should render correctly when acting as Link with disabled props 
 
 exports[`Button should render correctly when acting as dom link 1`] = `
 <DocumentFragment>
-  .cache-h512rj-StyledLink-StyledButton {
+  .cache-1dcnir3-StyledLink-StyledLink-StyledButton {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -837,12 +843,12 @@ exports[`Button should render correctly when acting as dom link 1`] = `
   color: #ffffff;
 }
 
-.cache-h512rj-StyledLink-StyledButton>* {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton>* {
   pointer-events: none;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover,
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   gap: 4px;
   outline: none;
   -webkit-text-decoration: underline;
@@ -852,28 +858,33 @@ exports[`Button should render correctly when acting as dom link 1`] = `
   text-decoration-color: #390171;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover::after,
-.cache-h512rj-StyledLink-StyledButton:focus::after {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover::after,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus::after {
   background-color: #390171;
 }
 
-.cache-h512rj-StyledLink-StyledButton:active {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:active {
   text-decoration-thickness: 2px;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover,
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
+  gap: 8px;
+}
+
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.cache-h512rj-StyledLink-StyledButton:hover,
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:hover,
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-h512rj-StyledLink-StyledButton:focus {
+.cache-1dcnir3-StyledLink-StyledLink-StyledButton:focus {
   box-shadow: 0 0 0 2px rgba(57,1,113,0.25);
 }
 
@@ -894,16 +905,14 @@ exports[`Button should render correctly when acting as dom link 1`] = `
 }
 
 <a
-    class="em6gco80 cache-h512rj-StyledLink-StyledButton e4bq1r50"
+    class="em6gco80 em6gco82 cache-1dcnir3-StyledLink-StyledLink-StyledButton e4bq1r50"
     href="/"
   >
-    <span>
-      <div
-        class="cache-m245rk-StyledContent em6gco82"
-      >
-        Hello
-      </div>
-    </span>
+    <div
+      class="cache-m245rk-StyledContent em6gco83"
+    >
+      Hello
+    </div>
   </a>
 </DocumentFragment>
 `;
@@ -992,7 +1001,7 @@ exports[`Button should render correctly when disabled 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -1002,7 +1011,7 @@ exports[`Button should render correctly when disabled 1`] = `
 
 exports[`Button should render correctly when extendable 1`] = `
 <DocumentFragment>
-  .cache-1485t75-StyledButton-StyledButton {
+  .cache-1403xh5-StyledButton-StyledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1043,23 +1052,23 @@ exports[`Button should render correctly when extendable 1`] = `
   display: inline-flex;
 }
 
-.cache-1485t75-StyledButton-StyledButton:hover,
-.cache-1485t75-StyledButton-StyledButton:focus {
+.cache-1403xh5-StyledButton-StyledButton:hover,
+.cache-1403xh5-StyledButton-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.cache-1485t75-StyledButton-StyledButton:hover,
-.cache-1485t75-StyledButton-StyledButton:focus {
+.cache-1403xh5-StyledButton-StyledButton:hover,
+.cache-1403xh5-StyledButton-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-1485t75-StyledButton-StyledButton:focus {
+.cache-1403xh5-StyledButton-StyledButton:focus {
   box-shadow: 0 0 0 2px rgba(57,1,113,0.25);
 }
 
-.cache-1485t75-StyledButton-StyledButton .em6gco82 {
+.cache-1403xh5-StyledButton-StyledButton .em6gco83 {
   -webkit-transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   max-width: 0;
@@ -1068,8 +1077,8 @@ exports[`Button should render correctly when extendable 1`] = `
   overflow: hidden;
 }
 
-.cache-1485t75-StyledButton-StyledButton:focus .em6gco82,
-.cache-1485t75-StyledButton-StyledButton:hover .em6gco82 {
+.cache-1403xh5-StyledButton-StyledButton:focus .em6gco83,
+.cache-1403xh5-StyledButton-StyledButton:hover .em6gco83 {
   max-width: 275px;
   margin-right: 8px;
   padding-left: 8px;
@@ -1093,11 +1102,11 @@ exports[`Button should render correctly when extendable 1`] = `
 
 <button
     aria-disabled="false"
-    class="em6gco80 cache-1485t75-StyledButton-StyledButton"
+    class="em6gco80 cache-1403xh5-StyledButton-StyledButton"
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -1107,7 +1116,7 @@ exports[`Button should render correctly when extendable 1`] = `
 
 exports[`Button should render correctly when extendable with an icon 1`] = `
 <DocumentFragment>
-  .cache-10bxndj-StyledButton-StyledButton {
+  .cache-3gc6k1-StyledButton-StyledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1148,23 +1157,23 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
   display: inline-flex;
 }
 
-.cache-10bxndj-StyledButton-StyledButton:hover,
-.cache-10bxndj-StyledButton-StyledButton:focus {
+.cache-3gc6k1-StyledButton-StyledButton:hover,
+.cache-3gc6k1-StyledButton-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.cache-10bxndj-StyledButton-StyledButton:hover,
-.cache-10bxndj-StyledButton-StyledButton:focus {
+.cache-3gc6k1-StyledButton-StyledButton:hover,
+.cache-3gc6k1-StyledButton-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-10bxndj-StyledButton-StyledButton:focus {
+.cache-3gc6k1-StyledButton-StyledButton:focus {
   box-shadow: 0 0 0 2px rgba(57,1,113,0.25);
 }
 
-.cache-10bxndj-StyledButton-StyledButton .em6gco82 {
+.cache-3gc6k1-StyledButton-StyledButton .em6gco83 {
   -webkit-transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   max-width: 0;
@@ -1173,8 +1182,8 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
   overflow: hidden;
 }
 
-.cache-10bxndj-StyledButton-StyledButton:focus .em6gco82,
-.cache-10bxndj-StyledButton-StyledButton:hover .em6gco82 {
+.cache-3gc6k1-StyledButton-StyledButton:focus .em6gco83,
+.cache-3gc6k1-StyledButton-StyledButton:hover .em6gco83 {
   max-width: 275px;
   margin-right: 8px;
   padding-right: 8x;
@@ -1219,7 +1228,7 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
 
 <button
     aria-disabled="false"
-    class="em6gco80 cache-10bxndj-StyledButton-StyledButton"
+    class="em6gco80 cache-3gc6k1-StyledButton-StyledButton"
     type="button"
   >
     <div
@@ -1235,7 +1244,7 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
       </svg>
     </div>
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -1543,7 +1552,7 @@ exports[`Button should render correctly with a tooltip 1`] = `
         </svg>
       </div>
       <div
-        class="cache-m245rk-StyledContent em6gco82"
+        class="cache-m245rk-StyledContent em6gco83"
       >
         Hello
       </div>
@@ -1757,7 +1766,7 @@ exports[`Button should render correctly with an icon on the right 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -1922,7 +1931,7 @@ exports[`Button should render correctly with as 1`] = `
       </svg>
     </div>
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2135,7 +2144,7 @@ exports[`Button should render correctly with progress left and icon right 1`] = 
       </svg>
     </div>
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2300,7 +2309,7 @@ exports[`Button should render correctly with progress right and icon left 1`] = 
       </svg>
     </div>
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2582,7 +2591,7 @@ exports[`Button size render large 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2666,7 +2675,7 @@ exports[`Button size render medium 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2750,7 +2759,7 @@ exports[`Button size render small 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2834,7 +2843,7 @@ exports[`Button size render xsmall 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -2916,7 +2925,7 @@ exports[`Button size render xxsmall 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3001,7 +3010,7 @@ exports[`Button variant render info 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3098,7 +3107,7 @@ exports[`Button variant render info-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3195,7 +3204,7 @@ exports[`Button variant render link 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3280,7 +3289,7 @@ exports[`Button variant render primary 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3377,7 +3386,7 @@ exports[`Button variant render primary-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3474,7 +3483,7 @@ exports[`Button variant render primary-soft-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3559,7 +3568,7 @@ exports[`Button variant render secondary 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3656,7 +3665,7 @@ exports[`Button variant render secondary-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3741,7 +3750,7 @@ exports[`Button variant render success 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3838,7 +3847,7 @@ exports[`Button variant render success-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -3935,7 +3944,7 @@ exports[`Button variant render success-soft-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -4010,7 +4019,7 @@ exports[`Button variant render transparent 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -4095,7 +4104,7 @@ exports[`Button variant render warning 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -4192,7 +4201,7 @@ exports[`Button variant render warning-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>
@@ -4289,7 +4298,7 @@ exports[`Button variant render warning-soft-bordered 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Hello
     </div>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -29,6 +29,14 @@ const StyledContent = styled.div`
   pointer-events: none;
 `
 
+// It will remove animation between Link and left icon that is implemented into Link component
+const StyledLink = styled(Link)`
+  &:hover,
+  &:focus {
+    gap: ${({ theme }) => theme.space['1']};
+  }
+`
+
 const borderedVariant = ({
   colorValue,
   bgColorValue,
@@ -401,7 +409,7 @@ const FwdButton = ({
   const as = useMemo(() => {
     if (disabled) return 'button'
     if (asProp) return asProp
-    if (href || download) return Link
+    if (href || download) return StyledLink
 
     return 'button'
   }, [disabled, href, download, asProp])

--- a/src/components/Link/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Link/__tests__/__snapshots__/index.tsx.snap
@@ -68,9 +68,7 @@ exports[`Link render correctly with bad variant 1`] = `
     class="cache-1rfggew-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -143,9 +141,7 @@ exports[`Link render correctly with href props 1`] = `
     class="cache-mlmgzv-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -238,9 +234,7 @@ exports[`Link render correctly with href props 2`] = `
         d="M5.29289 8.70735C4.90237 8.31683 4.90237 7.68366 5.29289 7.29314L9.29289 3.29314C9.68342 2.90261 10.3166 2.90261 10.7071 3.29314C11.0976 3.68366 11.0976 4.31683 10.7071 4.70735L7.41421 8.00024L10.7071 11.2931C11.0976 11.6837 11.0976 12.3168 10.7071 12.7074C10.3166 13.0979 9.68342 13.0979 9.29289 12.7074L5.29289 8.70735Z"
       />
     </svg>
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
   .cache-mlmgzv-StyledLink {
   background-color: transparent;
@@ -320,9 +314,7 @@ exports[`Link render correctly with href props 2`] = `
     class="cache-mlmgzv-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
     <svg
       class="sc-ui-icon etwatq50 cache-1gxgwfv-StyledIcon-sizeStyles"
       viewBox="0 0 16 16"
@@ -420,9 +412,7 @@ exports[`Link render correctly with href props 2`] = `
     rel="noopener noreferrer"
     target="_blank"
   >
-    <span>
-      Hello
-    </span>
+    Hello
     <span
       class="cache-1tang38-StyledExternalIconContainer e4bq1r51"
     >
@@ -524,9 +514,7 @@ exports[`Link render correctly with href props 2`] = `
     rel="noopener noreferrer"
     target="_blank"
   >
-    <span>
-      Hello
-    </span>
+    Hello
     <span
       class="cache-1tang38-StyledExternalIconContainer e4bq1r51"
     >
@@ -611,9 +599,7 @@ exports[`Link render correctly with no variant 1`] = `
     class="cache-mlmgzv-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -686,9 +672,7 @@ exports[`Link render correctly with sizes 1`] = `
     class="cache-mlmgzv-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
   ,
   .cache-u5thex-StyledLink {
@@ -757,9 +741,7 @@ exports[`Link render correctly with sizes 1`] = `
     class="cache-u5thex-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
   ,
 </DocumentFragment>
@@ -855,9 +837,7 @@ exports[`Link render correctly with target blank 1`] = `
     rel="noopener noreferrer"
     target="_blank"
   >
-    <span>
-      Hello
-    </span>
+    Hello
     <span
       class="cache-1tang38-StyledExternalIconContainer e4bq1r51"
     >
@@ -942,9 +922,7 @@ exports[`Link variant render danger 1`] = `
     class="cache-1kn1wsd-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -1017,9 +995,7 @@ exports[`Link variant render info 1`] = `
     class="cache-17qgxc4-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -1092,9 +1068,7 @@ exports[`Link variant render neutral 1`] = `
     class="cache-1rfggew-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -1167,9 +1141,7 @@ exports[`Link variant render primary 1`] = `
     class="cache-mlmgzv-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -1242,9 +1214,7 @@ exports[`Link variant render success 1`] = `
     class="cache-x7ygkl-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;
@@ -1317,9 +1287,7 @@ exports[`Link variant render warning 1`] = `
     class="cache-120nmsi-StyledLink e4bq1r50"
     href="/"
   >
-    <span>
-      Hello
-    </span>
+    Hello
   </a>
 </DocumentFragment>
 `;

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -136,7 +136,7 @@ const Link = forwardRef(
         {!isBlank && iconPosition === 'left' ? (
           <Icon name="arrow-left" size={ICON_SIZE} />
         ) : null}
-        <span>{children}</span>
+        {children}
 
         {isBlank ? (
           <StyledExternalIconContainer>

--- a/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -31403,7 +31403,7 @@ exports[`List should render correctly with pagination 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -31428,7 +31428,7 @@ exports[`List should render correctly with pagination 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -31492,7 +31492,7 @@ exports[`List should render correctly with pagination 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -31513,7 +31513,7 @@ exports[`List should render correctly with pagination 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32308,7 +32308,7 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32333,7 +32333,7 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32397,7 +32397,7 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32418,7 +32418,7 @@ exports[`List should render correctly with pagination and bad idKey 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32881,7 +32881,7 @@ exports[`List should render correctly with pagination and page loading 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32906,7 +32906,7 @@ exports[`List should render correctly with pagination and page loading 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32976,7 +32976,7 @@ exports[`List should render correctly with pagination and page loading 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg
@@ -32998,7 +32998,7 @@ exports[`List should render correctly with pagination and page loading 1`] = `
               type="button"
             >
               <div
-                class="cache-m245rk-StyledContent em6gco82"
+                class="cache-m245rk-StyledContent em6gco83"
               >
                 <div>
                   <svg

--- a/src/components/MarkDown/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/MarkDown/__tests__/__snapshots__/index.tsx.snap
@@ -60,7 +60,7 @@ exports[`MarkDown render simple string 1`] = `
   margin-top: 0;
 }
 
-.cache-17qgxc4-StyledLink {
+.cache-tgu88c-StyledLink-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -96,14 +96,15 @@ exports[`MarkDown render simple string 1`] = `
   line-height: 24px;
   paragraph-spacing: 0;
   text-case: none;
+  font-size: inherit;
 }
 
-.cache-17qgxc4-StyledLink>* {
+.cache-tgu88c-StyledLink-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-17qgxc4-StyledLink:hover,
-.cache-17qgxc4-StyledLink:focus {
+.cache-tgu88c-StyledLink-StyledLink:hover,
+.cache-tgu88c-StyledLink-StyledLink:focus {
   gap: 4px;
   outline: none;
   -webkit-text-decoration: underline;
@@ -113,12 +114,12 @@ exports[`MarkDown render simple string 1`] = `
   text-decoration-color: #1a4dbf;
 }
 
-.cache-17qgxc4-StyledLink:hover::after,
-.cache-17qgxc4-StyledLink:focus::after {
+.cache-tgu88c-StyledLink-StyledLink:hover::after,
+.cache-tgu88c-StyledLink-StyledLink:focus::after {
   background-color: #1a4dbf;
 }
 
-.cache-17qgxc4-StyledLink:active {
+.cache-tgu88c-StyledLink-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -177,13 +178,11 @@ exports[`MarkDown render simple string 1`] = `
         You can find the complete reference 
       </span>
       <a
-        class="cache-17qgxc4-StyledLink e4bq1r50"
+        class="ejtitxs1 cache-tgu88c-StyledLink-StyledLink e4bq1r50"
         href="https://commonmark.org/help/"
       >
         <span>
-          <span>
-            here
-          </span>
+          here
         </span>
       </a>
     </p>
@@ -232,7 +231,7 @@ exports[`MarkDown render simple string with target blank 1`] = `
   margin-top: 0;
 }
 
-.cache-17qgxc4-StyledLink {
+.cache-tgu88c-StyledLink-StyledLink {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -268,14 +267,15 @@ exports[`MarkDown render simple string with target blank 1`] = `
   line-height: 24px;
   paragraph-spacing: 0;
   text-case: none;
+  font-size: inherit;
 }
 
-.cache-17qgxc4-StyledLink>* {
+.cache-tgu88c-StyledLink-StyledLink>* {
   pointer-events: none;
 }
 
-.cache-17qgxc4-StyledLink:hover,
-.cache-17qgxc4-StyledLink:focus {
+.cache-tgu88c-StyledLink-StyledLink:hover,
+.cache-tgu88c-StyledLink-StyledLink:focus {
   gap: 4px;
   outline: none;
   -webkit-text-decoration: underline;
@@ -285,12 +285,12 @@ exports[`MarkDown render simple string with target blank 1`] = `
   text-decoration-color: #1a4dbf;
 }
 
-.cache-17qgxc4-StyledLink:hover::after,
-.cache-17qgxc4-StyledLink:focus::after {
+.cache-tgu88c-StyledLink-StyledLink:hover::after,
+.cache-tgu88c-StyledLink-StyledLink:focus::after {
   background-color: #1a4dbf;
 }
 
-.cache-17qgxc4-StyledLink:active {
+.cache-tgu88c-StyledLink-StyledLink:active {
   text-decoration-thickness: 2px;
 }
 
@@ -369,15 +369,13 @@ exports[`MarkDown render simple string with target blank 1`] = `
         You can find the complete reference 
       </span>
       <a
-        class="cache-17qgxc4-StyledLink e4bq1r50"
+        class="ejtitxs1 cache-tgu88c-StyledLink-StyledLink e4bq1r50"
         href="https://commonmark.org/help/"
         rel="noopener noreferrer"
         target="_blank"
       >
         <span>
-          <span>
-            here
-          </span>
+          here
         </span>
         <span
           class="cache-1tang38-StyledExternalIconContainer e4bq1r51"

--- a/src/components/MarkDown/index.tsx
+++ b/src/components/MarkDown/index.tsx
@@ -7,6 +7,10 @@ import Box, { BoxProps } from '../Box'
 import Link from '../Link'
 import Typography from '../Typography'
 
+const StyledLink = styled(Link)`
+  font-size: inherit;
+`
+
 const headingRenderer = ({
   node,
   children,
@@ -53,9 +57,9 @@ const linkRenderer = ({
   }
 
   return (
-    <Link variant="info" href={href} {...props}>
+    <StyledLink variant="info" href={href} {...props}>
       {children}
-    </Link>
+    </StyledLink>
   )
 }
 

--- a/src/components/Menu/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Menu/__tests__/__snapshots__/index.tsx.snap
@@ -99,7 +99,7 @@ exports[`Menu Menu.Item render with borderless props 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Borderless Props
     </div>
@@ -205,7 +205,7 @@ exports[`Menu Menu.Item render with default props 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Default Props
     </div>
@@ -331,7 +331,7 @@ exports[`Menu Menu.Item render with disabled props 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Disabled Props
     </div>
@@ -452,7 +452,7 @@ exports[`Menu Menu.Item render with variant danger 1`] = `
     type="button"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Danger
     </div>
@@ -571,7 +571,7 @@ exports[`Menu Menu.Item render with variant nav 1`] = `
     role="menuitem"
   >
     <div
-      class="cache-m245rk-StyledContent em6gco82"
+      class="cache-m245rk-StyledContent em6gco83"
     >
       Nav
     </div>
@@ -768,7 +768,7 @@ exports[`Menu placement renders "bottom" 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           bottom
         </div>
@@ -968,7 +968,7 @@ exports[`Menu placement renders "bottom-end" 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           bottom-end
         </div>
@@ -1168,7 +1168,7 @@ exports[`Menu placement renders "bottom-start" 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           bottom-start
         </div>
@@ -1367,7 +1367,7 @@ exports[`Menu placement renders "top" 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           top
         </div>
@@ -1567,7 +1567,7 @@ exports[`Menu placement renders "top-end" 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           top-end
         </div>
@@ -1767,7 +1767,7 @@ exports[`Menu placement renders "top-start" 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           top-start
         </div>
@@ -1966,7 +1966,7 @@ exports[`Menu renders with Menu.Item 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           Menu.Item
         </div>
@@ -2185,7 +2185,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           Menu.Item disabled
         </div>
@@ -2199,7 +2199,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           Menu.Item Link disabled
         </div>
@@ -2213,7 +2213,7 @@ exports[`Menu renders with Menu.ItemLink & Menu.Item disabled 1`] = `
         type="button"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           Menu.Item Link disabled
         </div>
@@ -2412,7 +2412,7 @@ exports[`Menu renders with Menu.ItemLink 1`] = `
         role="menuitem"
       >
         <div
-          class="cache-m245rk-StyledContent em6gco82"
+          class="cache-m245rk-StyledContent em6gco83"
         >
           Menu.Item as Link
         </div>

--- a/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -311,7 +311,7 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -336,7 +336,7 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -379,7 +379,7 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -400,7 +400,7 @@ exports[`Pagination should render correctly PaginationContainer 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -759,7 +759,7 @@ exports[`Pagination should render correctly component 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -784,7 +784,7 @@ exports[`Pagination should render correctly component 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -848,7 +848,7 @@ exports[`Pagination should render correctly component 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -869,7 +869,7 @@ exports[`Pagination should render correctly component 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1228,7 +1228,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1253,7 +1253,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1303,7 +1303,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1324,7 +1324,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1612,7 +1612,7 @@ exports[`Pagination should render correctly controlled with page 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1636,7 +1636,7 @@ exports[`Pagination should render correctly controlled with page 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1700,7 +1700,7 @@ exports[`Pagination should render correctly controlled with page 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -1721,7 +1721,7 @@ exports[`Pagination should render correctly controlled with page 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2311,7 +2311,7 @@ exports[`Pagination should render correctly function 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2336,7 +2336,7 @@ exports[`Pagination should render correctly function 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2400,7 +2400,7 @@ exports[`Pagination should render correctly function 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2421,7 +2421,7 @@ exports[`Pagination should render correctly function 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2758,7 +2758,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2783,7 +2783,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2821,7 +2821,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -2843,7 +2843,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3180,7 +3180,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3205,7 +3205,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3243,7 +3243,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3265,7 +3265,7 @@ exports[`Pagination should render correctly loadable with no data and initial pa
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3623,7 +3623,7 @@ exports[`Pagination should render correctly loadable with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3647,7 +3647,7 @@ exports[`Pagination should render correctly loadable with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3711,7 +3711,7 @@ exports[`Pagination should render correctly loadable with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -3733,7 +3733,7 @@ exports[`Pagination should render correctly loadable with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4092,7 +4092,7 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4117,7 +4117,7 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4181,7 +4181,7 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4202,7 +4202,7 @@ exports[`Pagination should render correctly onLoadPage 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4561,7 +4561,7 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4586,7 +4586,7 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4650,7 +4650,7 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -4671,7 +4671,7 @@ exports[`Pagination should render correctly onLoadPage and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5086,7 +5086,7 @@ exports[`Pagination should render correctly perPage 0 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5111,7 +5111,7 @@ exports[`Pagination should render correctly perPage 0 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5148,7 +5148,7 @@ exports[`Pagination should render correctly perPage 0 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5170,7 +5170,7 @@ exports[`Pagination should render correctly perPage 0 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5589,7 +5589,7 @@ exports[`Pagination should render correctly with controlled 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5614,7 +5614,7 @@ exports[`Pagination should render correctly with controlled 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5657,7 +5657,7 @@ exports[`Pagination should render correctly with controlled 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5678,7 +5678,7 @@ exports[`Pagination should render correctly with controlled 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5958,7 +5958,7 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -5983,7 +5983,7 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6020,7 +6020,7 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6042,7 +6042,7 @@ exports[`Pagination should render correctly with data (controlled component) 1`]
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6306,7 +6306,7 @@ exports[`Pagination should render correctly with empty data 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6331,7 +6331,7 @@ exports[`Pagination should render correctly with empty data 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6368,7 +6368,7 @@ exports[`Pagination should render correctly with empty data 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6390,7 +6390,7 @@ exports[`Pagination should render correctly with empty data 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6654,7 +6654,7 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6679,7 +6679,7 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6716,7 +6716,7 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -6738,7 +6738,7 @@ exports[`Pagination should render correctly with empty initialData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7096,7 +7096,7 @@ exports[`Pagination should render correctly with initial page greater than max a
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7120,7 +7120,7 @@ exports[`Pagination should render correctly with initial page greater than max a
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7185,7 +7185,7 @@ exports[`Pagination should render correctly with initial page greater than max a
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7207,7 +7207,7 @@ exports[`Pagination should render correctly with initial page greater than max a
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7566,7 +7566,7 @@ exports[`Pagination should render correctly with initial page less than 1 and no
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7591,7 +7591,7 @@ exports[`Pagination should render correctly with initial page less than 1 and no
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7655,7 +7655,7 @@ exports[`Pagination should render correctly with initial page less than 1 and no
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7676,7 +7676,7 @@ exports[`Pagination should render correctly with initial page less than 1 and no
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7949,7 +7949,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -7973,7 +7973,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8037,7 +8037,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8058,7 +8058,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8395,7 +8395,7 @@ exports[`Pagination should render correctly with pageClick and load and empty re
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8420,7 +8420,7 @@ exports[`Pagination should render correctly with pageClick and load and empty re
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8490,7 +8490,7 @@ exports[`Pagination should render correctly with pageClick and load and empty re
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8512,7 +8512,7 @@ exports[`Pagination should render correctly with pageClick and load and empty re
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8849,7 +8849,7 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8874,7 +8874,7 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8944,7 +8944,7 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -8966,7 +8966,7 @@ exports[`Pagination should render correctly with pageClick and load and no emtpy
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9308,7 +9308,7 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9332,7 +9332,7 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9397,7 +9397,7 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9419,7 +9419,7 @@ exports[`Pagination should render correctly with pageClick and pageCount 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9766,7 +9766,7 @@ exports[`Pagination should render correctly with setPageData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9791,7 +9791,7 @@ exports[`Pagination should render correctly with setPageData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9855,7 +9855,7 @@ exports[`Pagination should render correctly with setPageData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg
@@ -9876,7 +9876,7 @@ exports[`Pagination should render correctly with setPageData 1`] = `
             type="button"
           >
             <div
-              class="cache-m245rk-StyledContent em6gco82"
+              class="cache-m245rk-StyledContent em6gco83"
             >
               <div>
                 <svg


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

- Fixed button as link to make icon inline
- Fixed markdown link to inherit its size

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="139" alt="Screenshot 2022-08-02 at 18 04 15" src="https://user-images.githubusercontent.com/15812968/182422348-4781cb94-81cb-46cf-b08b-874fc958dd31.png"> | <img width="154" alt="Screenshot 2022-08-02 at 18 01 14" src="https://user-images.githubusercontent.com/15812968/182422372-c0647634-9ef2-4d71-bf19-9faf5fcef33d.png"> |
| url  | <img width="462" alt="Screenshot 2022-08-02 at 18 03 50" src="https://user-images.githubusercontent.com/15812968/182422420-2337eba6-98ab-4535-aec7-b71773d2da5a.png"> | <img width="457" alt="Screenshot 2022-08-02 at 18 01 53" src="https://user-images.githubusercontent.com/15812968/182422448-c3be0f0b-8068-42bf-9a2d-9c56081c8229.png"> |
