### PR TITLE
docs: fix description not display in storybook

### DIFF
--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -44,6 +44,7 @@ const DocsContainer: typeof CustomBaseContainer = ({ context, children }) => {
               parameters: {
                 ...storyContext?.parameters,
                 docs: {
+                  ...storyContext?.parameters.docs,
                   theme: isDarkTheme ? dark : light,
                 },
               },


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

There was an issue with description in storybook. It seems like it wasn't displayed since I made custom storybook parameters and dark theme. I forgot to spread parameters in context, now it should work just fine.

Before:

![Screenshot 2022-10-14 at 15 42 52](https://user-images.githubusercontent.com/15812968/195862058-02c65c53-2f35-465d-9f9a-49e99d8cc677.png)


After:

![Screenshot 2022-10-14 at 15 42 37](https://user-images.githubusercontent.com/15812968/195862074-b542f8f9-5b8c-4656-83e8-1b17e401c602.png)
