### PR TITLE
ci: fix flacky ci and remove unsed code

### DIFF
--- a/src/__tests__/a11y.test.tsx
+++ b/src/__tests__/a11y.test.tsx
@@ -66,11 +66,7 @@ if (process.argv[4]) {
 
 expect.extend(toHaveNoViolations)
 
-jest.setTimeout(90000)
-
-// TODO: Remove this once https://github.com/nickcolley/jest-axe/issues/147 is fixed.
-const { getComputedStyle } = window
-window.getComputedStyle = elt => getComputedStyle(elt)
+jest.setTimeout(120000)
 
 describe('A11y', () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

Some a11y tests are failing on CI so I increased the timeout value as TextBox sometimes take a little long to complete.

I also removed a snippet of code that has been fixed since last release of axe-jest.
