### PR TITLE
fix(CopyButton): add noBorder to not forwarded props list

### DIFF
--- a/src/components/CopyButton/index.tsx
+++ b/src/components/CopyButton/index.tsx
@@ -15,7 +15,7 @@ export const SIZES = {
  * TODO: replace when buttonV2 will be available
  */
 const StyledButton = styled('button', {
-  shouldForwardProp: prop => !['size', 'variant'].includes(prop),
+  shouldForwardProp: prop => !['size', 'variant', 'noBorder'].includes(prop),
 })<{ size: number; variant: Color; noBorder?: boolean }>`
   width: ${({ size }) => size}px;
   height: ${({ size }) => size}px;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Added `noBorder` to props that should not be forwarded to dom element

#### What is expected?

Remove warning in the console

#### The following changes where made:

1. Add `'noBorder'` string in `shouldForwardProp` exclusion list

## Relevant logs and/or screenshots

<img width="1650" alt="Screen Shot 2022-11-17 at 15 06 47" src="https://user-images.githubusercontent.com/2362139/202477449-d4de6590-2ee1-443e-9afb-7b994c15e9b4.png">
