### PR TITLE
fix(Button): manage flex display on tooltip

### DIFF
--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -1481,7 +1481,11 @@ exports[`Button should render correctly with a rounded action button 1`] = `
 
 exports[`Button should render correctly with a tooltip 1`] = `
 <DocumentFragment>
-  .cache-1btucg0-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-1btucg0-StyledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1570,6 +1574,7 @@ exports[`Button should render correctly with a tooltip 1`] = `
 
 <div
     aria-describedby="test"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       aria-describedby="test"

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`CopyButton renders correctly 1`] = `
 <DocumentFragment>
-  .cache-16ljkze-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-16ljkze-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -45,6 +49,7 @@ exports[`CopyButton renders correctly 1`] = `
 
 <div
     aria-describedby=":r0:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -65,7 +70,11 @@ exports[`CopyButton renders correctly 1`] = `
 
 exports[`CopyButton renders correctly variant large 1`] = `
 <DocumentFragment>
-  .cache-r06x4m-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-r06x4m-StyledButton {
   width: 48px;
   height: 48px;
   background: transparent;
@@ -108,6 +117,7 @@ exports[`CopyButton renders correctly variant large 1`] = `
 
 <div
     aria-describedby=":r2:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-r06x4m-StyledButton e1go4oa30"
@@ -128,7 +138,11 @@ exports[`CopyButton renders correctly variant large 1`] = `
 
 exports[`CopyButton renders correctly variant neutral 1`] = `
 <DocumentFragment>
-  .cache-xsw6vc-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-xsw6vc-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -171,6 +185,7 @@ exports[`CopyButton renders correctly variant neutral 1`] = `
 
 <div
     aria-describedby=":r4:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-xsw6vc-StyledButton e1go4oa30"
@@ -191,7 +206,11 @@ exports[`CopyButton renders correctly variant neutral 1`] = `
 
 exports[`CopyButton renders correctly variant primary 1`] = `
 <DocumentFragment>
-  .cache-16ljkze-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-16ljkze-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -234,6 +253,7 @@ exports[`CopyButton renders correctly variant primary 1`] = `
 
 <div
     aria-describedby=":r3:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -254,7 +274,11 @@ exports[`CopyButton renders correctly variant primary 1`] = `
 
 exports[`CopyButton renders correctly variant small 1`] = `
 <DocumentFragment>
-  .cache-16ljkze-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-16ljkze-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -297,6 +321,7 @@ exports[`CopyButton renders correctly variant small 1`] = `
 
 <div
     aria-describedby=":r1:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -317,7 +342,11 @@ exports[`CopyButton renders correctly variant small 1`] = `
 
 exports[`CopyButton renders correctly with custom class name 1`] = `
 <DocumentFragment>
-  .cache-16ljkze-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-16ljkze-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -360,6 +389,7 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 
 <div
     aria-describedby=":r8:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="custom-class cache-16ljkze-StyledButton e1go4oa30"
@@ -380,7 +410,11 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 
 exports[`CopyButton renders correctly with custom copied text 1`] = `
 <DocumentFragment>
-  .cache-16ljkze-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-16ljkze-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -423,6 +457,7 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 
 <div
     aria-describedby=":r7:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -443,7 +478,11 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 
 exports[`CopyButton renders correctly with custom copy text 1`] = `
 <DocumentFragment>
-  .cache-16ljkze-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-16ljkze-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -486,6 +525,7 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 
 <div
     aria-describedby=":r6:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -506,7 +546,11 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 
 exports[`CopyButton renders correctly with no border 1`] = `
 <DocumentFragment>
-  .cache-1gy37wj-StyledButton {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-1gy37wj-StyledButton {
   width: 32px;
   height: 32px;
   background: transparent;
@@ -549,6 +593,7 @@ exports[`CopyButton renders correctly with no border 1`] = `
 
 <div
     aria-describedby=":r5:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <button
       class="cache-1gy37wj-StyledButton e1go4oa30"

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -12174,6 +12174,10 @@ exports[`List should render correctly multiselect with condition 1`] = `
   flex-wrap: wrap;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1h3zz7k-CheckboxContainer-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
@@ -12492,6 +12496,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-0"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -12687,6 +12692,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-2"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -12787,6 +12793,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-3"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -12887,6 +12894,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-4"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -13293,6 +13301,10 @@ exports[`List should render correctly multiselect with condition, table variant 
   opacity: 1;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-cx07pk-CheckboxContainer-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
@@ -13580,6 +13592,7 @@ exports[`List should render correctly multiselect with condition, table variant 
         <div>
           <div
             aria-describedby="list-tooltip-row-0"
+            class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           >
             <label
               aria-disabled="true"
@@ -13749,6 +13762,7 @@ exports[`List should render correctly multiselect with condition, table variant 
         <div>
           <div
             aria-describedby="list-tooltip-row-2"
+            class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           >
             <label
               aria-disabled="true"
@@ -13836,6 +13850,7 @@ exports[`List should render correctly multiselect with condition, table variant 
         <div>
           <div
             aria-describedby="list-tooltip-row-3"
+            class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           >
             <label
               aria-disabled="true"
@@ -13923,6 +13938,7 @@ exports[`List should render correctly multiselect with condition, table variant 
         <div>
           <div
             aria-describedby="list-tooltip-row-4"
+            class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           >
             <label
               aria-disabled="true"
@@ -23271,6 +23287,10 @@ exports[`List should render correctly with bad idKey 1`] = `
   flex-wrap: wrap;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1h3zz7k-CheckboxContainer-StyledCheckbox {
   position: relative;
   display: -webkit-inline-box;
@@ -23589,6 +23609,7 @@ exports[`List should render correctly with bad idKey 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-0"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -23695,6 +23716,7 @@ exports[`List should render correctly with bad idKey 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-1"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -23801,6 +23823,7 @@ exports[`List should render correctly with bad idKey 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-2"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -23907,6 +23930,7 @@ exports[`List should render correctly with bad idKey 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-3"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"
@@ -24013,6 +24037,7 @@ exports[`List should render correctly with bad idKey 1`] = `
             >
               <div
                 aria-describedby="list-tooltip-row-4"
+                class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               >
                 <label
                   aria-disabled="true"

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.tsx.snap
@@ -45,6 +45,10 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
   overflow-y: auto;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-exvtnx-ListItem {
   display: -webkit-box;
   display: -webkit-flex;
@@ -245,6 +249,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-exvtnx-ListItem enw618e7"
@@ -283,6 +288,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -369,6 +375,10 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
   overflow-y: auto;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-exvtnx-ListItem {
   display: -webkit-box;
   display: -webkit-flex;
@@ -569,6 +579,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-exvtnx-ListItem enw618e7"
@@ -607,6 +618,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -882,6 +894,10 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
   overflow-y: auto;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1klfns5-ListItem {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1042,6 +1058,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1080,6 +1097,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1150,6 +1168,10 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
   flex-direction: column;
   max-height: 100%;
   overflow-y: auto;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1klfns5-ListItem {
@@ -1319,6 +1341,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
     >
       <div
         aria-describedby="chart-legend-discount"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1506,6 +1529,10 @@ exports[`PieChart renders correctly with legend 1`] = `
   flex-direction: column;
   max-height: 100%;
   overflow-y: auto;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1klfns5-ListItem {
@@ -1796,6 +1823,7 @@ exports[`PieChart renders correctly with legend 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1834,6 +1862,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1872,6 +1901,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-functions"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1910,6 +1940,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-containers"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1948,6 +1979,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-s3"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1986,6 +2018,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-dns"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2024,6 +2057,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-appleSilicon"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2062,6 +2096,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-baremetal"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2100,6 +2135,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-database"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2138,6 +2174,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-lb"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.tsx.snap
@@ -1146,7 +1146,11 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 
 exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-dgvm93-Container {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-dgvm93-Container {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1370,6 +1374,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 
 <div
     aria-describedby=":rn:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <div
       class="cache-dgvm93-Container ejleepd1"
@@ -2713,7 +2718,11 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 
 exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-dgvm93-Container {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-dgvm93-Container {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2909,6 +2918,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 
 <div
     aria-describedby=":rl:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <div
       class="cache-dgvm93-Container ejleepd1"

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.tsx.snap
@@ -84,6 +84,10 @@ exports[`Snippet renders correctly 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1nnm9m7-StyledButton {
   width: 32px;
   height: 32px;
@@ -145,6 +149,7 @@ exports[`Snippet renders correctly 1`] = `
       >
         <div
           aria-describedby=":r1:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -247,6 +252,10 @@ exports[`Snippet renders correctly in multiline  1`] = `
   background: #f6f6f8;
   border-radius: 4px;
   border: 2px solid transparent;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -389,6 +398,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
       >
         <div
           aria-describedby=":r3:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -528,6 +538,10 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
   background: #f6f6f8;
   border-radius: 4px;
   border: 2px solid transparent;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -670,6 +684,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
       >
         <div
           aria-describedby=":r9:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -812,6 +827,10 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
   border: 2px solid transparent;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1nnm9m7-StyledButton {
   width: 32px;
   height: 32px;
@@ -952,6 +971,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
       >
         <div
           aria-describedby=":r6:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1079,6 +1099,10 @@ exports[`Snippet renders correctly with copiedText 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1nnm9m7-StyledButton {
   width: 32px;
   height: 32px;
@@ -1140,6 +1164,7 @@ exports[`Snippet renders correctly with copiedText 1`] = `
       >
         <div
           aria-describedby=":ri:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1245,6 +1270,10 @@ exports[`Snippet renders correctly with copyText 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1nnm9m7-StyledButton {
   width: 32px;
   height: 32px;
@@ -1306,6 +1335,7 @@ exports[`Snippet renders correctly with copyText 1`] = `
       >
         <div
           aria-describedby=":rg:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1408,6 +1438,10 @@ exports[`Snippet renders correctly with hideText 1`] = `
   background: #f6f6f8;
   border-radius: 4px;
   border: 2px solid transparent;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1550,6 +1584,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
       >
         <div
           aria-describedby=":rk:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1674,6 +1709,10 @@ exports[`Snippet renders correctly with showText 1`] = `
   background: #f6f6f8;
   border-radius: 4px;
   border: 2px solid transparent;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1816,6 +1855,7 @@ exports[`Snippet renders correctly with showText 1`] = `
       >
         <div
           aria-describedby=":rn:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1958,6 +1998,10 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1nnm9m7-StyledButton {
   width: 32px;
   height: 32px;
@@ -2019,6 +2063,7 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
       >
         <div
           aria-describedby=":rc:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -2140,6 +2185,10 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-1nnm9m7-StyledButton {
   width: 32px;
   height: 32px;
@@ -2201,6 +2250,7 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
       >
         <div
           aria-describedby=":re:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -2303,6 +2353,10 @@ exports[`Snippet should click on extend button to display full content on  1`] =
   background: #f6f6f8;
   border-radius: 4px;
   border: 2px solid transparent;
+}
+
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -2445,6 +2499,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
       >
         <div
           aria-describedby=":rq:"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.tsx.snap
@@ -950,7 +950,11 @@ exports[`SwitchButton renders correctly with right value 1`] = `
 
 exports[`SwitchButton renders with tooltip 1`] = `
 <DocumentFragment>
-  .cache-fo08zx-BorderedBox-StyledBorderedBox {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-fo08zx-BorderedBox-StyledBorderedBox {
   padding: 24px;
   border-radius: 4px;
   border: 1px solid #d4dae7;
@@ -1266,6 +1270,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
 
 <div
     aria-describedby=":ra:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <div
       style="display: inline-flex;"

--- a/packages/ui/src/components/TagsPoplist/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/TagsPoplist/__tests__/__snapshots__/index.tsx.snap
@@ -58,6 +58,10 @@ exports[`TagsPoplist renders correctly 1`] = `
   text-overflow: ellipsis;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-15hi38u-StyledTooltipReference {
   color: #390171;
   border: none;
@@ -94,6 +98,7 @@ exports[`TagsPoplist renders correctly 1`] = `
       </div>
       <div
         aria-describedby=":r0:"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference eom2dbt2"
@@ -256,6 +261,10 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags 1`] 
   text-overflow: ellipsis;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-15hi38u-StyledTooltipReference {
   color: #390171;
   border: none;
@@ -302,6 +311,7 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags 1`] 
       </div>
       <div
         aria-describedby=":r1:"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference eom2dbt2"
@@ -372,6 +382,10 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags and 
   text-overflow: ellipsis;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-15hi38u-StyledTooltipReference {
   color: #390171;
   border: none;
@@ -408,6 +422,7 @@ exports[`TagsPoplist renders correctly with custom threshold and extra tags and 
       </div>
       <div
         aria-describedby=":r2:"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference eom2dbt2"
@@ -482,6 +497,10 @@ exports[`TagsPoplist renders correctly with multiline 1`] = `
   text-overflow: ellipsis;
 }
 
+.cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
 .cache-15hi38u-StyledTooltipReference {
   color: #390171;
   border: none;
@@ -528,6 +547,7 @@ exports[`TagsPoplist renders correctly with multiline 1`] = `
       </div>
       <div
         aria-describedby=":r3:"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference eom2dbt2"

--- a/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,8 +2,13 @@
 
 exports[`Tooltip should render correctly 1`] = `
 <DocumentFragment>
-  <div
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+<div
     aria-describedby=":r0:"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     Hover me
   </div>

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -89,6 +89,10 @@ const StyledTooltip = styled.div<StyledTooltipProps>`
   }
 `
 
+const StyledChildrenContainer = styled.div`
+  display: inherit;
+`
+
 type TooltipProps = {
   id?: string
   children:
@@ -224,7 +228,7 @@ const Tooltip = ({
     }
 
     return (
-      <div
+      <StyledChildrenContainer
         aria-describedby={generatedId}
         onBlur={onMouseEvent(false)}
         onFocus={onMouseEvent(true)}
@@ -233,7 +237,7 @@ const Tooltip = ({
         ref={childrenRef}
       >
         {children}
-      </div>
+      </StyledChildrenContainer>
     )
   }, [children, generatedId, onMouseEvent])
 

--- a/packages/ui/src/components/TooltipIcon/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/TooltipIcon/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`TooltipIcon renders with default props 1`] = `
 <DocumentFragment>
-  .cache-dwb18c-StyledIcon-sizeStyles {
+  .cache-yb56yg-StyledChildrenContainer {
+  display: inherit;
+}
+
+.cache-dwb18c-StyledIcon-sizeStyles {
   vertical-align: middle;
   fill: #b2b6c3;
   height: 20px;
@@ -13,6 +17,7 @@ exports[`TooltipIcon renders with default props 1`] = `
 
 <div
     aria-describedby="test"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
   >
     <svg
       class="cache-dwb18c-StyledIcon-sizeStyles etwatq50"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The button didn't have the same height when the prop `tooltip` was given in a flex element.

## Relevant logs and/or screenshots

|   Before   |      After |
| --------: | ---------: |
|  ![Capture d’écran 2022-12-30 à 12 12 00](https://user-images.githubusercontent.com/1339931/210065254-2a72324e-2bc4-4941-8b10-3c4e6e7e0661.png) |  ![Capture d’écran 2022-12-30 à 12 12 43](https://user-images.githubusercontent.com/1339931/210065361-074f36f3-bb26-4e63-adbb-bdebed6fd4e0.png) |

