### PR TITLE
fix: container props

### DIFF
--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -57,7 +57,7 @@ type ContainerProps = ContainerBaseProps & {
   header?: ReactNode
   /** Right title can be a string but also a component, like header properties does. */
   rightTitle?: ReactNode
-  subtitle?: string
+  subtitle?: ReactNode
   title: string
 } & BoxProps
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Sometimes in our console we need to pass an Element to the subtitle (like Badge)

#### The following changes where made:

1. Update type
