### PR TITLE
ci: fix script with new storiesfile format

### DIFF
--- a/src/__tests__/a11y.test.tsx
+++ b/src/__tests__/a11y.test.tsx
@@ -69,6 +69,12 @@ expect.extend(toHaveNoViolations)
 jest.setTimeout(120000)
 
 describe('A11y', () => {
+  beforeEach(() => {
+    console.log = jest.fn()
+    console.warn = jest.fn()
+    console.error = jest.fn()
+  })
+
   afterEach(() => {
     cleanup()
   })
@@ -86,22 +92,23 @@ describe('A11y', () => {
   })
 
   foundFiles.forEach((file, index) => {
-    test(`${file.split('/')[2]}`, async () => {
-      const module = await moduleArray[index]
-      const components = composeStories(module)
+    describe(`${file.split('/')[2]}`, () =>
+      test(file.split('/')[4].split('.')[0], async () => {
+        const module = await moduleArray[index]
+        const components = composeStories(module)
 
-      for (const componentName of Object.keys(components)) {
-        if (componentName !== 'default') {
-          const ComponentToRender = components[
-            componentName as keyof typeof components
-          ] as () => JSX.Element
-          const { container } = renderWithTheme(<ComponentToRender />)
-          // eslint-disable-next-line no-await-in-loop
-          const results = await axe(container)
+        for (const componentName of Object.keys(components)) {
+          if (componentName !== 'default') {
+            const ComponentToRender = components[
+              componentName as keyof typeof components
+            ] as () => JSX.Element
+            const { container } = renderWithTheme(<ComponentToRender />)
+            // eslint-disable-next-line no-await-in-loop
+            const results = await axe(container)
 
-          expect(results).toHaveNoViolations()
+            expect(results).toHaveNoViolations()
+          }
         }
-      }
-    })
+      }))
   })
 })


### PR DESCRIPTION
## Summary

## Type

- CI

### Summarise concisely:

#### What is expected?

Since we changed structure of our stories, a11y script needed a little refreshment. We now categories each component with individual a11y test for each stories.

Before:
<img width="426" alt="Screenshot 2022-11-09 at 15 41 40" src="https://user-images.githubusercontent.com/15812968/200859961-44663aa7-526f-452a-946f-09e2ea3f3189.png">


After:
<img width="535" alt="Screenshot 2022-11-09 at 15 23 52" src="https://user-images.githubusercontent.com/15812968/200859993-b639dc31-eef1-45b8-9928-5acb603a1d20.png">

 
