### PR TITLE
style: add inline nested component eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,25 +66,10 @@
       }
     },
     {
-      "files": ["**/__stories__/**/*.{ts,tsx}"],
+      "files": ["**/__stories__/**/*.stories.{ts,tsx}"],
       "rules": {
-        // Unused vars : to allow storybook to show code snippets on custom stories
-        "no-unused-vars": [
-          "error",
-          {
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ],
-        "@typescript-eslint/no-unused-vars": [
-          "error",
-          {
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_"
-          }
-        ]
+        // Allow inline nested components (for code snippets)
+        "react/no-unstable-nested-components": "off"
       }
     }
   ]

--- a/src/components/Menu/__stories__/Variants.tsx
+++ b/src/components/Menu/__stories__/Variants.tsx
@@ -10,6 +10,7 @@ const DefaultDisclosure = (
   </Touchable>
 )
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const Variants: Story = _props => (
   <Menu disclosure={DefaultDisclosure}>
     <Menu.Item>default</Menu.Item>


### PR DESCRIPTION
## Summary

We don't need to disable `no-unused-vars` anymore as we figured out that our Storybook config automatically parse the code snippets for files ending with `stories.tsx`

But, we need to disable `react/no-unstable-nested-components` because for some case it is required to inline components in our stories