### PR TITLE
fix(toaster): wrong variant for error

### DIFF
--- a/src/components/Toaster/__tests__/__snapshots__/index.tsx.snap
+++ b/src/components/Toaster/__tests__/__snapshots__/index.tsx.snap
@@ -186,7 +186,7 @@ exports[`Toaster renders correctly with all kind of toast 1`] = `
       </div>
     </div>
   </div>,
-  .cache-1gioye0-Stack-StyledStackContainer-alertStyles-StyledAlert {
+  .cache-r1gait-Stack-StyledStackContainer-alertStyles-StyledAlert {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -209,8 +209,8 @@ exports[`Toaster renders correctly with all kind of toast 1`] = `
   flex-wrap: nowrap;
   border-radius: 4px;
   padding: 16px;
-  background-color: #ffefe6;
-  color: #cc4e18;
+  background-color: #ffe1e7;
+  color: #a6102d;
   padding: 0;
 }
 
@@ -256,7 +256,7 @@ exports[`Toaster renders correctly with all kind of toast 1`] = `
   >
     <div>
       <div
-        class="e1txm9iz0 cache-1gioye0-Stack-StyledStackContainer-alertStyles-StyledAlert eenhiht2"
+        class="e1txm9iz0 cache-r1gait-Stack-StyledStackContainer-alertStyles-StyledAlert eenhiht2"
       >
         <svg
           class="cache-wp3con-StyledIcon-sizeStyles etwatq50"
@@ -433,7 +433,7 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
   padding: 0;
 }
 
-.cache-1gioye0-Stack-StyledStackContainer-alertStyles-StyledAlert {
+.cache-r1gait-Stack-StyledStackContainer-alertStyles-StyledAlert {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -456,8 +456,8 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
   flex-wrap: nowrap;
   border-radius: 4px;
   padding: 16px;
-  background-color: #ffefe6;
-  color: #cc4e18;
+  background-color: #ffe1e7;
+  color: #a6102d;
   padding: 0;
 }
 
@@ -586,7 +586,7 @@ exports[`Toaster renders correctly with all kind of toast 2`] = `
         >
           <div>
             <div
-              class="e1txm9iz0 cache-1gioye0-Stack-StyledStackContainer-alertStyles-StyledAlert eenhiht2"
+              class="e1txm9iz0 cache-r1gait-Stack-StyledStackContainer-alertStyles-StyledAlert eenhiht2"
             >
               <svg
                 class="cache-wp3con-StyledIcon-sizeStyles etwatq50"

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -92,7 +92,7 @@ const SanitizedAlertBar = ({ variant, children }: SanitizedAlertBarProps) => (
 const toast = {
   error: (children: ReactNode, options?: ToastOptions): number | string =>
     baseToast.error(
-      <SanitizedAlertBar variant="warning">{children}</SanitizedAlertBar>,
+      <SanitizedAlertBar variant="danger">{children}</SanitizedAlertBar>,
       options,
     ),
   info: (children: ReactNode, options?: ToastOptions): number | string =>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Wrong variant for toaster that display an orange color while it should be red.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2022-12-12 at 10 11 56](https://user-images.githubusercontent.com/15812968/207007913-27aa85c7-bd15-4a88-89e8-c57f5645a1e1.png) | ![Screenshot 2022-12-12 at 10 11 14](https://user-images.githubusercontent.com/15812968/207007934-31e31c4e-650c-458e-9bf8-b952c0d2d91e.png) |
