### PR TITLE
fix: unselect all when no selectable rows

### DIFF
--- a/src/components/ListV2/ListHeaderRow.tsx
+++ b/src/components/ListV2/ListHeaderRow.tsx
@@ -57,7 +57,10 @@ export const ListHeaderRow = ({
   )
 
   const checkedValue = useMemo(() => {
-    if (selectedIds.length === getSelectableRows().length) {
+    if (
+      getSelectableRows().length > 0 &&
+      selectedIds.length === getSelectableRows().length
+    ) {
       return true
     }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Dont select all checkbox when no row are selectable

#### The following changes where made:

1. Update condition

2.

3.
