### PR TITLE
fix(StepList): set ul padding-left to 0

### DIFF
--- a/src/components/StepList/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/StepList/__tests__/__snapshots__/index.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`StepList renders correctly  1`] = `
 <DocumentFragment>
-  .cache-oswjln-Steps {
+  .cache-1abqgir-Steps {
   list-style: none;
-  padding-left: 16px;
+  padding-left: 0;
   text-align: left;
   display: -webkit-box;
   display: -webkit-flex;
@@ -67,7 +67,7 @@ exports[`StepList renders correctly  1`] = `
 }
 
 <ul
-    class="cache-oswjln-Steps e1p9x3di2"
+    class="cache-1abqgir-Steps e1p9x3di2"
   >
     <li
       class="cache-15bydan-Step e1p9x3di1"
@@ -89,9 +89,9 @@ exports[`StepList renders correctly  1`] = `
 
 exports[`StepList renders correctly with bulletIcon & variant 1`] = `
 <DocumentFragment>
-  .cache-oswjln-Steps {
+  .cache-1abqgir-Steps {
   list-style: none;
-  padding-left: 16px;
+  padding-left: 0;
   text-align: left;
   display: -webkit-box;
   display: -webkit-flex;
@@ -162,7 +162,7 @@ exports[`StepList renders correctly with bulletIcon & variant 1`] = `
 }
 
 <ul
-    class="cache-oswjln-Steps e1p9x3di2"
+    class="cache-1abqgir-Steps e1p9x3di2"
   >
     <li
       class="cache-15bydan-Step e1p9x3di1"
@@ -191,9 +191,9 @@ exports[`StepList renders correctly with bulletIcon & variant 1`] = `
 
 exports[`StepList renders correctly with bulletIcon 1`] = `
 <DocumentFragment>
-  .cache-oswjln-Steps {
+  .cache-1abqgir-Steps {
   list-style: none;
-  padding-left: 16px;
+  padding-left: 0;
   text-align: left;
   display: -webkit-box;
   display: -webkit-flex;
@@ -265,7 +265,7 @@ exports[`StepList renders correctly with bulletIcon 1`] = `
 }
 
 <ul
-    class="cache-oswjln-Steps e1p9x3di2"
+    class="cache-1abqgir-Steps e1p9x3di2"
   >
     <li
       class="cache-15bydan-Step e1p9x3di1"
@@ -294,9 +294,9 @@ exports[`StepList renders correctly with bulletIcon 1`] = `
 
 exports[`StepList renders correctly with disabled state & bullet icon 1`] = `
 <DocumentFragment>
-  .cache-oswjln-Steps {
+  .cache-1abqgir-Steps {
   list-style: none;
-  padding-left: 16px;
+  padding-left: 0;
   text-align: left;
   display: -webkit-box;
   display: -webkit-flex;
@@ -368,7 +368,7 @@ exports[`StepList renders correctly with disabled state & bullet icon 1`] = `
 }
 
 <ul
-    class="cache-oswjln-Steps e1p9x3di2"
+    class="cache-1abqgir-Steps e1p9x3di2"
   >
     <li
       class="cache-1x18xpe-Step e1p9x3di1"
@@ -399,9 +399,9 @@ exports[`StepList renders correctly with disabled state & bullet icon 1`] = `
 
 exports[`StepList renders correctly with disabled state 1`] = `
 <DocumentFragment>
-  .cache-oswjln-Steps {
+  .cache-1abqgir-Steps {
   list-style: none;
-  padding-left: 16px;
+  padding-left: 0;
   text-align: left;
   display: -webkit-box;
   display: -webkit-flex;
@@ -464,7 +464,7 @@ exports[`StepList renders correctly with disabled state 1`] = `
 }
 
 <ul
-    class="cache-oswjln-Steps e1p9x3di2"
+    class="cache-1abqgir-Steps e1p9x3di2"
   >
     <li
       class="cache-1x18xpe-Step e1p9x3di1"
@@ -488,9 +488,9 @@ exports[`StepList renders correctly with disabled state 1`] = `
 
 exports[`StepList renders correctly with small size 1`] = `
 <DocumentFragment>
-  .cache-oswjln-Steps {
+  .cache-1abqgir-Steps {
   list-style: none;
-  padding-left: 16px;
+  padding-left: 0;
   text-align: left;
   display: -webkit-box;
   display: -webkit-flex;
@@ -553,7 +553,7 @@ exports[`StepList renders correctly with small size 1`] = `
 }
 
 <ul
-    class="cache-oswjln-Steps e1p9x3di2"
+    class="cache-1abqgir-Steps e1p9x3di2"
   >
     <li
       class="cache-15bydan-Step e1p9x3di1"

--- a/src/components/StepList/index.tsx
+++ b/src/components/StepList/index.tsx
@@ -4,7 +4,7 @@ import Bullet from '../Bullet'
 
 export const Steps = styled.ul`
   list-style: none;
-  padding-left: ${({ theme }) => theme.space['2']};
+  padding-left: 0;
   text-align: left;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Set padding-left for the `ul` of `StepList` to 0

#### What is expected?

`StepLists` comes now with 0 padding

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| /docs/components-data-display-steplist--default  | 
<img width="1081" alt="Screen Shot 2022-11-24 at 17 27 45" src="https://user-images.githubusercontent.com/2362139/203831322-890a4ba5-e6be-4849-81ce-d6582e1ed717.png">
 | 
<img width="1135" alt="Screen Shot 2022-11-24 at 17 27 04" src="https://user-images.githubusercontent.com/2362139/203831350-20298be7-8449-4045-94d2-b4fdd2ee8828.png">
 |
