### PR TITLE
docs: make pagination deprecated

### DIFF
--- a/src/components/Pagination/__stories__/index.stories.tsx
+++ b/src/components/Pagination/__stories__/index.stories.tsx
@@ -9,6 +9,9 @@ import ExampleChildren from './ExampleChildren'
 export default {
   component: Pagination,
   parameters: {
+    deprecated: true,
+    deprecatedReason:
+      'This component is deprecated please use PaginationV2 instead.',
     docs: {
       description: {
         component: 'Pagination can be useful for long listings.',

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -444,6 +444,9 @@ function Pagination<T>(
   )
 }
 
+/**
+ * @deprecated Use PaginationV2 instead
+ */
 // @ts-expect-error it breaks on i don't know what
 const PaginationForward = forwardRef(Pagination) as (<T>(
   props: PaginationProps<T> & { ref?: ForwardedRef<PaginationState<T>> },


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Changed pagination to make it deprecated. In storybook too
