### PR TITLE
fix: force text align in counter

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -22,6 +22,7 @@ const StyledCounter = styled(Text)`
   height: 24px;
   width: 24px;
   line-height: 22px;
+  text-align: center;
 `
 
 const StyledTooltip = styled(Tooltip)``

--- a/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -1155,7 +1155,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-vvk6yx-StyledText-StyledCounter {
+.cache-5l885d-StyledText-StyledCounter {
   color: #4a4f62;
   font-size: 12px;
   font-family: Asap;
@@ -1175,6 +1175,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   height: 24px;
   width: 24px;
   line-height: 22px;
+  text-align: center;
 }
 
 .cache-1hjfwlj-BadgeContainer {
@@ -1447,7 +1448,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       Counter
       <span
-        class="e1ej5pcd3 cache-vvk6yx-StyledText-StyledCounter e1tg3t120"
+        class="e1ej5pcd3 cache-5l885d-StyledText-StyledCounter e1tg3t120"
       >
         12
       </span>
@@ -1461,7 +1462,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     >
       Conter and badge
       <span
-        class="e1ej5pcd3 cache-vvk6yx-StyledText-StyledCounter e1tg3t120"
+        class="e1ej5pcd3 cache-5l885d-StyledText-StyledCounter e1tg3t120"
       >
         12
       </span>
@@ -1824,7 +1825,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-vvk6yx-StyledText-StyledCounter {
+.cache-5l885d-StyledText-StyledCounter {
   color: #4a4f62;
   font-size: 12px;
   font-family: Asap;
@@ -1844,6 +1845,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   height: 24px;
   width: 24px;
   line-height: 22px;
+  text-align: center;
 }
 
 .cache-1hjfwlj-BadgeContainer {
@@ -2023,7 +2025,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           >
             Counter
             <span
-              class="e1ej5pcd3 cache-vvk6yx-StyledText-StyledCounter e1tg3t120"
+              class="e1ej5pcd3 cache-5l885d-StyledText-StyledCounter e1tg3t120"
             >
               12
             </span>
@@ -2037,7 +2039,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           >
             Conter and badge
             <span
-              class="e1ej5pcd3 cache-vvk6yx-StyledText-StyledCounter e1tg3t120"
+              class="e1ej5pcd3 cache-5l885d-StyledText-StyledCounter e1tg3t120"
             >
               12
             </span>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Force counter to be centered. In our console other styles override the default behaviour

#### The following changes where made:

1. Add text-align: center
