### PR TITLE
fix(Tabs): dynamic width and more menu

### DIFF
--- a/src/components/Tabs/__stories__/index.stories.tsx
+++ b/src/components/Tabs/__stories__/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, Story } from '@storybook/react'
-import { ComponentProps, useState } from 'react'
+import { ComponentProps, useEffect, useState } from 'react'
 import Tabs from '..'
 import Badge from '../../Badge'
 import Tab from '../Tab'
@@ -223,3 +223,36 @@ WithCounter.args = {
   ],
   selected: 1,
 }
+
+export const Test = Template.bind({})
+Test.decorators = [
+  () => {
+    const [change, onChange] = useState(2)
+    const onChangeHandler = (e?: string | number) => onChange(e)
+    const [counter, setCounter] = useState<number | undefined>(undefined)
+
+    useEffect(() => {
+      setTimeout(() => setCounter(2), 2000)
+    }, [])
+
+    return (
+      <Tabs selected={change} onChange={onChangeHandler}>
+        <Tabs.Tab value={1} counter={counter}>
+          First Awesome Tab
+        </Tabs.Tab>
+        <Tabs.Tab value={2} counter={counter}>
+          Second Awesome Tab
+        </Tabs.Tab>
+        <Tabs.Tab value={3} counter={counter}>
+          Third Awesome Tab
+        </Tabs.Tab>
+        <Tabs.Tab value={4} counter={counter}>
+          Fourth Awesome Tab
+        </Tabs.Tab>
+        <Tabs.Tab value={5} counter={counter}>
+          Fifth Awesome Tab blablabla
+        </Tabs.Tab>
+      </Tabs>
+    )
+  },
+]

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -37,14 +37,22 @@ const StyledTabMenu = styled(TabMenu)`
   box-shadow: ${({ theme }) => theme.shadows.menu};
 `
 
+const TabsRoot = styled.div`
+  position: relative;
+  display: flex;
+  overflow-x: scroll;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  z-index: 0;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`
+
 const TabsContainer = styled.div`
   display: flex;
   flex-wrap: nowrap;
-  overflow-x: scroll;
-  position: relative;
-  z-index: 0;
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
 
   &::after {
     z-index: -1;
@@ -55,10 +63,6 @@ const TabsContainer = styled.div`
     right: 0;
     height: 2px;
     background: ${({ theme }) => theme.colors.neutral.borderWeak};
-  }
-
-  &::-webkit-scrollbar {
-    display: none;
   }
 `
 
@@ -77,6 +81,7 @@ const Tabs = ({
   selected,
   ...props
 }: TabsProps) => {
+  const rootRef = useRef<HTMLDivElement>({} as HTMLDivElement)
   const tabsRef = useRef<HTMLDivElement>({} as HTMLDivElement)
   const moreStaticRef = useRef<HTMLButtonElement>({} as HTMLButtonElement)
   const [displayMore, setDisplayMore] = useState(false)
@@ -89,7 +94,13 @@ const Tabs = ({
   )
 
   useEffect(() => {
-    setDisplayMore(tabsRef.current.scrollWidth > tabsRef.current.clientWidth)
+    const observedTarget = tabsRef.current
+    const observer = new ResizeObserver(() => {
+      setDisplayMore(observedTarget.scrollWidth > rootRef.current.clientWidth)
+    })
+    observer.observe(observedTarget)
+
+    return () => observedTarget && observer.unobserve(observedTarget)
   }, [])
 
   // Scroll automatically to the tab
@@ -128,14 +139,16 @@ const Tabs = ({
 
   return (
     <TabsContext.Provider value={value}>
-      <TabsContainer ref={tabsRef} role="tablist" {...props}>
-        {children}
+      <TabsRoot ref={rootRef}>
+        <TabsContainer ref={tabsRef} role="tablist" {...props}>
+          {children}
+        </TabsContainer>
         {displayMore ? (
           <StyledTabMenu ref={moreStaticRef} disclosure={moreDisclosure}>
             <MenuContainer>{children}</MenuContainer>
           </StyledTabMenu>
         ) : null}
-      </TabsContainer>
+      </TabsRoot>
     </TabsContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary

## Type

- Bug ✅ 
- Feature
- Enhancement
- Documentation
- Migration
- Refactor

### Summarise concisely:

Tabs width wasn't recomputed. In some cases "More" menu wasn't displayed

#### What is expected?

Bug should be fixed

#### The following changes where made:

1. Add a new wrapper layer to have a clean tabs content width resize detect