### PR TITLE
ci(codecov): fix very low coverage changes on ci

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ codecov:
   bot: scaleway-bot
 
 coverage:
+  threshold: 0.1%
   precision: 2
   round: down
   range: "70...100"


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

Sometime CodeCov is flacky and shows a tiny change on code coverage while there is none. In order to avoir having this error in CI, I added a 0.1% threshold that should allow any PR to have 0.1% coverage difference and so solve this issue.
