### PR TITLE
fix: a11y parameters for text and link

### DIFF
--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -26,6 +26,7 @@ type LinkProps = {
   href: string
   // For react router shouldn't be used directly
   onClick?: MouseEventHandler<HTMLAnchorElement>
+  'aria-label'?: string
 }
 
 const ICON_SIZE = 16
@@ -125,6 +126,7 @@ const Link = forwardRef(
       rel,
       className,
       onClick,
+      'aria-label': ariaLabel,
     }: LinkProps,
     ref: ForwardedRef<HTMLAnchorElement>,
   ) => {
@@ -143,6 +145,7 @@ const Link = forwardRef(
         size={size}
         onClick={onClick}
         iconPosition={iconPosition}
+        aria-label={ariaLabel}
       >
         {!isBlank && iconPosition === 'left' ? (
           <StyledIcon name="arrow-left" size={ICON_SIZE} />

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -84,6 +84,7 @@ type TextProps = {
   disabled?: boolean
   italic?: boolean
   underline?: boolean
+  id?: string
 }
 
 const StyledText = styled('div', {
@@ -119,6 +120,7 @@ const Text = ({
   disabled = false,
   italic = false,
   underline = false,
+  id,
 }: TextProps) => {
   const [isTruncated, setIsTruncated] = useState(false)
   const elementRef = useRef(null)
@@ -145,6 +147,7 @@ const Text = ({
         disabled={disabled}
         italic={italic}
         underline={underline}
+        id={id}
       >
         {children}
       </StyledText>


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

I added possibility to set and `id` for text to be able to anchor some titles.
I also added `aria-label` for links as apparently links should always have label: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Text_labels_and_names#interactive_elements_must_be_labeled 
