### PR TITLE
feat(RichSelect): allow customization of empty state

### DIFF
--- a/src/components/RichSelect/__stories__/index.stories.tsx
+++ b/src/components/RichSelect/__stories__/index.stories.tsx
@@ -4,6 +4,9 @@ import RichSelect, { SelectOption } from '..'
 import { Badge, Button, Loader } from '../..'
 import ControlValue from '../../../__stories__/components/ControlValue'
 import * as animations from '../../../utils/animations'
+import Icon from '../../Icon'
+import Stack from '../../Stack'
+import Text from '../../Text'
 
 export default {
   component: RichSelect,
@@ -365,6 +368,40 @@ Description.parameters = {
     description: {
       story:
         'You can add a description to each of your options. There is two type of description `description` and `inlineDescription`.',
+    },
+  },
+}
+
+export const EmptyState = Template.bind({})
+EmptyState.decorators = [
+  () => (
+    <RichSelect
+      name="emptyState"
+      emptyState={() => (
+        <Stack justifyContent="center" alignItems="center" gap={1}>
+          <Icon
+            color="neutral"
+            name="information-outline"
+            size={32}
+            prominence="strong"
+          />
+          <Text as="p" variant="bodyStrong">
+            There is currently no option available
+          </Text>
+          <Text as="small" variant="caption">
+            Please reload or try again later
+          </Text>
+        </Stack>
+      )}
+    />
+  ),
+]
+
+EmptyState.parameters = {
+  docs: {
+    description: {
+      story:
+        'Empty state will be shown when there is no option available. You can customize it by passing a function to the `emptyState` prop.',
     },
   },
 }

--- a/src/components/RichSelect/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/RichSelect/__tests__/__snapshots__/index.tsx.snap
@@ -290,7 +290,7 @@ exports[`RichSelect renders correctly animated 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-14-live-region"
+      id="react-select-15-live-region"
     />
     <span
       aria-atomic="false"
@@ -314,7 +314,7 @@ exports[`RichSelect renders correctly animated 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-14-placeholder"
+          id="react-select-15-placeholder"
         >
           Select...
         </div>
@@ -324,7 +324,7 @@ exports[`RichSelect renders correctly animated 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-14-placeholder"
+            aria-describedby="react-select-15-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -646,7 +646,7 @@ exports[`RichSelect renders correctly controlled 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-4-live-region"
+      id="react-select-5-live-region"
     />
     <span
       aria-atomic="false"
@@ -670,7 +670,7 @@ exports[`RichSelect renders correctly controlled 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-4-placeholder"
+          id="react-select-5-placeholder"
         >
           Select...
         </div>
@@ -680,7 +680,7 @@ exports[`RichSelect renders correctly controlled 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-4-placeholder"
+            aria-describedby="react-select-5-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -1078,7 +1078,7 @@ exports[`RichSelect renders correctly default values with click 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-13-live-region"
+      id="react-select-14-live-region"
     />
     <span
       aria-atomic="false"
@@ -1111,7 +1111,7 @@ exports[`RichSelect renders correctly default values with click 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-13-placeholder"
+          id="react-select-14-placeholder"
         >
           Select...
         </div>
@@ -1121,10 +1121,10 @@ exports[`RichSelect renders correctly default values with click 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-13-placeholder"
+            aria-describedby="react-select-14-placeholder"
             aria-expanded="true"
             aria-haspopup="true"
-            aria-owns="react-select-13-listbox"
+            aria-owns="react-select-14-listbox"
             autocapitalize="none"
             autocomplete="off"
             autocorrect="off"
@@ -1166,7 +1166,7 @@ exports[`RichSelect renders correctly default values with click 1`] = `
     </div>
     <div
       class=" cache-betdxi-menu"
-      id="react-select-13-listbox"
+      id="react-select-14-listbox"
     >
       <div
         class=" cache-udg73h-MenuList"
@@ -1177,7 +1177,7 @@ exports[`RichSelect renders correctly default values with click 1`] = `
           <div
             aria-disabled="false"
             class=" cache-2q1g32-option"
-            id="react-select-13-option-0"
+            id="react-select-14-option-0"
             tabindex="-1"
           >
             Option A
@@ -1189,7 +1189,7 @@ exports[`RichSelect renders correctly default values with click 1`] = `
           <div
             aria-disabled="false"
             class=" cache-l626qb-option"
-            id="react-select-13-option-1"
+            id="react-select-14-option-1"
             tabindex="-1"
           >
             Option B
@@ -1463,7 +1463,7 @@ exports[`RichSelect renders correctly disabled 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-5-live-region"
+      id="react-select-6-live-region"
     />
     <span
       aria-atomic="false"
@@ -1487,7 +1487,7 @@ exports[`RichSelect renders correctly disabled 1`] = `
         </label>
         <div
           class=" cache-wd8d14-placeholder"
-          id="react-select-5-placeholder"
+          id="react-select-6-placeholder"
         >
           Select...
         </div>
@@ -1497,7 +1497,7 @@ exports[`RichSelect renders correctly disabled 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-5-placeholder"
+            aria-describedby="react-select-6-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -1801,7 +1801,7 @@ exports[`RichSelect renders correctly disabled with click 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-12-live-region"
+      id="react-select-13-live-region"
     />
     <span
       aria-atomic="false"
@@ -1825,7 +1825,7 @@ exports[`RichSelect renders correctly disabled with click 1`] = `
         </label>
         <div
           class=" cache-wd8d14-placeholder"
-          id="react-select-12-placeholder"
+          id="react-select-13-placeholder"
         >
           Select...
         </div>
@@ -1835,7 +1835,7 @@ exports[`RichSelect renders correctly disabled with click 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-12-placeholder"
+            aria-describedby="react-select-13-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -2152,7 +2152,7 @@ exports[`RichSelect renders correctly multi 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-15-live-region"
+      id="react-select-16-live-region"
     />
     <span
       aria-atomic="false"
@@ -2176,7 +2176,7 @@ exports[`RichSelect renders correctly multi 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-15-placeholder"
+          id="react-select-16-placeholder"
         >
           Select...
         </div>
@@ -2186,7 +2186,7 @@ exports[`RichSelect renders correctly multi 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-15-placeholder"
+            aria-describedby="react-select-16-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -2573,7 +2573,7 @@ exports[`RichSelect renders correctly multi disabled 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-16-live-region"
+      id="react-select-17-live-region"
     />
     <span
       aria-atomic="false"
@@ -2960,7 +2960,7 @@ exports[`RichSelect renders correctly required 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-6-live-region"
+      id="react-select-7-live-region"
     />
     <span
       aria-atomic="false"
@@ -2984,7 +2984,7 @@ exports[`RichSelect renders correctly required 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-6-placeholder"
+          id="react-select-7-placeholder"
         >
           Select...
         </div>
@@ -2994,7 +2994,7 @@ exports[`RichSelect renders correctly required 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-6-placeholder"
+            aria-describedby="react-select-7-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             aria-required="true"
@@ -3330,7 +3330,7 @@ exports[`RichSelect renders correctly timed 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-7-live-region"
+      id="react-select-8-live-region"
     />
     <span
       aria-atomic="false"
@@ -3354,7 +3354,7 @@ exports[`RichSelect renders correctly timed 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-7-placeholder"
+          id="react-select-8-placeholder"
         >
           Select...
         </div>
@@ -3364,7 +3364,7 @@ exports[`RichSelect renders correctly timed 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-7-placeholder"
+            aria-describedby="react-select-8-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -3689,7 +3689,7 @@ exports[`RichSelect renders correctly timed with error 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-8-live-region"
+      id="react-select-9-live-region"
     />
     <span
       aria-atomic="false"
@@ -3713,7 +3713,7 @@ exports[`RichSelect renders correctly timed with error 1`] = `
         </label>
         <div
           class=" cache-dw13vo-placeholder"
-          id="react-select-8-placeholder"
+          id="react-select-9-placeholder"
         >
           Select...
         </div>
@@ -3723,7 +3723,7 @@ exports[`RichSelect renders correctly timed with error 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-8-placeholder"
+            aria-describedby="react-select-9-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -4596,507 +4596,6 @@ exports[`RichSelect renders correctly with click 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-9-live-region"
-    />
-    <span
-      aria-atomic="false"
-      aria-live="polite"
-      aria-relevant="additions text"
-      class="cache-1f43avz-a11yText-A11yText"
-    >
-      <span
-        id="aria-selection"
-      />
-      <span
-        id="aria-context"
-      >
-        option Option A focused, 1 of 2. 2 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
-      </span>
-    </span>
-    <div
-      class=" cache-1fg3ywt-control"
-    >
-      <div
-        class=" cache-evyzo2-ValueContainer"
-      >
-        <label
-          aria-live="assertive"
-          as="label"
-          class="cache-1ulf5oa-StyledPlaceholder e1lzna4r2"
-          for="test"
-        >
-          Select...
-        </label>
-        <div
-          class=" cache-m44uhw-placeholder"
-          id="react-select-9-placeholder"
-        >
-          Select...
-        </div>
-        <div
-          class="cache-1eede0w-inputStyles"
-          data-value=""
-        >
-          <input
-            aria-autocomplete="list"
-            aria-describedby="react-select-9-placeholder"
-            aria-expanded="true"
-            aria-haspopup="true"
-            aria-owns="react-select-9-listbox"
-            autocapitalize="none"
-            autocomplete="off"
-            autocorrect="off"
-            class=""
-            id="test"
-            role="combobox"
-            spellcheck="false"
-            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
-            tabindex="0"
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        class=" cache-ralm3g-IndicatorsContainer"
-      >
-        <span
-          class=" cache-27txfv-indicatorSeparator"
-        />
-        <div
-          aria-hidden="true"
-          class=" cache-1gtu0rj-indicatorContainer"
-        >
-          <div
-            class="cache-6874q2-Stack e1sgck4o0"
-          >
-            <svg
-              class="cache-baoksu-StyledIcon-sizeStyles etwatq50"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M9.88,18.29l-9-8.55a2.75,2.75,0,0,1,0-4,3.12,3.12,0,0,1,4.24,0L12,12.25l6.88-6.54a3.12,3.12,0,0,1,4.24,0,2.75,2.75,0,0,1,0,4l-9,8.55a3.12,3.12,0,0,1-4.24,0Z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class=" cache-betdxi-menu"
-      id="react-select-9-listbox"
-    >
-      <div
-        class=" cache-udg73h-MenuList"
-      >
-        <div
-          data-testid="option-test-a"
-        >
-          <div
-            aria-disabled="false"
-            class=" cache-2q1g32-option"
-            id="react-select-9-option-0"
-            tabindex="-1"
-          >
-            Option A
-          </div>
-        </div>
-        <div
-          data-testid="option-test-b"
-        >
-          <div
-            aria-disabled="false"
-            class=" cache-l626qb-option"
-            id="react-select-9-option-1"
-            tabindex="-1"
-          >
-            Option B
-          </div>
-        </div>
-      </div>
-    </div>
-    <input
-      name="test"
-      type="hidden"
-      value=""
-    />
-    <div
-      class="cache-fojapx-Expandable-ExpandableWithHiddenOverflow e1lzna4r3"
-    >
-      <div
-        class="cache-1k8ev0-StyledError e1lzna4r4"
-      />
-    </div>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`RichSelect renders correctly with click and option disabled 1`] = `
-<DocumentFragment>
-  .cache-w1hmin-StyledContainer-container-StyledContainer {
-  width: 100%;
-  position: relative;
-  box-sizing: border-box;
-}
-
-.cache-1f43avz-a11yText-A11yText {
-  z-index: 9999;
-  border: 0;
-  clip: rect(1px, 1px, 1px, 1px);
-  height: 1px;
-  width: 1px;
-  position: absolute;
-  overflow: hidden;
-  padding: 0;
-  white-space: nowrap;
-}
-
-.cache-1fg3ywt-control {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #ffffff;
-  border-color: #d4dae7;
-  border-radius: 4px;
-  border-style: solid;
-  border-width: 1px;
-  box-shadow: none;
-  cursor: default;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  min-height: 48px;
-  outline: 0!important;
-  position: relative;
-  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
-  transition: border-color 200ms ease,box-shadow 200ms ease;
-  box-sizing: border-box;
-  color: #4a4f62;
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 24px;
-  -webkit-animation: none;
-  animation: none;
-}
-
-.cache-1fg3ywt-control:hover {
-  border-color: #2684FF;
-}
-
-.cache-1fg3ywt-control:focus-within {
-  border-color: #390171;
-  box-shadow: 0px 0px 0px 3px #4F059940;
-}
-
-.cache-1fg3ywt-control:focus-within svg {
-  fill: #390171;
-}
-
-.cache-1fg3ywt-control:hover {
-  border-color: #390171;
-}
-
-.cache-1fg3ywt-control:hover svg {
-  fill: #390171;
-}
-
-.cache-evyzo2-ValueContainer {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: grid;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 2px 8px;
-  -webkit-overflow-scrolling: touch;
-  position: relative;
-  overflow: hidden;
-  box-sizing: border-box;
-  height: 100%;
-  padding-top: 0;
-}
-
-.cache-evyzo2-ValueContainer label {
-  display: initial;
-}
-
-.cache-1ulf5oa-StyledPlaceholder {
-  position: absolute;
-  left: 0;
-  font-weight: 400;
-  pointer-events: none;
-  color: #4a4f62;
-  white-space: nowrap;
-  width: 100%;
-  height: 100%;
-  font-size: 16px;
-  -webkit-transition: -webkit-transform 250ms ease;
-  transition: transform 250ms ease;
-  opacity: 0;
-}
-
-.cache-m44uhw-placeholder {
-  color: #b2b6c3;
-  grid-area: 1/1/2/3;
-  margin-left: 2px;
-  margin-right: 2px;
-  box-sizing: border-box;
-}
-
-.cache-1eede0w-inputStyles {
-  margin: 2px;
-  padding-bottom: 2px;
-  padding-top: 11px;
-  visibility: visible;
-  color: hsl(0, 0%, 20%);
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  display: inline-grid;
-  grid-area: 1/1/2/3;
-  grid-template-columns: 0 min-content;
-  box-sizing: border-box;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  margin-left: 0;
-  margin-left: 0px;
-  caret-color: transparent;
-}
-
-.cache-1eede0w-inputStyles:after {
-  content: attr(data-value) " ";
-  visibility: hidden;
-  white-space: pre;
-  grid-area: 1/2;
-  font: inherit;
-  min-width: 2px;
-  border: 0;
-  margin: 0;
-  outline: 0;
-  padding: 0;
-}
-
-.cache-ralm3g-IndicatorsContainer {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  box-sizing: border-box;
-  max-height: 48px;
-}
-
-.cache-27txfv-indicatorSeparator {
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  background-color: #d4dae7;
-  margin-bottom: 8px;
-  margin-top: 8px;
-  width: 1px;
-  box-sizing: border-box;
-  display: none;
-}
-
-.cache-1gtu0rj-indicatorContainer {
-  color: hsl(0, 0%, 40%);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 8px;
-  -webkit-transition: color 150ms;
-  transition: color 150ms;
-  box-sizing: border-box;
-}
-
-.cache-1gtu0rj-indicatorContainer:hover {
-  color: hsl(0, 0%, 20%);
-}
-
-.cache-6874q2-Stack {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 16px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
-.cache-baoksu-StyledIcon-sizeStyles {
-  vertical-align: middle;
-  fill: #4a4f62;
-  height: 11px;
-  width: 11px;
-  min-width: 11px;
-  min-height: 11px;
-}
-
-.cache-betdxi-menu {
-  top: 100%;
-  background-color: hsl(0, 0%, 100%);
-  border-radius: 4px;
-  box-shadow: 0px 0px 24px 6px #D4DAE766;
-  margin-bottom: 8px;
-  margin-top: 8px;
-  position: absolute;
-  width: 100%;
-  z-index: 1;
-  box-sizing: border-box;
-}
-
-.cache-udg73h-MenuList {
-  max-height: 225px;
-  overflow-y: auto;
-  padding-bottom: 4px;
-  padding-top: 4px;
-  position: relative;
-  -webkit-overflow-scrolling: touch;
-  box-sizing: border-box;
-  background-color: #ffffff;
-}
-
-.cache-2q1g32-option {
-  background-color: #eeeeff;
-  color: #4a4f62;
-  cursor: default;
-  display: block;
-  font-size: inherit;
-  padding: 8px 12px;
-  width: 100%;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  box-sizing: border-box;
-}
-
-.cache-2q1g32-option:active {
-  background-color: #eeeeff;
-  color: #390171;
-}
-
-.cache-2q1g32-option:hover {
-  background-color: #eeeeff;
-  color: #4a4f62;
-}
-
-.cache-l626qb-option {
-  background-color: #ffffff;
-  color: #4a4f62;
-  cursor: default;
-  display: block;
-  font-size: inherit;
-  padding: 8px 12px;
-  width: 100%;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  box-sizing: border-box;
-}
-
-.cache-l626qb-option:active {
-  background-color: #eeeeff;
-  color: #390171;
-}
-
-.cache-l626qb-option:hover {
-  background-color: #eeeeff;
-  color: #4a4f62;
-}
-
-.cache-mlmorm-option {
-  background-color: #f6f6f8;
-  color: #c4c9d6;
-  cursor: default;
-  display: block;
-  font-size: inherit;
-  padding: 8px 12px;
-  width: 100%;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  box-sizing: border-box;
-}
-
-.cache-mlmorm-option:active {
-  background-color: #f6f6f8;
-  color: #c4c9d6;
-}
-
-.cache-mlmorm-option:hover {
-  background-color: #f6f6f8;
-  color: #c4c9d6;
-}
-
-.cache-fojapx-Expandable-ExpandableWithHiddenOverflow {
-  -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
-  transition: max-height 300ms ease-out,opacity 300ms ease-out;
-  max-height: 0;
-  overflow: hidden;
-  opacity: 0;
-  height: auto;
-  margin-top: 0;
-  overflow: hidden;
-}
-
-.cache-1k8ev0-StyledError {
-  font-size: 12px;
-  color: #a6102d;
-  padding-top: 2px;
-}
-
-<div
-    class=" cache-w1hmin-StyledContainer-container-StyledContainer e1lzna4r5"
-    data-testid="rich-select-test"
-  >
-    <span
-      class="cache-1f43avz-a11yText-A11yText"
       id="react-select-10-live-region"
     />
     <span
@@ -5111,7 +4610,7 @@ exports[`RichSelect renders correctly with click and option disabled 1`] = `
       <span
         id="aria-context"
       >
-        option Option A focused, 1 of 3. 3 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+        option Option A focused, 1 of 2. 2 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
       </span>
     </span>
     <div
@@ -5214,18 +4713,6 @@ exports[`RichSelect renders correctly with click and option disabled 1`] = `
             Option B
           </div>
         </div>
-        <div
-          data-testid="option-test-c"
-        >
-          <div
-            aria-disabled="true"
-            class=" cache-mlmorm-option"
-            id="react-select-10-option-2"
-            tabindex="-1"
-          >
-            Option C
-          </div>
-        </div>
       </div>
     </div>
     <input
@@ -5244,7 +4731,7 @@ exports[`RichSelect renders correctly with click and option disabled 1`] = `
 </DocumentFragment>
 `;
 
-exports[`RichSelect renders correctly with click and options 1`] = `
+exports[`RichSelect renders correctly with click and option disabled 1`] = `
 <DocumentFragment>
   .cache-w1hmin-StyledContainer-container-StyledContainer {
   width: 100%;
@@ -5757,6 +5244,519 @@ exports[`RichSelect renders correctly with click and options 1`] = `
 </DocumentFragment>
 `;
 
+exports[`RichSelect renders correctly with click and options 1`] = `
+<DocumentFragment>
+  .cache-w1hmin-StyledContainer-container-StyledContainer {
+  width: 100%;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.cache-1f43avz-a11yText-A11yText {
+  z-index: 9999;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.cache-1fg3ywt-control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #ffffff;
+  border-color: #d4dae7;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+  cursor: default;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 48px;
+  outline: 0!important;
+  position: relative;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  box-sizing: border-box;
+  color: #4a4f62;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px;
+  -webkit-animation: none;
+  animation: none;
+}
+
+.cache-1fg3ywt-control:hover {
+  border-color: #2684FF;
+}
+
+.cache-1fg3ywt-control:focus-within {
+  border-color: #390171;
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-1fg3ywt-control:focus-within svg {
+  fill: #390171;
+}
+
+.cache-1fg3ywt-control:hover {
+  border-color: #390171;
+}
+
+.cache-1fg3ywt-control:hover svg {
+  fill: #390171;
+}
+
+.cache-evyzo2-ValueContainer {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: grid;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  padding: 2px 8px;
+  -webkit-overflow-scrolling: touch;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  height: 100%;
+  padding-top: 0;
+}
+
+.cache-evyzo2-ValueContainer label {
+  display: initial;
+}
+
+.cache-1ulf5oa-StyledPlaceholder {
+  position: absolute;
+  left: 0;
+  font-weight: 400;
+  pointer-events: none;
+  color: #4a4f62;
+  white-space: nowrap;
+  width: 100%;
+  height: 100%;
+  font-size: 16px;
+  -webkit-transition: -webkit-transform 250ms ease;
+  transition: transform 250ms ease;
+  opacity: 0;
+}
+
+.cache-m44uhw-placeholder {
+  color: #b2b6c3;
+  grid-area: 1/1/2/3;
+  margin-left: 2px;
+  margin-right: 2px;
+  box-sizing: border-box;
+}
+
+.cache-1eede0w-inputStyles {
+  margin: 2px;
+  padding-bottom: 2px;
+  padding-top: 11px;
+  visibility: visible;
+  color: hsl(0, 0%, 20%);
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  display: inline-grid;
+  grid-area: 1/1/2/3;
+  grid-template-columns: 0 min-content;
+  box-sizing: border-box;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  margin-left: 0;
+  margin-left: 0px;
+  caret-color: transparent;
+}
+
+.cache-1eede0w-inputStyles:after {
+  content: attr(data-value) " ";
+  visibility: hidden;
+  white-space: pre;
+  grid-area: 1/2;
+  font: inherit;
+  min-width: 2px;
+  border: 0;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+}
+
+.cache-ralm3g-IndicatorsContainer {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  max-height: 48px;
+}
+
+.cache-27txfv-indicatorSeparator {
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  background-color: #d4dae7;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  width: 1px;
+  box-sizing: border-box;
+  display: none;
+}
+
+.cache-1gtu0rj-indicatorContainer {
+  color: hsl(0, 0%, 40%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 8px;
+  -webkit-transition: color 150ms;
+  transition: color 150ms;
+  box-sizing: border-box;
+}
+
+.cache-1gtu0rj-indicatorContainer:hover {
+  color: hsl(0, 0%, 20%);
+}
+
+.cache-6874q2-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-baoksu-StyledIcon-sizeStyles {
+  vertical-align: middle;
+  fill: #4a4f62;
+  height: 11px;
+  width: 11px;
+  min-width: 11px;
+  min-height: 11px;
+}
+
+.cache-betdxi-menu {
+  top: 100%;
+  background-color: hsl(0, 0%, 100%);
+  border-radius: 4px;
+  box-shadow: 0px 0px 24px 6px #D4DAE766;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+  box-sizing: border-box;
+}
+
+.cache-udg73h-MenuList {
+  max-height: 225px;
+  overflow-y: auto;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  box-sizing: border-box;
+  background-color: #ffffff;
+}
+
+.cache-2q1g32-option {
+  background-color: #eeeeff;
+  color: #4a4f62;
+  cursor: default;
+  display: block;
+  font-size: inherit;
+  padding: 8px 12px;
+  width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  box-sizing: border-box;
+}
+
+.cache-2q1g32-option:active {
+  background-color: #eeeeff;
+  color: #390171;
+}
+
+.cache-2q1g32-option:hover {
+  background-color: #eeeeff;
+  color: #4a4f62;
+}
+
+.cache-l626qb-option {
+  background-color: #ffffff;
+  color: #4a4f62;
+  cursor: default;
+  display: block;
+  font-size: inherit;
+  padding: 8px 12px;
+  width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  box-sizing: border-box;
+}
+
+.cache-l626qb-option:active {
+  background-color: #eeeeff;
+  color: #390171;
+}
+
+.cache-l626qb-option:hover {
+  background-color: #eeeeff;
+  color: #4a4f62;
+}
+
+.cache-mlmorm-option {
+  background-color: #f6f6f8;
+  color: #c4c9d6;
+  cursor: default;
+  display: block;
+  font-size: inherit;
+  padding: 8px 12px;
+  width: 100%;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  box-sizing: border-box;
+}
+
+.cache-mlmorm-option:active {
+  background-color: #f6f6f8;
+  color: #c4c9d6;
+}
+
+.cache-mlmorm-option:hover {
+  background-color: #f6f6f8;
+  color: #c4c9d6;
+}
+
+.cache-fojapx-Expandable-ExpandableWithHiddenOverflow {
+  -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
+  transition: max-height 300ms ease-out,opacity 300ms ease-out;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  height: auto;
+  margin-top: 0;
+  overflow: hidden;
+}
+
+.cache-1k8ev0-StyledError {
+  font-size: 12px;
+  color: #a6102d;
+  padding-top: 2px;
+}
+
+<div
+    class=" cache-w1hmin-StyledContainer-container-StyledContainer e1lzna4r5"
+    data-testid="rich-select-test"
+  >
+    <span
+      class="cache-1f43avz-a11yText-A11yText"
+      id="react-select-12-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="cache-1f43avz-a11yText-A11yText"
+    >
+      <span
+        id="aria-selection"
+      />
+      <span
+        id="aria-context"
+      >
+        option Option A focused, 1 of 3. 3 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+      </span>
+    </span>
+    <div
+      class=" cache-1fg3ywt-control"
+    >
+      <div
+        class=" cache-evyzo2-ValueContainer"
+      >
+        <label
+          aria-live="assertive"
+          as="label"
+          class="cache-1ulf5oa-StyledPlaceholder e1lzna4r2"
+          for="test"
+        >
+          Select...
+        </label>
+        <div
+          class=" cache-m44uhw-placeholder"
+          id="react-select-12-placeholder"
+        >
+          Select...
+        </div>
+        <div
+          class="cache-1eede0w-inputStyles"
+          data-value=""
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-12-placeholder"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-owns="react-select-12-listbox"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            class=""
+            id="test"
+            role="combobox"
+            spellcheck="false"
+            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+            tabindex="0"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class=" cache-ralm3g-IndicatorsContainer"
+      >
+        <span
+          class=" cache-27txfv-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          class=" cache-1gtu0rj-indicatorContainer"
+        >
+          <div
+            class="cache-6874q2-Stack e1sgck4o0"
+          >
+            <svg
+              class="cache-baoksu-StyledIcon-sizeStyles etwatq50"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M9.88,18.29l-9-8.55a2.75,2.75,0,0,1,0-4,3.12,3.12,0,0,1,4.24,0L12,12.25l6.88-6.54a3.12,3.12,0,0,1,4.24,0,2.75,2.75,0,0,1,0,4l-9,8.55a3.12,3.12,0,0,1-4.24,0Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class=" cache-betdxi-menu"
+      id="react-select-12-listbox"
+    >
+      <div
+        class=" cache-udg73h-MenuList"
+      >
+        <div
+          data-testid="option-test-a"
+        >
+          <div
+            aria-disabled="false"
+            class=" cache-2q1g32-option"
+            id="react-select-12-option-0"
+            tabindex="-1"
+          >
+            Option A
+          </div>
+        </div>
+        <div
+          data-testid="option-test-b"
+        >
+          <div
+            aria-disabled="false"
+            class=" cache-l626qb-option"
+            id="react-select-12-option-1"
+            tabindex="-1"
+          >
+            Option B
+          </div>
+        </div>
+        <div
+          data-testid="option-test-c"
+        >
+          <div
+            aria-disabled="true"
+            class=" cache-mlmorm-option"
+            id="react-select-12-option-2"
+            tabindex="-1"
+          >
+            Option C
+          </div>
+        </div>
+      </div>
+    </div>
+    <input
+      name="test"
+      type="hidden"
+      value=""
+    />
+    <div
+      class="cache-fojapx-Expandable-ExpandableWithHiddenOverflow e1lzna4r3"
+    >
+      <div
+        class="cache-1k8ev0-StyledError e1lzna4r4"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`RichSelect renders correctly with custom styles 1`] = `
 <DocumentFragment>
   .cache-w1hmin-StyledContainer-container-StyledContainer {
@@ -6021,7 +6021,7 @@ exports[`RichSelect renders correctly with custom styles 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-3-live-region"
+      id="react-select-4-live-region"
     />
     <span
       aria-atomic="false"
@@ -6045,7 +6045,7 @@ exports[`RichSelect renders correctly with custom styles 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-3-placeholder"
+          id="react-select-4-placeholder"
         >
           Select...
         </div>
@@ -6055,7 +6055,7 @@ exports[`RichSelect renders correctly with custom styles 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-3-placeholder"
+            aria-describedby="react-select-4-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -6099,6 +6099,417 @@ exports[`RichSelect renders correctly with custom styles 1`] = `
     </div>
     <input
       name="uncontrolled"
+      type="hidden"
+      value=""
+    />
+    <div
+      class="cache-fojapx-Expandable-ExpandableWithHiddenOverflow e1lzna4r3"
+    >
+      <div
+        class="cache-1k8ev0-StyledError e1lzna4r4"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`RichSelect renders correctly with emptyState 1`] = `
+<DocumentFragment>
+  .cache-w1hmin-StyledContainer-container-StyledContainer {
+  width: 100%;
+  position: relative;
+  box-sizing: border-box;
+}
+
+.cache-1f43avz-a11yText-A11yText {
+  z-index: 9999;
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  position: absolute;
+  overflow: hidden;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.cache-1fg3ywt-control {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #ffffff;
+  border-color: #d4dae7;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: none;
+  cursor: default;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  min-height: 48px;
+  outline: 0!important;
+  position: relative;
+  -webkit-transition: border-color 200ms ease,box-shadow 200ms ease;
+  transition: border-color 200ms ease,box-shadow 200ms ease;
+  box-sizing: border-box;
+  color: #4a4f62;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px;
+  -webkit-animation: none;
+  animation: none;
+}
+
+.cache-1fg3ywt-control:hover {
+  border-color: #2684FF;
+}
+
+.cache-1fg3ywt-control:focus-within {
+  border-color: #390171;
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-1fg3ywt-control:focus-within svg {
+  fill: #390171;
+}
+
+.cache-1fg3ywt-control:hover {
+  border-color: #390171;
+}
+
+.cache-1fg3ywt-control:hover svg {
+  fill: #390171;
+}
+
+.cache-evyzo2-ValueContainer {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: grid;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  padding: 2px 8px;
+  -webkit-overflow-scrolling: touch;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+  height: 100%;
+  padding-top: 0;
+}
+
+.cache-evyzo2-ValueContainer label {
+  display: initial;
+}
+
+.cache-1ulf5oa-StyledPlaceholder {
+  position: absolute;
+  left: 0;
+  font-weight: 400;
+  pointer-events: none;
+  color: #4a4f62;
+  white-space: nowrap;
+  width: 100%;
+  height: 100%;
+  font-size: 16px;
+  -webkit-transition: -webkit-transform 250ms ease;
+  transition: transform 250ms ease;
+  opacity: 0;
+}
+
+.cache-m44uhw-placeholder {
+  color: #b2b6c3;
+  grid-area: 1/1/2/3;
+  margin-left: 2px;
+  margin-right: 2px;
+  box-sizing: border-box;
+}
+
+.cache-1eede0w-inputStyles {
+  margin: 2px;
+  padding-bottom: 2px;
+  padding-top: 11px;
+  visibility: visible;
+  color: hsl(0, 0%, 20%);
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  display: inline-grid;
+  grid-area: 1/1/2/3;
+  grid-template-columns: 0 min-content;
+  box-sizing: border-box;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  margin-left: 0;
+  margin-left: 0px;
+  caret-color: transparent;
+}
+
+.cache-1eede0w-inputStyles:after {
+  content: attr(data-value) " ";
+  visibility: hidden;
+  white-space: pre;
+  grid-area: 1/2;
+  font: inherit;
+  min-width: 2px;
+  border: 0;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+}
+
+.cache-ralm3g-IndicatorsContainer {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  max-height: 48px;
+}
+
+.cache-27txfv-indicatorSeparator {
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  background-color: #d4dae7;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  width: 1px;
+  box-sizing: border-box;
+  display: none;
+}
+
+.cache-1gtu0rj-indicatorContainer {
+  color: hsl(0, 0%, 40%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 8px;
+  -webkit-transition: color 150ms;
+  transition: color 150ms;
+  box-sizing: border-box;
+}
+
+.cache-1gtu0rj-indicatorContainer:hover {
+  color: hsl(0, 0%, 20%);
+}
+
+.cache-6874q2-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-baoksu-StyledIcon-sizeStyles {
+  vertical-align: middle;
+  fill: #4a4f62;
+  height: 11px;
+  width: 11px;
+  min-width: 11px;
+  min-height: 11px;
+}
+
+.cache-betdxi-menu {
+  top: 100%;
+  background-color: hsl(0, 0%, 100%);
+  border-radius: 4px;
+  box-shadow: 0px 0px 24px 6px #D4DAE766;
+  margin-bottom: 8px;
+  margin-top: 8px;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+  box-sizing: border-box;
+}
+
+.cache-udg73h-MenuList {
+  max-height: 225px;
+  overflow-y: auto;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+  box-sizing: border-box;
+  background-color: #ffffff;
+}
+
+.cache-gg45go-NoOptionsMessage {
+  color: hsl(0, 0%, 60%);
+  padding: 8px 12px;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.cache-fojapx-Expandable-ExpandableWithHiddenOverflow {
+  -webkit-transition: max-height 300ms ease-out,opacity 300ms ease-out;
+  transition: max-height 300ms ease-out,opacity 300ms ease-out;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  height: auto;
+  margin-top: 0;
+  overflow: hidden;
+}
+
+.cache-1k8ev0-StyledError {
+  font-size: 12px;
+  color: #a6102d;
+  padding-top: 2px;
+}
+
+<div
+    class=" cache-w1hmin-StyledContainer-container-StyledContainer e1lzna4r5"
+    data-testid="rich-select-emptyState"
+  >
+    <span
+      class="cache-1f43avz-a11yText-A11yText"
+      id="react-select-3-live-region"
+    />
+    <span
+      aria-atomic="false"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="cache-1f43avz-a11yText-A11yText"
+    >
+      <span
+        id="aria-selection"
+      />
+      <span
+        id="aria-context"
+      >
+          Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
+      </span>
+    </span>
+    <div
+      class=" cache-1fg3ywt-control"
+    >
+      <div
+        class=" cache-evyzo2-ValueContainer"
+      >
+        <label
+          aria-live="assertive"
+          as="label"
+          class="cache-1ulf5oa-StyledPlaceholder e1lzna4r2"
+          for="test"
+        >
+          Select...
+        </label>
+        <div
+          class=" cache-m44uhw-placeholder"
+          id="react-select-3-placeholder"
+        >
+          Select...
+        </div>
+        <div
+          class="cache-1eede0w-inputStyles"
+          data-value=""
+        >
+          <input
+            aria-autocomplete="list"
+            aria-describedby="react-select-3-placeholder"
+            aria-expanded="true"
+            aria-haspopup="true"
+            aria-owns="react-select-3-listbox"
+            autocapitalize="none"
+            autocomplete="off"
+            autocorrect="off"
+            class=""
+            id="test"
+            role="combobox"
+            spellcheck="false"
+            style="opacity: 1; width: 100%; grid-area: 1 / 2; min-width: 2px; border: 0px; margin: 0px; outline: 0; padding: 0px;"
+            tabindex="0"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class=" cache-ralm3g-IndicatorsContainer"
+      >
+        <span
+          class=" cache-27txfv-indicatorSeparator"
+        />
+        <div
+          aria-hidden="true"
+          class=" cache-1gtu0rj-indicatorContainer"
+        >
+          <div
+            class="cache-6874q2-Stack e1sgck4o0"
+          >
+            <svg
+              class="cache-baoksu-StyledIcon-sizeStyles etwatq50"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M9.88,18.29l-9-8.55a2.75,2.75,0,0,1,0-4,3.12,3.12,0,0,1,4.24,0L12,12.25l6.88-6.54a3.12,3.12,0,0,1,4.24,0,2.75,2.75,0,0,1,0,4l-9,8.55a3.12,3.12,0,0,1-4.24,0Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class=" cache-betdxi-menu"
+      id="react-select-3-listbox"
+    >
+      <div
+        class=" cache-udg73h-MenuList"
+      >
+        <div
+          class=" cache-gg45go-NoOptionsMessage"
+        >
+          test
+        </div>
+      </div>
+    </div>
+    <input
+      name="emptyState"
       type="hidden"
       value=""
     />
@@ -6377,7 +6788,7 @@ exports[`RichSelect should render correctly custom isLoading 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-24-live-region"
+      id="react-select-25-live-region"
     />
     <span
       aria-atomic="false"
@@ -6401,7 +6812,7 @@ exports[`RichSelect should render correctly custom isLoading 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-24-placeholder"
+          id="react-select-25-placeholder"
         >
           Select...
         </div>
@@ -6411,7 +6822,7 @@ exports[`RichSelect should render correctly custom isLoading 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-24-placeholder"
+            aria-describedby="react-select-25-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -6736,7 +7147,7 @@ exports[`RichSelect should render correctly description and inlineDescription 1`
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-25-live-region"
+      id="react-select-26-live-region"
     />
     <span
       aria-atomic="false"
@@ -6760,7 +7171,7 @@ exports[`RichSelect should render correctly description and inlineDescription 1`
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-25-placeholder"
+          id="react-select-26-placeholder"
         >
           Select...
         </div>
@@ -6770,7 +7181,7 @@ exports[`RichSelect should render correctly description and inlineDescription 1`
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-25-placeholder"
+            aria-describedby="react-select-26-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -7177,7 +7588,7 @@ exports[`RichSelect should render correctly isLoading 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-21-live-region"
+      id="react-select-22-live-region"
     />
     <span
       aria-atomic="false"
@@ -7201,7 +7612,7 @@ exports[`RichSelect should render correctly isLoading 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-21-placeholder"
+          id="react-select-22-placeholder"
         >
           Select...
         </div>
@@ -7211,7 +7622,7 @@ exports[`RichSelect should render correctly isLoading 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-21-placeholder"
+            aria-describedby="react-select-22-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -7571,7 +7982,7 @@ exports[`RichSelect should render correctly multi isClearable 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-17-live-region"
+      id="react-select-18-live-region"
     />
     <span
       aria-atomic="false"
@@ -7941,7 +8352,7 @@ exports[`RichSelect should render correctly multi isClearable disabled 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-18-live-region"
+      id="react-select-19-live-region"
     />
     <span
       aria-atomic="false"
@@ -8306,7 +8717,7 @@ exports[`RichSelect should render correctly multi isSearchable 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-19-live-region"
+      id="react-select-20-live-region"
     />
     <span
       aria-atomic="false"
@@ -8662,7 +9073,7 @@ exports[`RichSelect should render correctly multi isSearchable disabled 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-20-live-region"
+      id="react-select-21-live-region"
     />
     <span
       aria-atomic="false"
@@ -9012,7 +9423,7 @@ exports[`RichSelect should render correctly with portal 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-22-live-region"
+      id="react-select-23-live-region"
     />
     <span
       aria-atomic="false"
@@ -9036,7 +9447,7 @@ exports[`RichSelect should render correctly with portal 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-22-placeholder"
+          id="react-select-23-placeholder"
         >
           Select...
         </div>
@@ -9046,7 +9457,7 @@ exports[`RichSelect should render correctly with portal 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-22-placeholder"
+            aria-describedby="react-select-23-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"
@@ -9371,7 +9782,7 @@ exports[`RichSelect should render correctly without children 1`] = `
   >
     <span
       class="cache-1f43avz-a11yText-A11yText"
-      id="react-select-23-live-region"
+      id="react-select-24-live-region"
     />
     <span
       aria-atomic="false"
@@ -9395,7 +9806,7 @@ exports[`RichSelect should render correctly without children 1`] = `
         </label>
         <div
           class=" cache-m44uhw-placeholder"
-          id="react-select-23-placeholder"
+          id="react-select-24-placeholder"
         >
           Select...
         </div>
@@ -9405,7 +9816,7 @@ exports[`RichSelect should render correctly without children 1`] = `
         >
           <input
             aria-autocomplete="list"
-            aria-describedby="react-select-23-placeholder"
+            aria-describedby="react-select-24-placeholder"
             aria-expanded="false"
             aria-haspopup="true"
             autocapitalize="none"

--- a/src/components/RichSelect/__tests__/index.tsx
+++ b/src/components/RichSelect/__tests__/index.tsx
@@ -37,6 +37,22 @@ describe('RichSelect', () => {
       },
     ))
 
+  test('renders correctly with emptyState', () =>
+    shouldMatchEmotionSnapshot(
+      <RichSelect
+        inputId="test"
+        labelId="test-label"
+        name="emptyState"
+        emptyState={() => 'test'}
+      />,
+      {
+        transform: async node => {
+          const input = node.getByRole('combobox')
+          await userEvent.click(input)
+        },
+      },
+    ))
+
   test('renders correctly with custom styles', () =>
     shouldMatchEmotionSnapshot(
       <RichSelect

--- a/src/components/RichSelect/index.tsx
+++ b/src/components/RichSelect/index.tsx
@@ -1,6 +1,7 @@
 import { CSSObject, Theme, css, keyframes, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
 import {
+  ComponentProps,
   ForwardRefExoticComponent,
   ForwardedRef,
   ReactElement,
@@ -649,6 +650,7 @@ type RichSelectProps = SelectProps &
      */
     customComponents?: SelectProps['components']
     children: ReactNode
+    emptyState?: ComponentProps<Select>['noOptionsMessage']
   }
 
 const defaultCustomStyle = () => ({})
@@ -680,6 +682,7 @@ const RichSelect = ({
   time,
   isLoading,
   required,
+  emptyState,
 }: Partial<RichSelectProps>) => {
   const id = useId()
   const inputId = inputIdProp ?? id
@@ -753,6 +756,7 @@ const RichSelect = ({
       time={time}
       isLoading={isLoading}
       required={required}
+      noOptionsMessage={emptyState}
     />
   )
 }


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

To be able to customize empty state of the RichSelect.

## Relevant logs and/or screenshots

Default empty state:
<img width="1046" alt="Screenshot 2022-11-16 at 16 05 40" src="https://user-images.githubusercontent.com/15812968/202218166-572f806f-36a8-4fce-be3d-e011635852c0.png">

New customizable example:
<img width="1041" alt="Screenshot 2022-11-16 at 16 05 16" src="https://user-images.githubusercontent.com/15812968/202218211-a82e9817-c7c9-400b-85cc-1900992f1190.png">

