### PR TITLE
fix(Text): italic & underline missing semicolon

### DIFF
--- a/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
@@ -308,7 +308,7 @@ exports[`Text with disabled 1`] = `
 
 exports[`Text with italic 1`] = `
 <DocumentFragment>
-  .cache-1qu9itg-StyledText {
+  .cache-1w5sr7l-StyledText {
   color: #4a4f62;
   font-size: 16px;
   font-family: Asap;
@@ -323,7 +323,7 @@ exports[`Text with italic 1`] = `
 }
 
 <div
-    class="cache-1qu9itg-StyledText e1tg3t120"
+    class="cache-1w5sr7l-StyledText e1tg3t120"
   >
     Lorem Ipsum
   </div>
@@ -402,7 +402,7 @@ exports[`Text with prominence stronger on non neutral 1`] = `
 
 exports[`Text with underline 1`] = `
 <DocumentFragment>
-  .cache-1k6wxvh-StyledText {
+  .cache-1uxxaaq-StyledText {
   color: #4a4f62;
   font-size: 16px;
   font-family: Asap;
@@ -418,7 +418,7 @@ exports[`Text with underline 1`] = `
 }
 
 <div
-    class="cache-1k6wxvh-StyledText e1tg3t120"
+    class="cache-1uxxaaq-StyledText e1tg3t120"
   >
     Lorem Ipsum
   </div>

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -69,8 +69,8 @@ const generateStyles = ({
     overflow: hidden;`
         : ''
     }
-    ${italic ? `font-style: italic` : ''}
-    ${underline ? `text-decoration: underline` : ''}
+    ${italic ? `font-style: italic;` : ''}
+    ${underline ? `text-decoration: underline;` : ''}
   `
 }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `Text` italic and underline style that were missing a semicolon.
