### PR TITLE
fix(PieChart): vertical scroll auto

### DIFF
--- a/src/components/PieChart/Legends.tsx
+++ b/src/components/PieChart/Legends.tsx
@@ -32,7 +32,7 @@ const List = styled.ul`
   flex: 1;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 `
 
 const ListItem = styled.li<{ isFocused: boolean }>`

--- a/src/components/PieChart/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/PieChart/__tests__/__snapshots__/index.tsx.snap
@@ -28,7 +28,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
   height: 206px;
 }
 
-.cache-1bc84hq-List {
+.cache-1hor4qk-List {
   font-size: 14px;
   list-style-type: none;
   display: -webkit-box;
@@ -42,7 +42,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .cache-exvtnx-ListItem {
@@ -241,7 +241,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       </div>
     </div>
     <ul
-      class="cache-1bc84hq-List enw618e8"
+      class="cache-1hor4qk-List enw618e8"
     >
       <div
         aria-describedby="chart-legend-compute"
@@ -352,7 +352,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
   height: 206px;
 }
 
-.cache-1bc84hq-List {
+.cache-1hor4qk-List {
   font-size: 14px;
   list-style-type: none;
   display: -webkit-box;
@@ -366,7 +366,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .cache-exvtnx-ListItem {
@@ -565,7 +565,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       </div>
     </div>
     <ul
-      class="cache-1bc84hq-List enw618e8"
+      class="cache-1hor4qk-List enw618e8"
     >
       <div
         aria-describedby="chart-legend-compute"
@@ -865,7 +865,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
   height: 206px;
 }
 
-.cache-1bc84hq-List {
+.cache-1hor4qk-List {
   font-size: 14px;
   list-style-type: none;
   display: -webkit-box;
@@ -879,7 +879,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .cache-1klfns5-ListItem {
@@ -1038,7 +1038,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       </div>
     </div>
     <ul
-      class="cache-1bc84hq-List enw618e8"
+      class="cache-1hor4qk-List enw618e8"
     >
       <div
         aria-describedby="chart-legend-compute"
@@ -1135,7 +1135,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
   height: 206px;
 }
 
-.cache-1bc84hq-List {
+.cache-1hor4qk-List {
   font-size: 14px;
   list-style-type: none;
   display: -webkit-box;
@@ -1149,7 +1149,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .cache-1klfns5-ListItem {
@@ -1315,7 +1315,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
       </div>
     </div>
     <ul
-      class="cache-1bc84hq-List enw618e8"
+      class="cache-1hor4qk-List enw618e8"
     >
       <div
         aria-describedby="chart-legend-discount"
@@ -1491,7 +1491,7 @@ exports[`PieChart renders correctly with legend 1`] = `
   height: 206px;
 }
 
-.cache-1bc84hq-List {
+.cache-1hor4qk-List {
   font-size: 14px;
   list-style-type: none;
   display: -webkit-box;
@@ -1505,7 +1505,7 @@ exports[`PieChart renders correctly with legend 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .cache-1klfns5-ListItem {
@@ -1792,7 +1792,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
     </div>
     <ul
-      class="cache-1bc84hq-List enw618e8"
+      class="cache-1hor4qk-List enw618e8"
     >
       <div
         aria-describedby="chart-legend-compute"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Scroll bar is always displayed in PieChart even when legend is not long enough to have a scroll bar. I fixed it by changing prop from `scroll` to `auto`. This way it will show it only when necessary.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| PieChart  | ![Screenshot 2022-10-03 at 11 27 42](https://user-images.githubusercontent.com/15812968/193545762-b3c75a92-d80d-43a7-a508-01da51fa6fc5.png) | ![Screenshot 2022-10-03 at 11 27 59](https://user-images.githubusercontent.com/15812968/193545804-d7f6729c-652a-47cc-8a7f-55353c8c3a15.png) |
