### PR TITLE
ci: make sync tokens triggerable

### DIFF
--- a/.github/workflows/sync-design-tokens.yml
+++ b/.github/workflows/sync-design-tokens.yml
@@ -1,6 +1,7 @@
 name: Design tokens
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "30 9 * * 1-5"
 


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Allow action sync tokens to be manually triggered if necessary.

#### The following changes where made:

![image](https://user-images.githubusercontent.com/15812968/193538791-3ef3fc5e-c0c0-436d-b929-7650a7e5ec57.png)

