### PR TITLE
feat(tooltip): dymanic position

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8474,7 +8474,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -9975,7 +9975,7 @@ packages:
     dev: true
 
   /detect-file/1.0.0:
-    resolution: {integrity: sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=}
+    resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -10171,7 +10171,7 @@ packages:
     dev: true
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: true
 
   /electron-to-chromium/1.4.132:
@@ -10909,7 +10909,7 @@ packages:
     dev: true
 
   /expand-tilde/2.0.2:
-    resolution: {integrity: sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=}
+    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       homedir-polyfill: 1.0.3
@@ -11756,7 +11756,7 @@ packages:
     dev: true
 
   /global-prefix/1.0.2:
-    resolution: {integrity: sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=}
+    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       expand-tilde: 2.0.2
@@ -15849,7 +15849,7 @@ packages:
       lines-and-columns: 1.2.4
 
   /parse-passwd/1.0.0:
-    resolution: {integrity: sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=}
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -16633,17 +16633,6 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
-    dev: true
-
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
     dev: true
 
   /promise.allsettled/1.0.5:
@@ -17564,7 +17553,7 @@ packages:
     dev: true
 
   /resolve-dir/1.0.1:
-    resolution: {integrity: sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=}
+    resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       expand-tilde: 2.0.2
@@ -18455,7 +18444,7 @@ packages:
     dev: true
 
   /string-hash/1.1.3:
-    resolution: {integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=}
+    resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
     dev: true
 
   /string-length/4.0.2:
@@ -19679,7 +19668,7 @@ packages:
     dev: true
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
     dev: true
 

--- a/src/components/Tooltip/__stories__/index.stories.tsx
+++ b/src/components/Tooltip/__stories__/index.stories.tsx
@@ -51,7 +51,7 @@ Placement.decorators = [
         justifyContent: 'center',
       }}
     >
-      {['top', 'bottom', 'left', 'right'].map(placement => (
+      {['auto', 'top', 'bottom', 'left', 'right'].map(placement => (
         <Tooltip
           key={placement}
           placement={placement as ComponentProps<typeof Tooltip>['placement']}

--- a/src/components/Tooltip/__tests__/index.test.tsx
+++ b/src/components/Tooltip/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ComponentProps } from 'react'
 import Tooltip from '..'
@@ -29,7 +30,9 @@ describe('Tooltip', () => {
     )
 
     const input = node.getByTestId('children') as HTMLInputElement
-    userEvent.hover(input)
+    act(() => {
+      userEvent.hover(input)
+    })
     const tooltipPortal = node.getByText('test success!') as HTMLInputElement
     expect(tooltipPortal).toBeVisible()
   })
@@ -46,7 +49,9 @@ describe('Tooltip', () => {
     )
 
     const input = node.getByTestId('children') as HTMLInputElement
-    userEvent.hover(input)
+    act(() => {
+      userEvent.hover(input)
+    })
     const tooltipPortal = node.getByText('test success!') as HTMLInputElement
     expect(tooltipPortal).toBeVisible()
   })
@@ -59,11 +64,17 @@ describe('Tooltip', () => {
     )
 
     const input = node.getByTestId('children') as HTMLInputElement
-    userEvent.hover(input)
+    act(() => {
+      userEvent.hover(input)
+    })
     const tooltipPortal = node.getByText('test success!') as HTMLInputElement
     expect(tooltipPortal).toBeVisible()
-    userEvent.unhover(input)
-    jest.advanceTimersByTime(230)
+    act(() => {
+      userEvent.unhover(input)
+
+      // That's the time until animation finishes
+      jest.advanceTimersByTime(230)
+    })
     expect(tooltipPortal).not.toBeVisible()
   })
 
@@ -75,11 +86,15 @@ describe('Tooltip', () => {
     )
 
     const input = node.getByTestId('children') as HTMLInputElement
-    userEvent.hover(input)
+    act(() => {
+      userEvent.hover(input)
+    })
     const tooltipPortal = node.getByText('test success!') as HTMLInputElement
     expect(tooltipPortal).toBeVisible()
-    userEvent.unhover(input)
-    userEvent.hover(input)
+    act(() => {
+      userEvent.unhover(input)
+      userEvent.hover(input)
+    })
     expect(tooltipPortal).toBeVisible()
   })
 
@@ -91,7 +106,9 @@ describe('Tooltip', () => {
     )
 
     const input = node.getByTestId('children') as HTMLInputElement
-    userEvent.hover(input)
+    act(() => {
+      userEvent.hover(input)
+    })
     const tooltipPortal = node.getByText('test success!') as HTMLInputElement
     expect(tooltipPortal).toBeVisible()
   })
@@ -104,12 +121,14 @@ describe('Tooltip', () => {
     )
 
     const input = node.getByTestId('children') as HTMLInputElement
-    userEvent.hover(input)
+    act(() => {
+      userEvent.hover(input)
+    })
     const tooltipPortal = node.getByText('test success!') as HTMLInputElement
     expect(tooltipPortal).toBeVisible()
   })
 
-  describe(`placement`, () => {
+  describe(`defined placement`, () => {
     ;['top', 'left', 'right', 'bottom'].forEach(placement => {
       test(`should renders tooltip with placement ${placement}`, () => {
         const node = renderWithTheme(
@@ -122,7 +141,9 @@ describe('Tooltip', () => {
         )
 
         const input = node.getByTestId('children') as HTMLInputElement
-        userEvent.hover(input)
+        act(() => {
+          userEvent.hover(input)
+        })
         const tooltipPortal = node.getByText(
           'test success!',
         ) as HTMLInputElement

--- a/src/components/Tooltip/helpers.ts
+++ b/src/components/Tooltip/helpers.ts
@@ -1,0 +1,143 @@
+import { RefObject } from 'react'
+
+export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left' | 'auto'
+export const ARROW_WIDTH = 6 // in px
+export const SPACE = 6 // in px
+export const TOTAL_USED_SPACE = ARROW_WIDTH + SPACE // in px
+export const DEFAULT_POSITIONS = {
+  arrowLeft: 50,
+  arrowTop: 99,
+  arrowTransform: 'translate(-50%, -50)',
+  left: 0,
+  rotate: 135,
+  tooltipInitialPosition: 'translate3d(0, 0, 0))',
+  top: 0,
+}
+
+export const TOOLTIP_INITIAL_POSITION = {
+  auto: `translate3d(0, ${TOTAL_USED_SPACE}px, 0)`,
+  bottom: `translate3d(0, -${TOTAL_USED_SPACE}px, 0)`,
+  left: `translate3d(${TOTAL_USED_SPACE}px, 0, 0)`,
+  right: `translate3d(-${TOTAL_USED_SPACE}px, 0, 0)`,
+  top: `translate3d(0, ${TOTAL_USED_SPACE}px, 0)`,
+}
+
+type ComputePlacementTypes = {
+  childrenStructuredRef: DOMRect
+  tooltipStructuredRef: DOMRect
+}
+
+/**
+ * This function will find the best placement in a window for tooltip based on children position and tooltip size
+ */
+export const computePlacement = ({
+  childrenStructuredRef,
+  tooltipStructuredRef,
+}: ComputePlacementTypes) => {
+  const {
+    top: childrenTop,
+    left: childrenLeft,
+    right: childrenRight,
+  } = childrenStructuredRef
+
+  const { width: tooltipWidth, height: tooltipHeight } = tooltipStructuredRef
+
+  if (childrenTop - tooltipHeight - TOTAL_USED_SPACE < 0) {
+    return 'bottom'
+  }
+
+  if (childrenLeft - tooltipWidth - TOTAL_USED_SPACE < 0) {
+    return 'right'
+  }
+
+  if (childrenRight + tooltipWidth + TOTAL_USED_SPACE > window.innerWidth) {
+    return 'left'
+  }
+
+  return 'top'
+}
+
+type ComputePositionsTypes = {
+  placement: TooltipPlacement
+  childrenRef: RefObject<HTMLDivElement>
+  tooltipRef: RefObject<HTMLDivElement>
+}
+
+/**
+ * This function will compute the positions of tooltip and arrow based on children position and tooltip size
+ */
+export const computePositions = ({
+  placement,
+  childrenRef,
+  tooltipRef,
+}: ComputePositionsTypes) => {
+  const childrenStructuredRef = (
+    childrenRef.current as HTMLDivElement
+  ).getBoundingClientRect()
+  const tooltipStructuredRef = (
+    tooltipRef.current as HTMLDivElement
+  ).getBoundingClientRect()
+
+  const placementBasedOnWindowSize =
+    placement === 'auto'
+      ? computePlacement({
+          childrenStructuredRef,
+          tooltipStructuredRef,
+        })
+      : placement
+
+  console.log(placementBasedOnWindowSize)
+
+  const {
+    top: childrenTop,
+    left: childrenLeft,
+    right: childrenRight,
+    width: childrenWidth,
+    height: childrenHeight,
+  } = childrenStructuredRef
+
+  const { width: tooltipWidth, height: tooltipHeight } = tooltipStructuredRef
+
+  switch (placementBasedOnWindowSize) {
+    case 'bottom':
+      return {
+        arrowLeft: tooltipWidth / 2,
+        arrowTop: -ARROW_WIDTH - 5,
+        arrowTransform: '',
+        left: childrenLeft + childrenWidth / 2 - tooltipWidth / 2,
+        rotate: 180,
+        tooltipInitialPosition: TOOLTIP_INITIAL_POSITION.bottom,
+        top: childrenTop + childrenHeight + ARROW_WIDTH + SPACE,
+      }
+    case 'left':
+      return {
+        arrowLeft: tooltipWidth + ARROW_WIDTH + 5,
+        arrowTop: tooltipHeight / 2,
+        arrowTransform: 'translate(-50%, -50%)',
+        left: childrenLeft - tooltipWidth - ARROW_WIDTH - SPACE * 2,
+        rotate: -90,
+        tooltipInitialPosition: TOOLTIP_INITIAL_POSITION.left,
+        top: childrenTop - tooltipHeight / 2 + childrenHeight / 2,
+      }
+    case 'right':
+      return {
+        arrowLeft: -ARROW_WIDTH - 5,
+        arrowTop: tooltipHeight / 2,
+        arrowTransform: 'translate(50%, -50%)',
+        left: childrenRight + ARROW_WIDTH + SPACE * 2,
+        rotate: 90,
+        tooltipInitialPosition: TOOLTIP_INITIAL_POSITION.right,
+        top: childrenTop - tooltipHeight / 2 + childrenHeight / 2,
+      }
+    default: // top placement is default value
+      return {
+        arrowLeft: tooltipWidth / 2,
+        arrowTop: tooltipHeight - 1,
+        arrowTransform: '',
+        left: childrenLeft + childrenWidth / 2 - tooltipWidth / 2,
+        rotate: 0,
+        tooltipInitialPosition: TOOLTIP_INITIAL_POSITION.top,
+        top: childrenTop - tooltipHeight - ARROW_WIDTH - SPACE,
+      }
+  }
+}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

To allow placement `auto` which will positionnante tooltip depending on its size and window size. 

The goal is to always display tooltip and avoid overflow. In the worst case scenario if the tooltip is too big for any position, it will be displayed on top.

Placement is computed again when window size changes or when user scroll. 

I also made tiny change in CSS: to use `transform3d` for using GPU while rendering and increase performance.

## Relevant logs and/or screenshots

https://user-images.githubusercontent.com/15812968/189650226-e769b335-7726-41f4-ae48-35500a86dbd6.mov


