### PR TITLE
fix: export utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components'
 export { default as lightTheme, extendTheme, darkTheme } from './theme'
 export type { SCWUITheme } from './theme'
+export * from './utils'


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Export `utils` after a regression of #1826 