### PR TITLE
fix(PieChart): tooltip alignement

### DIFF
--- a/src/components/PieChart/Tooltip.tsx
+++ b/src/components/PieChart/Tooltip.tsx
@@ -12,13 +12,8 @@ const StyledItem = styled.li`
   display: flex;
   margin-top: 6px;
   width: 100%;
-`
-
-const Space = styled.span`
-  position: relative;
-  display: flex;
-  flex: 1;
-  min-width: 5px;
+  justify-content: space-between;
+  text-align: left;
 `
 
 type TooltipProps = {
@@ -41,22 +36,20 @@ const Tooltip = ({ data }: TooltipProps) => (
         <Text as="p" variant="body" prominence="stronger">
           {data.name}
         </Text>
-        <Space />
         <Text as="p" variant="body" prominence="stronger">
           {data.value}
         </Text>
       </StyledItem>
       {data.details?.map(detail => (
-          <StyledItem key={detail.name}>
-            <Text as="p" variant="bodySmall" prominence="stronger">
-              {detail.name}
-            </Text>
-            <Space />
-            <Text as="p" variant="bodySmall" prominence="stronger">
-              {detail.value}
-            </Text>
-          </StyledItem>
-        ))}
+        <StyledItem key={detail.name}>
+          <Text as="p" variant="bodySmall" prominence="stronger">
+            {detail.name}
+          </Text>
+          <Text as="p" variant="bodySmall" prominence="stronger">
+            {detail.value}
+          </Text>
+        </StyledItem>
+      ))}
     </StyledList>
   </div>
 )


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

To align text on left into PieChart tooltip.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="607" alt="Screenshot 2022-08-09 at 11 48 19" src="https://user-images.githubusercontent.com/15812968/183619350-13a7caad-24e0-46f9-9f2e-0d9cef1d8e66.png"> | <img width="618" alt="Screenshot 2022-08-09 at 11 46 42" src="https://user-images.githubusercontent.com/15812968/183619374-541288b6-335f-41df-80fb-a64de03dd898.png"> |
