### PR TITLE
docs: remove fonts load at each story to make it global

### DIFF
--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -11,8 +11,43 @@ import {
 import { useDarkMode } from 'storybook-dark-mode'
 import { light, dark } from '../storybookThemes'
 import { darkTheme } from '../../src'
-import { ThemeProvider } from '@emotion/react'
+import { ThemeProvider, Global, css } from '@emotion/react'
 import lightTheme from '../../src/theme'
+import AsapRegularWoff2 from '../assets/fonts/asap/Asap-Regular.woff2'
+import AsapMediumWoff2 from '../assets/fonts/asap/Asap-Medium.woff2'
+import AsapBoldWoff2 from '../assets/fonts/asap/Asap-Bold.woff2'
+import JetBrains from '../assets/fonts/jetbrains/JetBrainsMono-Regular.woff2'
+
+const fonts = css`
+  @font-face {
+    font-family: 'Asap';
+    font-style: normal;
+    src: url(${AsapRegularWoff2}) format('woff2');
+    font-weight: 400;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Asap';
+    font-style: normal;
+    src: url(${AsapMediumWoff2}) format('woff2');
+    font-weight: 500;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'Asap';
+    font-style: normal;
+    src: url(${AsapBoldWoff2}) format('woff2');
+    font-weight: 600;
+    font-display: swap;
+  }
+  @font-face {
+    font-family: 'JetBrains';
+    font-style: normal;
+    src: url(${JetBrains}) format('woff2');
+    font-weight: 400;
+    font-display: swap;
+  }
+`
 
 type ExtraProps = {
   deprecated: boolean
@@ -34,6 +69,7 @@ const DocsContainer: typeof CustomBaseContainer = ({ context, children }) => {
 
   return (
     <ThemeProvider theme={currentTheme}>
+      <Global styles={[fonts]} />
       <CustomBaseContainer
         context={{
           ...context,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,10 +10,6 @@ import { light, dark } from './storybookThemes'
 import lightTheme, { darkTheme } from '../src/theme'
 import DocsContainer from './components/DocsContainer'
 import Page from './components/Page'
-import AsapBoldWoff2 from './assets/fonts/asap/Asap-Bold.woff2'
-import AsapMediumWoff2 from './assets/fonts/asap/Asap-Medium.woff2'
-import AsapRegularWoff2 from './assets/fonts/asap/Asap-Regular.woff2'
-import JetBrains from './assets/fonts/jetbrains/JetBrainsMono-Regular.woff2'
 import isChromatic from 'chromatic/isChromatic'
 
 if (isChromatic()) seedrandom('manual-seed', { global: true })
@@ -118,37 +114,6 @@ export const globalStyles = (mode: 'light' | 'dark') => (theme: Theme) =>
     }
   `
 
-const fonts = css`
-  @font-face {
-    font-family: 'Asap';
-    font-style: normal;
-    src: url(${AsapRegularWoff2}) format('woff2');
-    font-weight: 400;
-    font-display: swap;
-  }
-  @font-face {
-    font-family: 'Asap';
-    font-style: normal;
-    src: url(${AsapMediumWoff2}) format('woff2');
-    font-weight: 500;
-    font-display: swap;
-  }
-  @font-face {
-    font-family: 'Asap';
-    font-style: normal;
-    src: url(${AsapBoldWoff2}) format('woff2');
-    font-weight: 600;
-    font-display: swap;
-  }
-  @font-face {
-    font-family: 'JetBrains';
-    font-style: normal;
-    src: url(${JetBrains}) format('woff2');
-    font-weight: 400;
-    font-display: swap;
-  }
-`
-
 export const decorators = [
   (StoryComponent: Story) => {
     const mode = useDarkMode() ? 'dark' : 'light'
@@ -173,7 +138,7 @@ export const decorators = [
         supportedLocales={['en', 'fr', 'es']}
       >
         <ThemeProvider theme={generatedTheme}>
-          <Global styles={[globalStyles(mode), fonts]} />
+          <Global styles={[globalStyles(mode)]} />
           <StoryComponent />
         </ThemeProvider>
       </I18n>


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

There was an issue with fonts loading in storybook (check video). In fact fonts where loaded at every render of stories which made it "blink" while changing component story. I made the import of fonts globally to storybook so there is not that behavior.

## Relevant logs and/or screenshots

When switch from one component to another this happen (now solved):

https://user-images.githubusercontent.com/15812968/204014765-40936bbe-491f-4a4f-a996-b6f5028ee5a8.mov


