### PR TITLE
fix: use `useId` instead of `useUUID`

### DIFF
--- a/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Checkbox/__tests__/__snapshots__/index.tsx.snap
@@ -315,7 +315,7 @@ exports[`Checkbox renders correctly checked 1`] = `
       aria-invalid="false"
       checked=""
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r3:"
       type="checkbox"
     />
     <svg
@@ -492,7 +492,7 @@ exports[`Checkbox renders correctly checked and disabled 1`] = `
       checked=""
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
       disabled=""
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r5:"
       style="pointer-events: none;"
       type="checkbox"
     />
@@ -669,7 +669,7 @@ exports[`Checkbox renders correctly disabled 1`] = `
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
       disabled=""
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r2:"
       style="pointer-events: none;"
       type="checkbox"
     />
@@ -844,7 +844,7 @@ exports[`Checkbox renders correctly indeterminate 1`] = `
       aria-checked="mixed"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r4:"
       type="checkbox"
     />
     <svg
@@ -1019,7 +1019,7 @@ exports[`Checkbox renders correctly indeterminate and disabled 1`] = `
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
       disabled=""
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r6:"
       style="pointer-events: none;"
       type="checkbox"
     />
@@ -1194,7 +1194,7 @@ exports[`Checkbox renders correctly invisible 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r7:"
       type="checkbox"
     />
     <svg
@@ -1368,7 +1368,7 @@ exports[`Checkbox renders correctly no child 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r1:"
       type="checkbox"
     />
     <svg
@@ -1541,7 +1541,7 @@ exports[`Checkbox renders correctly with a value 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":rc:"
       type="checkbox"
       value="test"
     />
@@ -1714,10 +1714,10 @@ exports[`Checkbox renders correctly with an error 1`] = `
   >
     <input
       aria-checked="false"
-      aria-describedby="checkbox-6c756c756c756c756c756c756c756c75-hint"
+      aria-describedby=":r8:-hint"
       aria-invalid="true"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":r8:"
       type="checkbox"
     />
     <svg
@@ -1910,7 +1910,7 @@ exports[`Checkbox renders correctly with indeterminate state 1`] = `
       aria-checked="mixed"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":rf:"
       type="checkbox"
     />
     <svg
@@ -2137,7 +2137,7 @@ exports[`Checkbox renders correctly with progress 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":ra:"
       type="checkbox"
     />
     Checkbox Label
@@ -2339,7 +2339,7 @@ exports[`Checkbox renders correctly with progress and no child 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":rb:"
       type="checkbox"
     />
   </label>
@@ -2486,7 +2486,7 @@ exports[`Checkbox renders correctly with sizes 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-1xeahyq-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":rd:"
       type="checkbox"
       value="test"
     />
@@ -2710,7 +2710,7 @@ exports[`Checkbox renders correctly with sizes 1`] = `
       aria-checked="false"
       aria-invalid="false"
       class="cache-1xeahyq-StyledReakitCheckbox eu28k4m2"
-      name="checkbox-6c756c756c756c756c756c756c756c75"
+      name=":re:"
       type="checkbox"
       value="test"
     />

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -7,6 +7,7 @@ import {
   forwardRef,
   useCallback,
   useEffect,
+  useId,
   useMemo,
 } from 'react'
 import {
@@ -14,7 +15,6 @@ import {
   CheckboxProps as ReakitCheckboxProps,
   useCheckboxState,
 } from 'reakit/Checkbox'
-import { getUUID } from '../../utils'
 import Loader from '../Loader'
 import Text from '../Text'
 
@@ -205,12 +205,8 @@ const Checkbox = forwardRef(
   ) => {
     const hasChildren = !!children
     const { state, setState } = useCheckboxState({ state: checked })
-
-    const computedName = useMemo(() => {
-      if (!name) return getUUID('checkbox')
-
-      return name
-    }, [name])
+    const id = useId()
+    const computedName = name ?? id
 
     const icon = useMemo(() => {
       if (state === 'indeterminate') return 'minus-box-outline'

--- a/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -6058,7 +6058,7 @@ exports[`List should render correctly multiselect and with click 1`] = `
           aria-invalid="false"
           checked=""
           class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-          name="checkbox-6c756c756c756c756c756c756c756c75"
+          name=":r2o:"
           type="checkbox"
         />
         <svg
@@ -7273,7 +7273,7 @@ exports[`List should render correctly multiselect and with click and not functio
           aria-invalid="false"
           checked=""
           class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-          name="checkbox-6c756c756c756c756c756c756c756c75"
+          name=":r3k:"
           type="checkbox"
         />
         <svg
@@ -14135,7 +14135,7 @@ exports[`List should render correctly multiselect, explorer variant and with cli
           aria-invalid="false"
           checked=""
           class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-          name="checkbox-6c756c756c756c756c756c756c756c75"
+          name=":r6s:"
           type="checkbox"
         />
         <svg
@@ -16169,7 +16169,7 @@ exports[`List should render correctly multiselect, table variant and with click 
           aria-invalid="false"
           checked=""
           class="cache-18vdqte-StyledReakitCheckbox eu28k4m2"
-          name="checkbox-6c756c756c756c756c756c756c756c75"
+          name=":r60:"
           type="checkbox"
         />
         <svg

--- a/src/components/Radio/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Radio/__tests__/__snapshots__/index.tsx.snap
@@ -788,7 +788,7 @@ exports[`Radio renders without name 1`] = `
     aria-disabled="true"
     class="cache-o9aw7s-StyledRadioContainer e1duuirp0"
     data-checked="false"
-    for="radio-6c756c756c756c756c756c756c756c75-choice"
+    for=":r2:-choice"
   >
     <input
       aria-checked="false"
@@ -796,8 +796,8 @@ exports[`Radio renders without name 1`] = `
       aria-invalid="false"
       class="cache-h7u1sr-StyledRadio e1duuirp1"
       disabled=""
-      id="radio-6c756c756c756c756c756c756c756c75-choice"
-      name="radio-6c756c756c756c756c756c756c756c75"
+      id=":r2:-choice"
+      name=":r2:"
       style="pointer-events: none;"
       type="radio"
       value="choice"

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -4,10 +4,9 @@ import {
   InputHTMLAttributes,
   ReactNode,
   forwardRef,
-  useMemo,
+  useId,
 } from 'react'
 import { Radio as ReakitRadio, RadioProps as ReakitRadioProps } from 'reakit'
-import { getUUID } from '../../utils'
 
 const InnerCircleRing = styled.circle`
   fill: ${({ theme }) => theme.colors.neutral.backgroundWeak};
@@ -150,11 +149,8 @@ const Radio = forwardRef(
     }: RadioProps,
     ref: ForwardedRef<HTMLLabelElement>,
   ) => {
-    const computedName = useMemo(() => {
-      if (!name) return getUUID('radio')
-
-      return name
-    }, [name])
+    const id = useId()
+    const computedName = name ?? id
 
     return (
       <StyledRadioContainer

--- a/src/components/RichSelect/index.tsx
+++ b/src/components/RichSelect/index.tsx
@@ -9,6 +9,7 @@ import {
   Validator,
   forwardRef,
   useEffect,
+  useId,
   useMemo,
   useState,
 } from 'react'
@@ -27,7 +28,6 @@ import Select, {
   components,
 } from 'react-select'
 import isJSONString from '../../helpers/isJSON'
-import { getUUID } from '../../utils'
 import * as animations from '../../utils/animations'
 import Box, { XStyledProps } from '../Box'
 import Expandable from '../Expandable'
@@ -717,7 +717,8 @@ const RichSelect = ({
   value,
   ...props
 }: Partial<RichSelectProps>) => {
-  const inputId = useMemo(() => inputIdProp || getUUID('input'), [inputIdProp])
+  const id = useId()
+  const inputId = inputIdProp ?? id
   const theme = useTheme()
   const [isAnimated, setIsAnimated] = useState(false)
   const currentValue = (value as SelectOption)?.value

--- a/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
@@ -966,7 +966,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 }
 
 <div
-    aria-describedby="tooltip-6c756c756c756c756c756c756c756c75"
+    aria-describedby=":rn:"
   >
     <label
       aria-disabled="false"
@@ -2111,7 +2111,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 }
 
 <div
-    aria-describedby="tooltip-6c756c756c756c756c756c756c756c75"
+    aria-describedby=":rl:"
   >
     <label
       aria-disabled="false"

--- a/src/components/SwitchButton/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/SwitchButton/__tests__/__snapshots__/index.tsx.snap
@@ -1069,7 +1069,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
 }
 
 <div
-    aria-describedby="tooltip-6c756c756c756c756c756c756c756c75"
+    aria-describedby=":ra:"
   >
     <div
       style="display: inline-flex;"

--- a/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tooltip should render correctly 1`] = `
 <DocumentFragment>
   <div
-    aria-describedby="tooltip-6c756c756c756c756c756c756c756c75"
+    aria-describedby=":r0:"
   >
     Hover me
   </div>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -4,12 +4,11 @@ import {
   RefObject,
   useCallback,
   useEffect,
-  useMemo,
+  useId,
   useRef,
   useState,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { getUUID } from '../../utils'
 
 const ARROW_WIDTH = 6 // in px
 const SPACE = 6 // in px
@@ -183,12 +182,8 @@ const Tooltip = ({
     ...DEFAULT_POSITIONS,
     tooltipInitialPosition: TOOLTIP_INITIAL_POSITION[placement],
   })
-
-  const generatedId = useMemo(() => {
-    if (!id) return getUUID('tooltip')
-
-    return id
-  }, [id])
+  const uniqueId = useId()
+  const generatedId = id ?? uniqueId
 
   const getPositions = useCallback(() => {
     if (childrenRef.current && tooltipRef.current) {

--- a/src/components/UnitInput/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/UnitInput/__tests__/__snapshots__/index.tsx.snap
@@ -429,7 +429,7 @@ exports[`UnitInput renders with custom options 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r1:"
           >
             Select...
           </label>
@@ -450,7 +450,7 @@ exports[`UnitInput renders with custom options 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r1:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -927,7 +927,7 @@ exports[`UnitInput renders with default props 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r0:"
           >
             Select...
           </label>
@@ -948,7 +948,7 @@ exports[`UnitInput renders with default props 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r0:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -1425,7 +1425,7 @@ exports[`UnitInput renders with defaultOption 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r4:"
           >
             Select...
           </label>
@@ -1446,7 +1446,7 @@ exports[`UnitInput renders with defaultOption 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r4:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -1923,7 +1923,7 @@ exports[`UnitInput renders with defaultValue 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r3:"
           >
             Select...
           </label>
@@ -1944,7 +1944,7 @@ exports[`UnitInput renders with defaultValue 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r3:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -2414,7 +2414,7 @@ exports[`UnitInput renders with disabled and placeHolder 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-au1o7r-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r9:"
           >
             Select...
           </label>
@@ -2436,7 +2436,7 @@ exports[`UnitInput renders with disabled and placeHolder 1`] = `
               autocorrect="off"
               class=""
               disabled=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r9:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -2908,7 +2908,7 @@ exports[`UnitInput renders with min max 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r2:"
           >
             Select...
           </label>
@@ -2929,7 +2929,7 @@ exports[`UnitInput renders with min max 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r2:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -3406,7 +3406,7 @@ exports[`UnitInput renders with size large 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r5:"
           >
             Select...
           </label>
@@ -3427,7 +3427,7 @@ exports[`UnitInput renders with size large 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r5:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -3904,7 +3904,7 @@ exports[`UnitInput renders with size medium 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r6:"
           >
             Select...
           </label>
@@ -3925,7 +3925,7 @@ exports[`UnitInput renders with size medium 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r6:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -4402,7 +4402,7 @@ exports[`UnitInput renders with size small 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r7:"
           >
             Select...
           </label>
@@ -4423,7 +4423,7 @@ exports[`UnitInput renders with size small 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r7:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
@@ -4900,7 +4900,7 @@ exports[`UnitInput renders with textBoxWidth and richSelectWidth 1`] = `
             aria-live="assertive"
             as="label"
             class="cache-12w4gz-StyledPlaceholder e1lzna4r2"
-            for="input-6c756c756c756c756c756c756c756c75"
+            for=":r8:"
           >
             Select...
           </label>
@@ -4921,7 +4921,7 @@ exports[`UnitInput renders with textBoxWidth and richSelectWidth 1`] = `
               autocomplete="off"
               autocorrect="off"
               class=""
-              id="input-6c756c756c756c756c756c756c756c75"
+              id=":r8:"
               role="combobox"
               spellcheck="false"
               style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 export * from './components'
 export { default as lightTheme, extendTheme, darkTheme } from './theme'
 export type { SCWUITheme } from './theme'
-export * from './utils'

--- a/src/utils/__tests__/__snapshots__/index.tsx.snap
+++ b/src/utils/__tests__/__snapshots__/index.tsx.snap
@@ -3,15 +3,3 @@
 exports[`ids getUUID returns correctly with a prefix 1`] = `"ah-6c756c756c756c756c756c756c756c75"`;
 
 exports[`ids getUUID returns correctly without arguments 1`] = `"6c756c756c756c756c756c756c756c75"`;
-
-exports[`ids useUUID renders correctly with a prefix 1`] = `
-<DocumentFragment>
-  ah-6c756c756c756c756c756c756c756c75
-</DocumentFragment>
-`;
-
-exports[`ids useUUID renders correctly without arguments 1`] = `
-<DocumentFragment>
-  6c756c756c756c756c756c756c756c75
-</DocumentFragment>
-`;

--- a/src/utils/__tests__/index.tsx
+++ b/src/utils/__tests__/index.tsx
@@ -1,10 +1,4 @@
-import { shouldMatchEmotionSnapshot } from '../../helpers/jestHelpers'
-import capitalize from '../capitalize'
-import { getUUID, useUUID } from '../ids'
-
-const Component = ({ prefix }: { prefix?: string } = {}) => (
-  <>{useUUID(prefix)}</>
-)
+import { getUUID } from '../ids'
 
 describe('ids', () => {
   describe('getUUID', () => {
@@ -14,20 +8,6 @@ describe('ids', () => {
 
     test('returns correctly with a prefix', () => {
       expect(getUUID('ah')).toMatchSnapshot()
-    })
-  })
-
-  describe('useUUID', () => {
-    test('renders correctly without arguments', () =>
-      shouldMatchEmotionSnapshot(<Component />))
-
-    test('renders correctly with a prefix', () =>
-      shouldMatchEmotionSnapshot(<Component prefix="ah" />))
-  })
-
-  describe('capitalize', () => {
-    test('returns correctly without arguments', () => {
-      expect(capitalize('test')).toBe('Test')
     })
   })
 })

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,9 +1,5 @@
-import { useMemo } from 'react'
-
 const chr4 = () => Math.random().toString(16).slice(-4)
 const uuid = () => Array.from({ length: 8 }, chr4).join('')
 
 export const getUUID = (prefix = ''): string =>
   `${prefix ? `${prefix}-` : ''}${uuid()}`
-export const useUUID = (prefix = ''): string =>
-  useMemo(() => getUUID(prefix), [prefix])


### PR DESCRIPTION
## Summary

Closes #1790

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Use React 18 `useId` hook instead of `useUUID`.
Remove the exports from index of `useUUID` and `getUUID`.
I could not delete `getUUID` because it's still used in places where we can't use `useId`
