### PR TITLE
fix: add button type to styled buttons

### DIFF
--- a/src/components/PaginationV2/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/PaginationV2/__tests__/__snapshots__/index.test.tsx.snap
@@ -306,6 +306,7 @@ exports[`Pagination should render correctly 1`] = `
         aria-current="true"
         aria-label="Page 1"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         1
       </button>
@@ -313,6 +314,7 @@ exports[`Pagination should render correctly 1`] = `
         aria-current="false"
         aria-label="Page 2"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         2
       </button>
@@ -320,6 +322,7 @@ exports[`Pagination should render correctly 1`] = `
         aria-current="false"
         aria-label="Page 3"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         3
       </button>
@@ -327,6 +330,7 @@ exports[`Pagination should render correctly 1`] = `
         aria-current="false"
         aria-label="Page 4"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         4
       </button>
@@ -334,6 +338,7 @@ exports[`Pagination should render correctly 1`] = `
         aria-current="false"
         aria-label="Page 5"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         5
       </button>
@@ -615,6 +620,7 @@ exports[`Pagination should render correctly component with disabled 1`] = `
         aria-label="Page 4"
         class="cache-1senakc-StyledPageButton e2j7atg0"
         disabled=""
+        type="button"
       >
         4
       </button>
@@ -623,6 +629,7 @@ exports[`Pagination should render correctly component with disabled 1`] = `
         aria-label="Page 5"
         class="cache-1senakc-StyledPageButton e2j7atg0"
         disabled=""
+        type="button"
       >
         5
       </button>
@@ -631,6 +638,7 @@ exports[`Pagination should render correctly component with disabled 1`] = `
         aria-label="Page 6"
         class="cache-1senakc-StyledPageButton e2j7atg0"
         disabled=""
+        type="button"
       >
         6
       </button>
@@ -914,6 +922,7 @@ exports[`Pagination should render correctly component with disabled 2`] = `
         aria-label="Page 4"
         class="cache-1senakc-StyledPageButton e2j7atg0"
         disabled=""
+        type="button"
       >
         4
       </button>
@@ -922,6 +931,7 @@ exports[`Pagination should render correctly component with disabled 2`] = `
         aria-label="Page 5"
         class="cache-1senakc-StyledPageButton e2j7atg0"
         disabled=""
+        type="button"
       >
         5
       </button>
@@ -930,6 +940,7 @@ exports[`Pagination should render correctly component with disabled 2`] = `
         aria-label="Page 6"
         class="cache-1senakc-StyledPageButton e2j7atg0"
         disabled=""
+        type="button"
       >
         6
       </button>
@@ -1200,6 +1211,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         aria-current="false"
         aria-label="Page 4"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         4
       </button>
@@ -1207,6 +1219,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         aria-current="true"
         aria-label="Page 5"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         5
       </button>
@@ -1214,6 +1227,7 @@ exports[`Pagination should render correctly component with pageTabCount 1`] = `
         aria-current="false"
         aria-label="Page 6"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         6
       </button>
@@ -1482,6 +1496,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
         aria-current="false"
         aria-label="Page 1"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         1
       </button>
@@ -1489,6 +1504,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
         aria-current="true"
         aria-label="Page 2"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         2
       </button>
@@ -1496,6 +1512,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
         aria-current="false"
         aria-label="Page 3"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         3
       </button>
@@ -1503,6 +1520,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
         aria-current="false"
         aria-label="Page 4"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         4
       </button>
@@ -1510,6 +1528,7 @@ exports[`Pagination should render correctly with pageClick 1`] = `
         aria-current="false"
         aria-label="Page 5"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         5
       </button>
@@ -1790,6 +1809,7 @@ exports[`Pagination should render correctly with pageCount is 1 1`] = `
         aria-current="true"
         aria-label="Page 1"
         class="cache-1senakc-StyledPageButton e2j7atg0"
+        type="button"
       >
         1
       </button>

--- a/src/components/PaginationV2/index.tsx
+++ b/src/components/PaginationV2/index.tsx
@@ -146,6 +146,7 @@ function Pagination({
             disabled={disabled}
             aria-current={pageNumber === page}
             onClick={handlePageClick(pageNumber)}
+            type="button"
           >
             {pageNumber}
           </StyledPageButton>

--- a/src/components/SelectNumber/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/SelectNumber/__tests__/__snapshots__/index.tsx.snap
@@ -109,6 +109,7 @@ exports[`SelectNumber should click on center button 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -136,6 +137,7 @@ exports[`SelectNumber should click on center button 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -259,6 +261,7 @@ exports[`SelectNumber should click on min button 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -286,6 +289,7 @@ exports[`SelectNumber should click on min button 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -409,6 +413,7 @@ exports[`SelectNumber should click on plus button with a step value 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -436,6 +441,7 @@ exports[`SelectNumber should click on plus button with a step value 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -559,6 +565,7 @@ exports[`SelectNumber should click on plus button with a step value and an in-be
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -586,6 +593,7 @@ exports[`SelectNumber should click on plus button with a step value and an in-be
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -709,6 +717,7 @@ exports[`SelectNumber should focus input and modify value 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -736,6 +745,7 @@ exports[`SelectNumber should focus input and modify value 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -873,6 +883,7 @@ exports[`SelectNumber should focus input and modify value onMaxCrossed 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -901,6 +912,7 @@ exports[`SelectNumber should focus input and modify value onMaxCrossed 1`] = `
       aria-label="Plus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1039,6 +1051,7 @@ exports[`SelectNumber should focus input and modify value onMinCrossed 1`] = `
       aria-label="Minus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1066,6 +1079,7 @@ exports[`SelectNumber should focus input and modify value onMinCrossed 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1203,6 +1217,7 @@ exports[`SelectNumber should increase and decrease input with arrow up and down 
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1231,6 +1246,7 @@ exports[`SelectNumber should increase and decrease input with arrow up and down 
       aria-label="Plus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1362,6 +1378,7 @@ exports[`SelectNumber should renders correctly 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1394,6 +1411,7 @@ exports[`SelectNumber should renders correctly 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1537,6 +1555,7 @@ exports[`SelectNumber should renders correctly disabled 1`] = `
       aria-label="Minus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1571,6 +1590,7 @@ exports[`SelectNumber should renders correctly disabled 1`] = `
       aria-label="Plus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1716,6 +1736,7 @@ exports[`SelectNumber should renders correctly max value 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1749,6 +1770,7 @@ exports[`SelectNumber should renders correctly max value 1`] = `
       aria-label="Plus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1895,6 +1917,7 @@ exports[`SelectNumber should renders correctly min value 1`] = `
       aria-label="Minus"
       class="cache-asskgt-StyledSelectButton ermgxlz4"
       disabled=""
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -1927,6 +1950,7 @@ exports[`SelectNumber should renders correctly min value 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -2050,6 +2074,7 @@ exports[`SelectNumber should renders large size 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -2077,6 +2102,7 @@ exports[`SelectNumber should renders large size 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-oodroo-StyledIcon-sizeStyles etwatq50"
@@ -2200,6 +2226,7 @@ exports[`SelectNumber should renders small size 1`] = `
     <button
       aria-label="Minus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-lii5tu-StyledIcon-sizeStyles etwatq50"
@@ -2227,6 +2254,7 @@ exports[`SelectNumber should renders small size 1`] = `
     <button
       aria-label="Plus"
       class="cache-1h5w6a8-StyledSelectButton ermgxlz4"
+      type="button"
     >
       <svg
         class="cache-lii5tu-StyledIcon-sizeStyles etwatq50"

--- a/src/components/SelectNumber/index.tsx
+++ b/src/components/SelectNumber/index.tsx
@@ -280,6 +280,7 @@ const SelectNumber = ({
           onClick={offsetFn(-1)}
           disabled={isMinusDisabled}
           aria-label="Minus"
+          type="button"
         >
           <Icon name="minus" size={iconSizes[size]} />
         </StyledSelectButton>
@@ -322,6 +323,7 @@ const SelectNumber = ({
           onClick={offsetFn(1)}
           disabled={isPlusDisabled}
           aria-label="Plus"
+          type="button"
         >
           <Icon name="plus" size={iconSizes[size]} />
         </StyledSelectButton>


### PR DESCRIPTION
Default button `type` prop is `submit` and it is not expected for our styled buttons
