### PR TITLE
fix(Badge): consistent element sizing across variants

### DIFF
--- a/src/components/Badge/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Badge/__tests__/__snapshots__/index.tsx.snap
@@ -287,7 +287,7 @@ exports[`Badge renders correctly size small 1`] = `
 
 exports[`Badge renders correctly variant danger 1`] = `
 <DocumentFragment>
-  .cache-fe1k7o-StyledBox {
+  .cache-1jpkeko-StyledBox {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -310,6 +310,7 @@ exports[`Badge renders correctly variant danger 1`] = `
   height: 24px;
   color: #a6102d;
   background: #ffe1e7;
+  border: 1px solid transparent;
 }
 
 .cache-1vwepwg-StyledText-StyledText {
@@ -330,7 +331,7 @@ exports[`Badge renders correctly variant danger 1`] = `
 <div
     aria-label="danger"
     as="span"
-    class="cache-fe1k7o-StyledBox egvl2gp0"
+    class="cache-1jpkeko-StyledBox egvl2gp0"
     role="status"
   >
     <p
@@ -344,7 +345,7 @@ exports[`Badge renders correctly variant danger 1`] = `
 
 exports[`Badge renders correctly variant info 1`] = `
 <DocumentFragment>
-  .cache-1y7w5ob-StyledBox {
+  .cache-e8kl4x-StyledBox {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -367,6 +368,7 @@ exports[`Badge renders correctly variant info 1`] = `
   height: 24px;
   color: #1a4dbf;
   background: #e1ebff;
+  border: 1px solid transparent;
 }
 
 .cache-1vwepwg-StyledText-StyledText {
@@ -387,7 +389,7 @@ exports[`Badge renders correctly variant info 1`] = `
 <div
     aria-label="info"
     as="span"
-    class="cache-1y7w5ob-StyledBox egvl2gp0"
+    class="cache-e8kl4x-StyledBox egvl2gp0"
     role="status"
   >
     <p
@@ -458,7 +460,7 @@ exports[`Badge renders correctly variant neutral 1`] = `
 
 exports[`Badge renders correctly variant primary 1`] = `
 <DocumentFragment>
-  .cache-1ul7gvf-StyledBox {
+  .cache-161u4aq-StyledBox {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -481,6 +483,7 @@ exports[`Badge renders correctly variant primary 1`] = `
   height: 24px;
   color: #390171;
   background: #eeeeff;
+  border: 1px solid transparent;
 }
 
 .cache-1vwepwg-StyledText-StyledText {
@@ -500,7 +503,7 @@ exports[`Badge renders correctly variant primary 1`] = `
 
 <div
     as="span"
-    class="cache-1ul7gvf-StyledBox egvl2gp0"
+    class="cache-161u4aq-StyledBox egvl2gp0"
     role="status"
   >
     <p
@@ -514,7 +517,7 @@ exports[`Badge renders correctly variant primary 1`] = `
 
 exports[`Badge renders correctly variant success 1`] = `
 <DocumentFragment>
-  .cache-19imrtp-StyledBox {
+  .cache-1lxk5wh-StyledBox {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -537,6 +540,7 @@ exports[`Badge renders correctly variant success 1`] = `
   height: 24px;
   color: #149a7b;
   background: #eafffb;
+  border: 1px solid transparent;
 }
 
 .cache-1vwepwg-StyledText-StyledText {
@@ -557,7 +561,7 @@ exports[`Badge renders correctly variant success 1`] = `
 <div
     aria-label="success"
     as="span"
-    class="cache-19imrtp-StyledBox egvl2gp0"
+    class="cache-1lxk5wh-StyledBox egvl2gp0"
     role="status"
   >
     <p
@@ -571,7 +575,7 @@ exports[`Badge renders correctly variant success 1`] = `
 
 exports[`Badge renders correctly variant warning 1`] = `
 <DocumentFragment>
-  .cache-1xufqqv-StyledBox {
+  .cache-1oq7xgr-StyledBox {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -594,6 +598,7 @@ exports[`Badge renders correctly variant warning 1`] = `
   height: 24px;
   color: #cc4e18;
   background: #ffefe6;
+  border: 1px solid transparent;
 }
 
 .cache-1vwepwg-StyledText-StyledText {
@@ -614,7 +619,7 @@ exports[`Badge renders correctly variant warning 1`] = `
 <div
     aria-label="warning"
     as="span"
-    class="cache-1xufqqv-StyledBox egvl2gp0"
+    class="cache-1oq7xgr-StyledBox egvl2gp0"
     role="status"
   >
     <p

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -58,7 +58,8 @@ const generateStyles = ({
       };
       background: ${
         theme.colors[sentiment][background as keyof typeof theme.colors.primary]
-      }
+      };
+      border: 1px solid transparent;
     `,
       }),
       {},

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -51,7 +51,6 @@ export const StyledTabButton = styled.button`
   font-weight: ${({ theme }) => theme.typography.bodyStrong.weight};
   letter-spacing: ${({ theme }) => theme.typography.bodyStrong.letterSpacing};
   line-height: ${({ theme }) => theme.typography.bodyStrong.lineHeight};
-  text-case: ${({ theme }) => theme.typography.bodyStrong.textCase};
 
   &:hover,
   &:active,

--- a/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/components/Tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -73,7 +73,7 @@ exports[`Tabs renders correctly with Tabs and last disabled 1`] = `
   display: none;
 }
 
-.cache-17hs8u6-StyledTabButton {
+.cache-1iuo8xk-StyledTabButton {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -113,44 +113,43 @@ exports[`Tabs renders correctly with Tabs and last disabled 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-17hs8u6-StyledTabButton:hover,
-.cache-17hs8u6-StyledTabButton:active,
-.cache-17hs8u6-StyledTabButton:focus {
+.cache-1iuo8xk-StyledTabButton:hover,
+.cache-1iuo8xk-StyledTabButton:active,
+.cache-1iuo8xk-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-17hs8u6-StyledTabButton:focus-visible {
+.cache-1iuo8xk-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-selected='true'] {
+.cache-1iuo8xk-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='true'],
-.cache-17hs8u6-StyledTabButton:disabled {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='true'],
+.cache-1iuo8xk-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
@@ -163,7 +162,7 @@ exports[`Tabs renders correctly with Tabs and last disabled 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -173,7 +172,7 @@ exports[`Tabs renders correctly with Tabs and last disabled 1`] = `
       aria-disabled="false"
       aria-label="1"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -183,7 +182,7 @@ exports[`Tabs renders correctly with Tabs and last disabled 1`] = `
       aria-disabled="true"
       aria-label="2"
       aria-selected="true"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       disabled=""
       role="tab"
       type="button"
@@ -227,7 +226,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
   display: none;
 }
 
-.cache-17hs8u6-StyledTabButton {
+.cache-1iuo8xk-StyledTabButton {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,50 +266,49 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-17hs8u6-StyledTabButton:hover,
-.cache-17hs8u6-StyledTabButton:active,
-.cache-17hs8u6-StyledTabButton:focus {
+.cache-1iuo8xk-StyledTabButton:hover,
+.cache-1iuo8xk-StyledTabButton:active,
+.cache-1iuo8xk-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-17hs8u6-StyledTabButton:focus-visible {
+.cache-1iuo8xk-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-selected='true'] {
+.cache-1iuo8xk-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='true'],
-.cache-17hs8u6-StyledTabButton:disabled {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='true'],
+.cache-1iuo8xk-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu {
+.cache-8u14mj-StyledTabButton-StyledMenu {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -350,57 +348,56 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu:hover,
-.cache-18rgc9u-StyledTabButton-StyledMenu:active,
-.cache-18rgc9u-StyledTabButton-StyledMenu:focus {
+.cache-8u14mj-StyledTabButton-StyledMenu:hover,
+.cache-8u14mj-StyledTabButton-StyledMenu:active,
+.cache-8u14mj-StyledTabButton-StyledMenu:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu:focus-visible {
+.cache-8u14mj-StyledTabButton-StyledMenu:focus-visible {
   outline: auto;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-selected='true'] {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='true'],
-.cache-18rgc9u-StyledTabButton-StyledMenu:disabled {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='true'],
+.cache-8u14mj-StyledTabButton-StyledMenu:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu .e12ogfvr1 {
+.cache-8u14mj-StyledTabButton-StyledMenu .e12ogfvr1 {
   color: inherit;
   margin-left: 8px;
   -webkit-transition: 300ms -webkit-transform ease-out;
   transition: 300ms transform ease-out;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-expanded='true'] .e12ogfvr1 {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-expanded='true'] .e12ogfvr1 {
   -webkit-transform: rotate(-180deg);
   -moz-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
@@ -423,7 +420,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -433,7 +430,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       aria-disabled="false"
       aria-label="1"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -443,7 +440,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       aria-disabled="false"
       aria-label="2"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -454,7 +451,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       aria-disabled="false"
       aria-expanded="true"
       aria-haspopup="dialog"
-      class="cache-18rgc9u-StyledTabButton-StyledMenu e12ogfvr0"
+      class="cache-8u14mj-StyledTabButton-StyledMenu e12ogfvr0"
       role="tab"
       type="button"
     >
@@ -473,7 +470,7 @@ exports[`Tabs renders correctly with Tabs menu selected 1`] = `
       aria-disabled="true"
       aria-expanded="false"
       aria-haspopup="dialog"
-      class="cache-18rgc9u-StyledTabButton-StyledMenu e12ogfvr0"
+      class="cache-8u14mj-StyledTabButton-StyledMenu e12ogfvr0"
       disabled=""
       role="tab"
       type="button"
@@ -894,7 +891,7 @@ exports[`Tabs renders correctly with Tabs name 1`] = `
   display: none;
 }
 
-.cache-17hs8u6-StyledTabButton {
+.cache-1iuo8xk-StyledTabButton {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -934,44 +931,43 @@ exports[`Tabs renders correctly with Tabs name 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-17hs8u6-StyledTabButton:hover,
-.cache-17hs8u6-StyledTabButton:active,
-.cache-17hs8u6-StyledTabButton:focus {
+.cache-1iuo8xk-StyledTabButton:hover,
+.cache-1iuo8xk-StyledTabButton:active,
+.cache-1iuo8xk-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-17hs8u6-StyledTabButton:focus-visible {
+.cache-1iuo8xk-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-selected='true'] {
+.cache-1iuo8xk-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='true'],
-.cache-17hs8u6-StyledTabButton:disabled {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='true'],
+.cache-1iuo8xk-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
@@ -985,7 +981,7 @@ exports[`Tabs renders correctly with Tabs name 1`] = `
       aria-disabled="false"
       aria-label="first"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -995,7 +991,7 @@ exports[`Tabs renders correctly with Tabs name 1`] = `
       aria-disabled="false"
       aria-label="second"
       aria-selected="true"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1005,7 +1001,7 @@ exports[`Tabs renders correctly with Tabs name 1`] = `
       aria-disabled="true"
       aria-label="three"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       disabled=""
       role="tab"
       type="button"
@@ -1049,7 +1045,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   display: none;
 }
 
-.cache-17hs8u6-StyledTabButton {
+.cache-1iuo8xk-StyledTabButton {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1089,50 +1085,49 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-17hs8u6-StyledTabButton:hover,
-.cache-17hs8u6-StyledTabButton:active,
-.cache-17hs8u6-StyledTabButton:focus {
+.cache-1iuo8xk-StyledTabButton:hover,
+.cache-1iuo8xk-StyledTabButton:active,
+.cache-1iuo8xk-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-17hs8u6-StyledTabButton:focus-visible {
+.cache-1iuo8xk-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-selected='true'] {
+.cache-1iuo8xk-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='true'],
-.cache-17hs8u6-StyledTabButton:disabled {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='true'],
+.cache-1iuo8xk-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-6vti4y-StyledBox-StyledBadge {
+.cache-zdsvd2-StyledBox-StyledBadge {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1155,6 +1150,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   height: 24px;
   color: #390171;
   background: #eeeeff;
+  border: 1px solid transparent;
   padding: 0 8px;
   margin-left: 8px;
 }
@@ -1210,7 +1206,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   display: flex;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu {
+.cache-8u14mj-StyledTabButton-StyledMenu {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1250,57 +1246,56 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu:hover,
-.cache-18rgc9u-StyledTabButton-StyledMenu:active,
-.cache-18rgc9u-StyledTabButton-StyledMenu:focus {
+.cache-8u14mj-StyledTabButton-StyledMenu:hover,
+.cache-8u14mj-StyledTabButton-StyledMenu:active,
+.cache-8u14mj-StyledTabButton-StyledMenu:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu:focus-visible {
+.cache-8u14mj-StyledTabButton-StyledMenu:focus-visible {
   outline: auto;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-selected='true'] {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='true'],
-.cache-18rgc9u-StyledTabButton-StyledMenu:disabled {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='true'],
+.cache-8u14mj-StyledTabButton-StyledMenu:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu .e12ogfvr1 {
+.cache-8u14mj-StyledTabButton-StyledMenu .e12ogfvr1 {
   color: inherit;
   margin-left: 8px;
   -webkit-transition: 300ms -webkit-transform ease-out;
   transition: 300ms transform ease-out;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-expanded='true'] .e12ogfvr1 {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-expanded='true'] .e12ogfvr1 {
   -webkit-transform: rotate(-180deg);
   -moz-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
@@ -1316,7 +1311,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   min-height: 1em;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1356,7 +1351,6 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
   position: -webkit-sticky;
   position: sticky;
   right: 0;
@@ -1366,54 +1360,54 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   box-shadow: 0px 0px 24px 6px #D4DAE766;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu:hover,
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu:active,
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu:focus {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu:hover,
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu:active,
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu:focus-visible {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu:focus-visible {
   outline: auto;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-selected='true'] {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):hover,
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):focus,
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):active {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):hover,
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):focus,
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='true'],
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu:disabled {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-disabled='true'],
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu .e12ogfvr1 {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu .e12ogfvr1 {
   color: inherit;
   margin-left: 8px;
   -webkit-transition: 300ms -webkit-transform ease-out;
   transition: 300ms transform ease-out;
 }
 
-.cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu[aria-expanded='true'] .e12ogfvr1 {
+.cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu[aria-expanded='true'] .e12ogfvr1 {
   -webkit-transform: rotate(-180deg);
   -moz-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
@@ -1427,14 +1421,14 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="true"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
       First
       <div
         as="span"
-        class="e1ej5pcd3 cache-6vti4y-StyledBox-StyledBadge egvl2gp0"
+        class="e1ej5pcd3 cache-zdsvd2-StyledBox-StyledBadge egvl2gp0"
         role="status"
       >
         <p
@@ -1448,7 +1442,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       aria-disabled="false"
       aria-label="1"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1457,7 +1451,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1466,7 +1460,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1487,7 +1481,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       aria-disabled="false"
       aria-label="2"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1507,7 +1501,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1532,7 +1526,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1546,7 +1540,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1555,7 +1549,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1564,7 +1558,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1573,7 +1567,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1582,7 +1576,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1591,7 +1585,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1600,7 +1594,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1609,7 +1603,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1618,7 +1612,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1627,7 +1621,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1636,7 +1630,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
     <button
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
       type="button"
     >
@@ -1647,7 +1641,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="dialog"
-      class="cache-18rgc9u-StyledTabButton-StyledMenu e12ogfvr0"
+      class="cache-8u14mj-StyledTabButton-StyledMenu e12ogfvr0"
       role="tab"
       type="button"
     >
@@ -1666,7 +1660,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
       aria-disabled="false"
       aria-expanded="true"
       aria-haspopup="dialog"
-      class="e1h41e5k1 cache-1xmpwe9-StyledTabButton-StyledMenu-StyledTabMenu e12ogfvr0"
+      class="e1h41e5k1 cache-1ylocks-StyledTabButton-StyledMenu-StyledTabMenu e12ogfvr0"
       role="tab"
       style="box-shadow: none;"
       type="button"
@@ -1795,7 +1789,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   background-color: transparent;
 }
 
-.cache-17hs8u6-StyledTabButton {
+.cache-1iuo8xk-StyledTabButton {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1835,50 +1829,49 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-17hs8u6-StyledTabButton:hover,
-.cache-17hs8u6-StyledTabButton:active,
-.cache-17hs8u6-StyledTabButton:focus {
+.cache-1iuo8xk-StyledTabButton:hover,
+.cache-1iuo8xk-StyledTabButton:active,
+.cache-1iuo8xk-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-17hs8u6-StyledTabButton:focus-visible {
+.cache-1iuo8xk-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-selected='true'] {
+.cache-1iuo8xk-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='true'],
-.cache-17hs8u6-StyledTabButton:disabled {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='true'],
+.cache-1iuo8xk-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-6vti4y-StyledBox-StyledBadge {
+.cache-zdsvd2-StyledBox-StyledBadge {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1901,6 +1894,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   height: 24px;
   color: #390171;
   background: #eeeeff;
+  border: 1px solid transparent;
   padding: 0 8px;
   margin-left: 8px;
 }
@@ -1956,7 +1950,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   display: flex;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu {
+.cache-8u14mj-StyledTabButton-StyledMenu {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1996,57 +1990,56 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu:hover,
-.cache-18rgc9u-StyledTabButton-StyledMenu:active,
-.cache-18rgc9u-StyledTabButton-StyledMenu:focus {
+.cache-8u14mj-StyledTabButton-StyledMenu:hover,
+.cache-8u14mj-StyledTabButton-StyledMenu:active,
+.cache-8u14mj-StyledTabButton-StyledMenu:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu:focus-visible {
+.cache-8u14mj-StyledTabButton-StyledMenu:focus-visible {
   outline: auto;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-selected='true'] {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-disabled='true'],
-.cache-18rgc9u-StyledTabButton-StyledMenu:disabled {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-disabled='true'],
+.cache-8u14mj-StyledTabButton-StyledMenu:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu .e12ogfvr1 {
+.cache-8u14mj-StyledTabButton-StyledMenu .e12ogfvr1 {
   color: inherit;
   margin-left: 8px;
   -webkit-transition: 300ms -webkit-transform ease-out;
   transition: 300ms transform ease-out;
 }
 
-.cache-18rgc9u-StyledTabButton-StyledMenu[aria-expanded='true'] .e12ogfvr1 {
+.cache-8u14mj-StyledTabButton-StyledMenu[aria-expanded='true'] .e12ogfvr1 {
   -webkit-transform: rotate(-180deg);
   -moz-transform: rotate(-180deg);
   -ms-transform: rotate(-180deg);
@@ -2084,14 +2077,14 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="true"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
             First
             <div
               as="span"
-              class="e1ej5pcd3 cache-6vti4y-StyledBox-StyledBadge egvl2gp0"
+              class="e1ej5pcd3 cache-zdsvd2-StyledBox-StyledBadge egvl2gp0"
               role="status"
             >
               <p
@@ -2105,7 +2098,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
             aria-disabled="false"
             aria-label="1"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2114,7 +2107,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2123,7 +2116,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2144,7 +2137,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
             aria-disabled="false"
             aria-label="2"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2164,7 +2157,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2189,7 +2182,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2203,7 +2196,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2212,7 +2205,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2221,7 +2214,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2230,7 +2223,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2239,7 +2232,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2248,7 +2241,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2257,7 +2250,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2266,7 +2259,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2275,7 +2268,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2284,7 +2277,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2293,7 +2286,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
           <button
             aria-disabled="false"
             aria-selected="false"
-            class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+            class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
             role="tab"
             type="button"
           >
@@ -2304,7 +2297,7 @@ exports[`Tabs renders correctly with Tabs with prop 1`] = `
             aria-disabled="false"
             aria-expanded="false"
             aria-haspopup="dialog"
-            class="cache-18rgc9u-StyledTabButton-StyledMenu e12ogfvr0"
+            class="cache-8u14mj-StyledTabButton-StyledMenu e12ogfvr0"
             role="tab"
             type="button"
           >
@@ -2372,7 +2365,7 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   display: none;
 }
 
-.cache-17hs8u6-StyledTabButton {
+.cache-1iuo8xk-StyledTabButton {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2412,50 +2405,49 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-17hs8u6-StyledTabButton:hover,
-.cache-17hs8u6-StyledTabButton:active,
-.cache-17hs8u6-StyledTabButton:focus {
+.cache-1iuo8xk-StyledTabButton:hover,
+.cache-1iuo8xk-StyledTabButton:active,
+.cache-1iuo8xk-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-17hs8u6-StyledTabButton:focus-visible {
+.cache-1iuo8xk-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-selected='true'] {
+.cache-1iuo8xk-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-17hs8u6-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-1iuo8xk-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-17hs8u6-StyledTabButton[aria-disabled='true'],
-.cache-17hs8u6-StyledTabButton:disabled {
+.cache-1iuo8xk-StyledTabButton[aria-disabled='true'],
+.cache-1iuo8xk-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
 }
 
-.cache-caacqf-StyledLink-StyledTabButton {
+.cache-csaasm-StyledLink-StyledTabButton {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -2530,20 +2522,19 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   font-weight: 500;
   letter-spacing: 0;
   line-height: 24px;
-  text-case: none;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton .e4bq1r52 {
+.cache-csaasm-StyledLink-StyledTabButton .e4bq1r52 {
   -webkit-transition: -webkit-transform 250ms ease-out;
   transition: transform 250ms ease-out;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton>* {
+.cache-csaasm-StyledLink-StyledTabButton>* {
   pointer-events: none;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton:hover,
-.cache-caacqf-StyledLink-StyledTabButton:focus {
+.cache-csaasm-StyledLink-StyledTabButton:hover,
+.cache-csaasm-StyledLink-StyledTabButton:focus {
   outline: none;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -2552,58 +2543,58 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
   text-decoration-color: #390171;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton:hover .e4bq1r52,
-.cache-caacqf-StyledLink-StyledTabButton:focus .e4bq1r52 {
+.cache-csaasm-StyledLink-StyledTabButton:hover .e4bq1r52,
+.cache-csaasm-StyledLink-StyledTabButton:focus .e4bq1r52 {
   -webkit-transform: translate(-4px, 0);
   -moz-transform: translate(-4px, 0);
   -ms-transform: translate(-4px, 0);
   transform: translate(-4px, 0);
 }
 
-.cache-caacqf-StyledLink-StyledTabButton:hover::after,
-.cache-caacqf-StyledLink-StyledTabButton:focus::after {
+.cache-csaasm-StyledLink-StyledTabButton:hover::after,
+.cache-csaasm-StyledLink-StyledTabButton:focus::after {
   background-color: #390171;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton:active {
+.cache-csaasm-StyledLink-StyledTabButton:active {
   text-decoration-thickness: 2px;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton:hover,
-.cache-caacqf-StyledLink-StyledTabButton:active,
-.cache-caacqf-StyledLink-StyledTabButton:focus {
+.cache-csaasm-StyledLink-StyledTabButton:hover,
+.cache-csaasm-StyledLink-StyledTabButton:active,
+.cache-csaasm-StyledLink-StyledTabButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton:focus-visible {
+.cache-csaasm-StyledLink-StyledTabButton:focus-visible {
   outline: auto;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton[aria-selected='true'] {
+.cache-csaasm-StyledLink-StyledTabButton[aria-selected='true'] {
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active {
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover,
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus,
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active {
   outline: none;
   color: #390171;
   border-bottom-color: #4f0599;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):hover .e1ej5pcd3,
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):focus .e1ej5pcd3,
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='false']:not(:disabled):active .e1ej5pcd3 {
   background-color: #eeeeff;
   border-color: #eeeeff;
   color: #390171;
 }
 
-.cache-caacqf-StyledLink-StyledTabButton[aria-disabled='true'],
-.cache-caacqf-StyledLink-StyledTabButton:disabled {
+.cache-csaasm-StyledLink-StyledTabButton[aria-disabled='true'],
+.cache-csaasm-StyledLink-StyledTabButton:disabled {
   cursor: not-allowed;
   -webkit-filter: grayscale(1) opacity(50%);
   filter: grayscale(1) opacity(50%);
@@ -2616,7 +2607,7 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
     <div
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
     >
       First
@@ -2624,13 +2615,13 @@ exports[`Tabs renders correctly with custom Tabs component 1`] = `
     <a
       aria-disabled="false"
       aria-selected="false"
-      class="cache-17hs8u6-StyledTabButton e1ej5pcd0"
+      class="cache-1iuo8xk-StyledTabButton e1ej5pcd0"
       role="tab"
     >
       Second
     </a>
     <a
-      class="e1ej5pcd0 cache-caacqf-StyledLink-StyledTabButton e4bq1r50"
+      class="e1ej5pcd0 cache-csaasm-StyledLink-StyledTabButton e4bq1r50"
       href="#"
     >
       Very long tab name


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Neutral variant has a border while the other doesn't, meaning there would be a shift in size if we switch variants at runtime

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
