### PR TITLE
fix(pagination): do not update max page when list is loading

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -228,7 +228,7 @@ function List<DataType extends Record<string, unknown>>(
 
   const pagination = usePagination({
     data: sortedData,
-    isListLoading: isLoading,
+    isLoading,
     onChangePage: onChangePage || setPage,
     onLoadPage: onLoadPage ? handleLoadPage : undefined,
     page,

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -228,6 +228,7 @@ function List<DataType extends Record<string, unknown>>(
 
   const pagination = usePagination({
     data: sortedData,
+    isListLoading: isLoading,
     onChangePage: onChangePage || setPage,
     onLoadPage: onLoadPage ? handleLoadPage : undefined,
     page,

--- a/src/components/Pagination/usePagination.ts
+++ b/src/components/Pagination/usePagination.ts
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -13,6 +12,7 @@ export type UsePaginationParams<T> = {
   data: T[]
   page: number
   pageCount?: number
+  isListLoading?: boolean
   onLoadPage?: (params: {
     page: number
     perPage?: number
@@ -42,6 +42,7 @@ const usePagination = <T>({
   data,
   page,
   pageCount,
+  isListLoading,
   onLoadPage,
   onChangePage,
   perPage,
@@ -65,15 +66,20 @@ const usePagination = <T>({
         }, {})
       : { [page]: data },
   )
+  const [maxPage, setMaxPage] = useState<number>(
+    pageCount ??
+      Math.max(...Object.keys(paginatedData).map(value => parseInt(value, 10))),
+  )
 
-  const maxPage = useMemo(() => {
-    if (pageCount) return pageCount
-    const pageDataCount = Math.max(
-      ...Object.keys(paginatedData).map(value => parseInt(value, 10)),
+  useEffect(() => {
+    if (isListLoading) return
+    setMaxPage(
+      pageCount ??
+        Math.max(
+          ...Object.keys(paginatedData).map(value => parseInt(value, 10)),
+        ),
     )
-
-    return pageDataCount
-  }, [pageCount, paginatedData])
+  }, [isListLoading, pageCount, paginatedData])
 
   const goToPage = useCallback(
     (wantedPage: number) => {

--- a/src/components/Pagination/usePagination.ts
+++ b/src/components/Pagination/usePagination.ts
@@ -12,7 +12,7 @@ export type UsePaginationParams<T> = {
   data: T[]
   page: number
   pageCount?: number
-  isListLoading?: boolean
+  isLoading?: boolean
   onLoadPage?: (params: {
     page: number
     perPage?: number
@@ -42,7 +42,7 @@ const usePagination = <T>({
   data,
   page,
   pageCount,
-  isListLoading,
+  isLoading,
   onLoadPage,
   onChangePage,
   perPage,
@@ -72,14 +72,14 @@ const usePagination = <T>({
   )
 
   useEffect(() => {
-    if (isListLoading) return
+    if (isLoading) return
     setMaxPage(
       pageCount ??
         Math.max(
           ...Object.keys(paginatedData).map(value => parseInt(value, 10)),
         ),
     )
-  }, [isListLoading, pageCount, paginatedData])
+  }, [isLoading, pageCount, paginatedData])
 
   const goToPage = useCallback(
     (wantedPage: number) => {


### PR DESCRIPTION
## Summary

Make sure that pagination isn't updated while the parent list is loading.

## Type

- Enhancement
