### PR TITLE
feat(list): add correct type in SelectBar props

### DIFF
--- a/src/components/List/SelectBar.tsx
+++ b/src/components/List/SelectBar.tsx
@@ -32,7 +32,7 @@ const StyledContainer = styled.div`
   justify-content: flex-end;
 `
 
-type ListSelectBarProps<T> = {
+export type ListSelectBarProps<T> = {
   text?: ReactNode | ((length: number) => string)
   children?:
     | ((props: { selectedItems: T[]; unselectAll: () => void }) => ReactNode)

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -20,7 +20,7 @@ import type { PaginationProps } from '../Pagination'
 import usePagination, { UsePaginationReturn } from '../Pagination/usePagination'
 import Placeholder from '../Placeholder'
 import Text from '../Text'
-import SelectBar from './SelectBar'
+import SelectBar, { ListSelectBarProps } from './SelectBar'
 import ListContext, { useListContext } from './context'
 import type {
   ExpandedContentProps,
@@ -127,7 +127,7 @@ export type ListProps<DataType> = {
       | ((props: { children: ReactNode }) => ReactElement | null)
       | ((props: { children: ReactNode }) => ReactElement | null)
     data: DataType[]
-    SelectBar: typeof SelectBar
+    SelectBar: (props: ListSelectBarProps<DataType>) => JSX.Element | null
     Header: () => JSX.Element
     Row: (props: ListRowProps) => JSX.Element
     ExpendableContent: (props: ExpandedContentProps) => JSX.Element
@@ -492,7 +492,7 @@ function List<DataType extends Record<string, unknown>>(
 
     return {
       Body,
-      SelectBar,
+      SelectBar: SelectBar<DataType>,
       ...variantFound,
       Cell: variantFound.Cell,
       ExpendableContent:


### PR DESCRIPTION
## Summary

Before:

```ts
<List<{ message: string }>>
  {(list) => <list.SelectBar>{({selectedItems}) => {...}}</list.SelectBar>}
                             {/* ^ Record<string, unknown> */}
</List>
```

After:

```ts
<List<{ message: string }>>
  {(list) => <list.SelectBar>{({selectedItems}) => {...}}</list.SelectBar>}
                             {/* ^ { message: string }[] */}
</List>
```

## Type

- Enhancement
