### PR TITLE
fix(tabs): vertical scroll triggred on page load

### DIFF
--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -96,13 +96,10 @@ const Tabs = ({
   useEffect(() => {
     const tab = tabsRef.current.querySelector(
       `[role='tab'][aria-selected='true']`,
-    )
-    if (tab && tab.scrollIntoView) {
-      tab.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'center',
-      })
+    ) as HTMLElement
+
+    if (tab) {
+      tabsRef.current.scrollTo({ left: tab.offsetLeft, behavior: 'smooth' })
     }
   }, [selected])
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -98,7 +98,7 @@ const Tabs = ({
       `[role='tab'][aria-selected='true']`,
     ) as HTMLElement
 
-    if (tab) {
+    if (tab && tabsRef.current.scrollTo) {
       tabsRef.current.scrollTo({ left: tab.offsetLeft, behavior: 'smooth' })
     }
   }, [selected])


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

There is an issue with Tabs that scroll vertically when loading a page (like on website). This is because we have a scroll event on Tabs to make it go to selected tabs. As we don't want this effect on vertical scroll I blocked it on horizontal scroll avoiding to cause side effects.

## Relevant logs and/or screenshots

Before:

https://user-images.githubusercontent.com/15812968/206156368-25956682-bcce-41c2-a0f0-895ccd5ce953.mov

After:

https://user-images.githubusercontent.com/15812968/206156428-3468d936-4c7b-47c2-8c9d-a635617d5550.mov
