### PR TITLE
fix(menu): add forward ref to menu item

### DIFF
--- a/src/components/Menu/Item.tsx
+++ b/src/components/Menu/Item.tsx
@@ -1,5 +1,5 @@
 import { Theme, css } from '@emotion/react'
-import { ComponentProps } from 'react'
+import { ComponentProps, Ref, forwardRef } from 'react'
 import Button from '../Button'
 
 const variantStyle = {
@@ -83,29 +83,35 @@ type ItemProps = Omit<ComponentProps<typeof Button>, 'variant' | 'innerRef'> & {
   variant?: VariantItem
 }
 
-const Item = ({
-  borderless = false,
-  disabled = false,
-  onClick,
-  variant,
-  href,
-  ...props
-}: ItemProps) => (
-  <Button
-    variant="transparent"
-    role="menuitem"
-    disabled={disabled}
-    onClick={onClick}
-    href={href}
-    as={href ? 'a' : undefined}
-    {...props}
-    css={[
-      styles.item,
-      variant && variantStyle[variant],
-      disabled && styles.disabled,
-      borderless && styles.borderless,
-    ]}
-  />
+const Item = forwardRef(
+  (
+    {
+      borderless = false,
+      disabled = false,
+      onClick,
+      variant,
+      href,
+      ...props
+    }: ItemProps,
+    ref: Ref<HTMLButtonElement>,
+  ) => (
+    <Button
+      ref={ref}
+      variant="transparent"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      href={href}
+      as={href ? 'a' : undefined}
+      {...props}
+      css={[
+        styles.item,
+        variant && variantStyle[variant],
+        disabled && styles.disabled,
+        borderless && styles.borderless,
+      ]}
+    />
+  ),
 )
 
 export default Item


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarise concisely:

#### What is expected?

To avoid this kind or errors when using our Menu Item with our Modal components.

```js
instrument.js?bdb8:109 Can't determine whether the element is the current disclosure because `ref` wasn't passed to the component 
 See https://reakit.io/docs/dialog
```

#### The following changes where made:

Add forward ref to Menu.Item component
