### PR TITLE
fix(SelectableCard): avoid hidding all children svg

### DIFF
--- a/src/components/Radio/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Radio/__tests__/__snapshots__/index.tsx.snap
@@ -125,13 +125,14 @@ exports[`Radio renders correctly 1`] = `
 <label
     aria-disabled="false"
     class="e1duuirp0 e1g1zfwd0 cache-16xheb9-StyledText-variantStyles-StyledRadioContainer"
+    for="radio-choice"
   >
     <input
       aria-checked="false"
       aria-disabled="false"
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       tabindex="0"
       type="radio"
@@ -293,6 +294,7 @@ exports[`Radio renders correctly when checked 1`] = `
 <label
     aria-disabled="false"
     class="e1duuirp0 e1g1zfwd0 cache-16xheb9-StyledText-variantStyles-StyledRadioContainer"
+    for="radio-choice"
   >
     <input
       aria-checked="true"
@@ -300,7 +302,7 @@ exports[`Radio renders correctly when checked 1`] = `
       aria-invalid="false"
       checked=""
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       tabindex="0"
       type="radio"
@@ -462,6 +464,7 @@ exports[`Radio renders correctly when disabled 1`] = `
 <label
     aria-disabled="true"
     class="e1duuirp0 e1g1zfwd0 cache-16xheb9-StyledText-variantStyles-StyledRadioContainer"
+    for="radio-choice"
   >
     <input
       aria-checked="false"
@@ -469,7 +472,7 @@ exports[`Radio renders correctly when disabled 1`] = `
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
       disabled=""
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       style="pointer-events: none;"
       type="radio"
@@ -631,13 +634,14 @@ exports[`Radio renders correctly when error 1`] = `
 <label
     aria-disabled="false"
     class="e1duuirp0 e1g1zfwd0 cache-16xheb9-StyledText-variantStyles-StyledRadioContainer"
+    for="radio-choice"
   >
     <input
       aria-checked="false"
       aria-disabled="false"
       aria-invalid="true"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       tabindex="0"
       type="radio"
@@ -799,6 +803,7 @@ exports[`Radio renders without name 1`] = `
 <label
     aria-disabled="true"
     class="e1duuirp0 e1g1zfwd0 cache-16xheb9-StyledText-variantStyles-StyledRadioContainer"
+    for="radio-6c756c756c756c756c756c756c756c75-choice"
   >
     <input
       aria-checked="false"
@@ -806,7 +811,7 @@ exports[`Radio renders without name 1`] = `
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
       disabled=""
-      id="id-d9i348"
+      id="radio-6c756c756c756c756c756c756c756c75-choice"
       name="radio-6c756c756c756c756c756c756c756c75"
       style="pointer-events: none;"
       type="radio"

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -151,6 +151,7 @@ const Radio = ({
     <StyledRadioContainer
       as="label"
       aria-disabled={disabled}
+      htmlFor={`${computedName}-${value}`}
       className={className}
     >
       <StyledRadio
@@ -159,6 +160,7 @@ const Radio = ({
         aria-checked={checked}
         aria-disabled={disabled}
         checked={checked}
+        id={`${computedName}-${value}`}
         onChange={onChange}
         onFocus={onFocus}
         onKeyDown={onKeyDown}

--- a/src/components/RadioBorderedBox/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/RadioBorderedBox/__tests__/__snapshots__/index.tsx.snap
@@ -16,7 +16,7 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   gap: 8px;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -41,48 +41,50 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -195,14 +197,15 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
         aria-disabled="false"
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         tabindex="0"
         type="radio"
@@ -273,7 +276,7 @@ exports[`RadioBorderedBox renders correctly and triggers change on borderedbox c
   gap: 8px;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -298,48 +301,50 @@ exports[`RadioBorderedBox renders correctly and triggers change on borderedbox c
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -452,14 +457,15 @@ exports[`RadioBorderedBox renders correctly and triggers change on borderedbox c
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radioborderedbox-choice1"
     >
       <input
         aria-checked="false"
         aria-disabled="false"
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
-        id="id-d9i348"
+        id="radioborderedbox-choice1"
         name="radioborderedbox"
         tabindex="0"
         type="radio"
@@ -530,7 +536,7 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   gap: 8px;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -555,48 +561,50 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #4f0599;
   color: #4f0599;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: none;
 }
@@ -709,7 +717,8 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-xsca6q-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="true"
@@ -717,7 +726,7 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
         aria-invalid="false"
         checked=""
         class="cache-h7u1sr-StyledRadio e1duuirp1"
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         tabindex="0"
         type="radio"
@@ -788,7 +797,7 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   gap: 8px;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -813,43 +822,45 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -961,7 +972,8 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
@@ -969,7 +981,7 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
         disabled=""
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         style="pointer-events: none;"
         type="radio"
@@ -1040,7 +1052,7 @@ exports[`RadioBorderedBox renders correctly when error 1`] = `
   gap: 8px;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1065,42 +1077,44 @@ exports[`RadioBorderedBox renders correctly when error 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #a6102d;
   color: #a6102d;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -1232,14 +1246,15 @@ exports[`RadioBorderedBox renders correctly when error 1`] = `
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-6hyv65-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
         aria-disabled="false"
         aria-invalid="true"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         tabindex="0"
         type="radio"
@@ -1319,7 +1334,7 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   gap: 8px;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1344,43 +1359,45 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -1532,7 +1549,8 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
@@ -1540,7 +1558,7 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
         disabled=""
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         style="pointer-events: none;"
         type="radio"
@@ -1628,7 +1646,7 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
   gap: 8px;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1653,43 +1671,45 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -1814,7 +1834,8 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
@@ -1822,7 +1843,7 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
         disabled=""
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         style="pointer-events: none;"
         type="radio"
@@ -1903,7 +1924,7 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
   gap: 8px;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1928,43 +1949,45 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -2089,7 +2112,8 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1m51cql-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
@@ -2097,7 +2121,7 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
         disabled=""
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         style="pointer-events: none;"
         type="radio"

--- a/src/components/RadioBorderedBox/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/RadioBorderedBox/__tests__/__snapshots__/index.tsx.snap
@@ -16,7 +16,7 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   gap: 8px;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -45,44 +45,44 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   color: #4a4f62;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -195,7 +195,7 @@ exports[`RadioBorderedBox renders correctly 1`] = `
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -273,7 +273,7 @@ exports[`RadioBorderedBox renders correctly and triggers change on borderedbox c
   gap: 8px;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -302,44 +302,44 @@ exports[`RadioBorderedBox renders correctly and triggers change on borderedbox c
   color: #4a4f62;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -452,7 +452,7 @@ exports[`RadioBorderedBox renders correctly and triggers change on borderedbox c
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -530,7 +530,7 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   gap: 8px;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -559,44 +559,44 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   color: #4f0599;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: none;
 }
@@ -709,7 +709,7 @@ exports[`RadioBorderedBox renders correctly when checked 1`] = `
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1r9pah2-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-9xhj30-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="true"
@@ -788,7 +788,7 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   gap: 8px;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -818,38 +818,38 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   background: #f6f6f8;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -961,7 +961,7 @@ exports[`RadioBorderedBox renders correctly when disabled 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -1040,7 +1040,7 @@ exports[`RadioBorderedBox renders correctly when error 1`] = `
   gap: 8px;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1069,38 +1069,38 @@ exports[`RadioBorderedBox renders correctly when error 1`] = `
   color: #a6102d;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -1232,7 +1232,7 @@ exports[`RadioBorderedBox renders correctly when error 1`] = `
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-68mmyz-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-sw65in-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -1319,7 +1319,7 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   gap: 8px;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1349,38 +1349,38 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   background: #f6f6f8;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -1532,7 +1532,7 @@ exports[`RadioBorderedBox renders correctly with label desc and badge 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -1628,7 +1628,7 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
   gap: 8px;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1658,38 +1658,38 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
   background: #f6f6f8;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -1814,7 +1814,7 @@ exports[`RadioBorderedBox renders correctly with sideText 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -1903,7 +1903,7 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
   gap: 8px;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1933,38 +1933,38 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
   background: #f6f6f8;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
@@ -2089,7 +2089,7 @@ exports[`RadioBorderedBox renders correctly without children 1`] = `
   >
     <label
       aria-disabled="true"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-k0n2f0-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-pfo8e1-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"

--- a/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SelectableCard renders correctly with checkbox type 1`] = `
 <DocumentFragment>
-  .cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -30,52 +30,52 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   color: #4a4f62;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement svg {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -160,7 +160,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -203,7 +203,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
 
 exports[`SelectableCard renders correctly with checkbox type and checked prop 1`] = `
 <DocumentFragment>
-  .cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -231,52 +231,52 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   color: #4f0599;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: none;
 }
 
-.cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement svg {
+.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -361,7 +361,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1rzjook-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="true"
@@ -405,7 +405,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
 
 exports[`SelectableCard renders correctly with checkbox type and disabled prop 1`] = `
 <DocumentFragment>
-  .cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -434,45 +434,45 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   background: #f6f6f8;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement svg {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -557,7 +557,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
 
 <label
     aria-disabled="true"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -603,7 +603,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
 
 exports[`SelectableCard renders correctly with checkbox type and isError prop 1`] = `
 <DocumentFragment>
-  .cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -631,45 +631,45 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   color: #a6102d;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement svg {
+.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -754,7 +754,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-20gutv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -814,7 +814,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 
 exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -842,52 +842,52 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   color: #4a4f62;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement svg {
+.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -975,7 +975,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1crci7q-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+      class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -1019,7 +1019,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 
 exports[`SelectableCard renders correctly with complex children 1`] = `
 <DocumentFragment>
-  .cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1048,45 +1048,45 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   background: #f6f6f8;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement svg {
+.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1171,7 +1171,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
 
 <label
     aria-disabled="true"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1rsnnp8-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -1221,7 +1221,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
 
 exports[`SelectableCard renders correctly with default props 1`] = `
 <DocumentFragment>
-  .cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1250,49 +1250,49 @@ exports[`SelectableCard renders correctly with default props 1`] = `
   color: #4a4f62;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement svg {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1366,7 +1366,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -1412,7 +1412,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
 
 exports[`SelectableCard renders correctly with radio type and checked prop 1`] = `
 <DocumentFragment>
-  .cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1441,49 +1441,49 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
   color: #4f0599;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: none;
 }
 
-.cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement svg {
+.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1557,7 +1557,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1ro4vvu-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement"
   >
     <input
       aria-checked="true"
@@ -1604,7 +1604,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
 
 exports[`SelectableCard renders correctly with radio type and disabled prop 1`] = `
 <DocumentFragment>
-  .cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1634,42 +1634,42 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
   background: #f6f6f8;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement svg {
+.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1743,7 +1743,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
 
 <label
     aria-disabled="true"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-2s3l0o-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -1790,7 +1790,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
 
 exports[`SelectableCard renders correctly with radio type and isError prop 1`] = `
 <DocumentFragment>
-  .cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1819,42 +1819,42 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
   color: #a6102d;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement svg {
+.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1928,7 +1928,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1y4kmdq-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -1974,7 +1974,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 
 exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -2003,49 +2003,49 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   color: #4a4f62;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement svg {
+.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -2122,7 +2122,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-tm71ep-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -2169,7 +2169,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 
 exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = `
 <DocumentFragment>
-  .cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -2197,47 +2197,47 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   color: #4a4f62;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -2323,7 +2323,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-8l5797-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -2366,7 +2366,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
 
 exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
 <DocumentFragment>
-  .cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -2395,44 +2395,44 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
   color: #4a4f62;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -2507,7 +2507,7 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-e519sq-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement"
   >
     <input
       aria-checked="false"

--- a/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SelectableCard renders correctly with checkbox type 1`] = `
 <DocumentFragment>
-  .cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -26,56 +26,58 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -160,7 +162,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -203,7 +205,7 @@ exports[`SelectableCard renders correctly with checkbox type 1`] = `
 
 exports[`SelectableCard renders correctly with checkbox type and checked prop 1`] = `
 <DocumentFragment>
-  .cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -227,56 +229,58 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #4f0599;
   color: #4f0599;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: none;
 }
 
-.cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
+.cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -361,7 +365,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1xrtczm-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1q5cqx5-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="true"
@@ -405,7 +409,7 @@ exports[`SelectableCard renders correctly with checkbox type and checked prop 1`
 
 exports[`SelectableCard renders correctly with checkbox type and disabled prop 1`] = `
 <DocumentFragment>
-  .cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -429,50 +433,52 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -557,7 +563,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
 
 <label
     aria-disabled="true"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -603,7 +609,7 @@ exports[`SelectableCard renders correctly with checkbox type and disabled prop 1
 
 exports[`SelectableCard renders correctly with checkbox type and isError prop 1`] = `
 <DocumentFragment>
-  .cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -627,49 +633,51 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #a6102d;
   color: #a6102d;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
+.cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -754,7 +762,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1s2kozy-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-wzlkcb-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -814,7 +822,7 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 
 exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -838,56 +846,58 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
+.cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -975,7 +985,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1pcpsoc-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+      class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1fmibq4-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
     >
       <input
         aria-checked="false"
@@ -1019,7 +1029,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 
 exports[`SelectableCard renders correctly with complex children 1`] = `
 <DocumentFragment>
-  .cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1043,50 +1053,52 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
+.cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1171,7 +1183,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
 
 <label
     aria-disabled="true"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-ewc2in-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-1mmusue-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -1221,7 +1233,7 @@ exports[`SelectableCard renders correctly with complex children 1`] = `
 
 exports[`SelectableCard renders correctly with default props 1`] = `
 <DocumentFragment>
-  .cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1246,53 +1258,55 @@ exports[`SelectableCard renders correctly with default props 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1366,14 +1380,15 @@ exports[`SelectableCard renders correctly with default props 1`] = `
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    for="radio-choice"
   >
     <input
       aria-checked="false"
       aria-disabled="false"
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       tabindex="0"
       type="radio"
@@ -1412,7 +1427,7 @@ exports[`SelectableCard renders correctly with default props 1`] = `
 
 exports[`SelectableCard renders correctly with radio type and checked prop 1`] = `
 <DocumentFragment>
-  .cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1437,53 +1452,55 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #4f0599;
   color: #4f0599;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: none;
 }
 
-.cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
+.cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1557,7 +1574,8 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1bh3cz-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-vhbsps-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    for="radio-choice"
   >
     <input
       aria-checked="true"
@@ -1565,7 +1583,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
       aria-invalid="false"
       checked=""
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       tabindex="0"
       type="radio"
@@ -1604,7 +1622,7 @@ exports[`SelectableCard renders correctly with radio type and checked prop 1`] =
 
 exports[`SelectableCard renders correctly with radio type and disabled prop 1`] = `
 <DocumentFragment>
-  .cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1629,47 +1647,49 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #c4c9d6;
   background: #f6f6f8;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
+.cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1743,7 +1763,8 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
 
 <label
     aria-disabled="true"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-p1mn8y-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-zobnrv-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    for="radio-choice"
   >
     <input
       aria-checked="false"
@@ -1751,7 +1772,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
       disabled=""
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       style="pointer-events: none;"
       type="radio"
@@ -1790,7 +1811,7 @@ exports[`SelectableCard renders correctly with radio type and disabled prop 1`] 
 
 exports[`SelectableCard renders correctly with radio type and isError prop 1`] = `
 <DocumentFragment>
-  .cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1815,46 +1836,48 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #a6102d;
   color: #a6102d;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
+.cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -1928,14 +1951,15 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-3jl6dk-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1ejekvs-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    for="radio-choice"
   >
     <input
       aria-checked="false"
       aria-disabled="false"
       aria-invalid="true"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="radio-choice"
       name="radio"
       tabindex="0"
       type="radio"
@@ -1974,7 +1998,7 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 
 exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -1999,53 +2023,55 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
 
-.cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
+.cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement input+svg {
   display: none;
 }
 
@@ -2122,14 +2148,15 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
   >
     <label
       aria-disabled="false"
-      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-172bl44-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-1qoihw0-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+      for="radio-choice"
     >
       <input
         aria-checked="false"
         aria-disabled="false"
         aria-invalid="false"
         class="cache-h7u1sr-StyledRadio e1duuirp1"
-        id="id-d9i348"
+        id="radio-choice"
         name="radio"
         tabindex="0"
         type="radio"
@@ -2169,7 +2196,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 
 exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = `
 <DocumentFragment>
-  .cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
+  .cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -2193,51 +2220,53 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 {
   fill: #c4c9d6;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement[aria-disabled='true'] .eu28k4m3 .eu28k4m6 {
   stroke: #c4c9d6;
   fill: #f6f6f8;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 {
   background-color: #eeeeff;
   fill: #4f0599;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2+.eu28k4m3 .eu28k4m6 {
   stroke: #4f0599;
   fill: #eeeeff;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 {
   background-color: #ffe1e7;
   fill: #dd3252;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover[aria-disabled='false'] .eu28k4m2[aria-invalid="true"]+.eu28k4m3 .eu28k4m6 {
   stroke: #dd3252;
   fill: #ffe1e7;
 }
 
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
-.cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:hover,
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:focus-within,
+.cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -2323,7 +2352,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
 
 <label
     aria-disabled="false"
-    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-kzdskv-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
+    class="ejleepd0 eu28k4m1 e1g1zfwd0 cache-wns5yx-StyledText-variantStyles-StyledCheckBoxContainer-StyledElement"
   >
     <input
       aria-checked="false"
@@ -2366,7 +2395,7 @@ exports[`SelectableCard renders correctly with showTick and type checkbox 1`] = 
 
 exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
 <DocumentFragment>
-  .cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement {
+  .cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement {
   color: #4a4f62;
   font-weight: 400;
   margin-bottom: 0;
@@ -2391,48 +2420,50 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
   align-items: start;
   padding: 16px;
   border-radius: 4px;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
   border: 1px solid #d4dae7;
   color: #4a4f62;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='false'] {
   cursor: pointer;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 {
   background-color: #eeeeff;
   fill: #390171;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1+.e1duuirp2 .e1duuirp4 {
   fill: #eeeeff;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 {
   background-color: #ffe1e7;
   fill: #a6102d;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover[aria-disabled='false'] .e1duuirp1[aria-invalid='true']+.e1duuirp2 .e1duuirp4 {
   fill: #ffe1e7;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] {
   cursor: not-allowed;
   color: #c4c9d6;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 {
   fill: #c4c9d6;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement[aria-disabled='true'] .e1duuirp2 .e1duuirp4 {
   fill: #f6f6f8;
 }
 
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
-.cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:hover,
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:focus-within,
+.cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement:active {
   border: 1px solid #4f0599;
   box-shadow: 0px 4px 16px 4px #EEEEFFCC;
 }
@@ -2507,14 +2538,15 @@ exports[`SelectableCard renders correctly with showTick and type radio 1`] = `
 
 <label
     aria-disabled="false"
-    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-rfdf6w-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    class="ejleepd0 e1duuirp0 e1g1zfwd0 cache-2umup8-StyledText-variantStyles-StyledRadioContainer-StyledElement"
+    for="checkbox-choice"
   >
     <input
       aria-checked="false"
       aria-disabled="false"
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
-      id="id-d9i348"
+      id="checkbox-choice"
       name="checkbox"
       tabindex="0"
       type="radio"

--- a/src/components/SelectableCard/index.tsx
+++ b/src/components/SelectableCard/index.tsx
@@ -55,7 +55,7 @@ const StyledElement = (element: typeof Radio) => styled(element, {
     }}
   }
 
-  svg {
+  input + svg {
     ${({ showTick }) => (!showTick ? `display: none;` : null)}
   }
 `

--- a/src/components/SelectableCard/index.tsx
+++ b/src/components/SelectableCard/index.tsx
@@ -16,6 +16,7 @@ const StyledElement = (element: typeof Radio) => styled(element, {
   align-items: start;
   padding: ${({ theme }) => theme.space['2']};
   border-radius: ${({ theme }) => theme.radii.default};
+  transition: border-color 200ms ease, box-shadow 200ms ease;
 
   ${({ theme, checked, disabled, error }) => {
     if (error)


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Avoid removing all svg children, only the one of the input.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="264" alt="Screenshot 2022-08-16 at 11 45 48" src="https://user-images.githubusercontent.com/15812968/184853214-6e69f1cf-582e-451b-a382-d0cc836b6ea4.png"> | <img width="281" alt="Screenshot 2022-08-16 at 11 45 16" src="https://user-images.githubusercontent.com/15812968/184853227-7c0736fe-a9da-4fd5-be1d-42f6e26d165c.png"> |
