### PR TITLE
fix(Pagination): fix getPageNumbers in Pagination v1, add unit tests

### DIFF
--- a/src/components/Pagination/__tests__/getPageNumbers.test.ts
+++ b/src/components/Pagination/__tests__/getPageNumbers.test.ts
@@ -26,5 +26,17 @@ describe('getPageNumbers', () => {
     it('should get 3,4,5,6,7 if current page is 7, with 7 pages', () => {
       expect(getPageNumbers(7, 7)).toEqual([3, 4, 5, 6, 7])
     })
+    it('should get 1,2,3,4 if current page is 1, with 4 pages', () => {
+      expect(getPageNumbers(1, 4)).toEqual([1, 2, 3, 4])
+    })
+    it('should get 1,2,3,4 if current page is 0, with 4 pages', () => {
+      expect(getPageNumbers(0, 4)).toEqual([1, 2, 3, 4])
+    })
+    it('should get 1,2,3,4 if current page is 5, with 4 pages', () => {
+      expect(getPageNumbers(5, 4)).toEqual([1, 2, 3, 4])
+    })
+    it('should get 8,9,10,11,12 if current page is 10, with 20 pages', () => {
+      expect(getPageNumbers(10, 20)).toEqual([8, 9, 10, 11, 12])
+    })
   })
 })

--- a/src/components/Pagination/getPageNumbers.ts
+++ b/src/components/Pagination/getPageNumbers.ts
@@ -19,7 +19,7 @@ export default function getPageNumbers(
   }
   let start = currentPage - gap - remaining
   if (start < 1) {
-    remaining = -start + 1
+    remaining = -start
     start = 1
   }
   if (end < pageCount) {

--- a/src/components/PaginationV2/__tests__/getPageNumbers.test.ts
+++ b/src/components/PaginationV2/__tests__/getPageNumbers.test.ts
@@ -29,5 +29,17 @@ describe('getPageNumbers', () => {
     it('should get 3,4,5,6,7 if current page is 7, with 7 pages', () => {
       expect(getPageNumbers(7, 7)).toEqual([3, 4, 5, 6, 7])
     })
+    it('should get 1,2,3,4 if current page is 1, with 4 pages', () => {
+      expect(getPageNumbers(1, 4)).toEqual([1, 2, 3, 4])
+    })
+    it('should get 1,2,3,4 if current page is 0, with 4 pages', () => {
+      expect(getPageNumbers(0, 4)).toEqual([1, 2, 3, 4])
+    })
+    it('should get 1,2,3,4 if current page is 5, with 4 pages', () => {
+      expect(getPageNumbers(5, 4)).toEqual([1, 2, 3, 4])
+    })
+    it('should get 8,9,10,11,12 if current page is 10, with 20 pages', () => {
+      expect(getPageNumbers(10, 20)).toEqual([8, 9, 10, 11, 12])
+    })
   })
 })


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Fix a bug in `Pagination` v1 that use to display a supernumerary page.

#### What is expected?

Now the pagination correctly display the last page as the max pageCount if smaller than current + gap

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![image](https://user-images.githubusercontent.com/2362139/204854342-8b41c466-4465-4971-86c4-83c19b379ab4.png) | ![image (1)](https://user-images.githubusercontent.com/2362139/204854639-37482376-b97b-45a3-ad21-34f3f1adcdd5.png) |
