### PR TITLE
fix(List): fix sort type to allow numbers

### DIFF
--- a/packages/ui/src/components/List/index.tsx
+++ b/packages/ui/src/components/List/index.tsx
@@ -15,7 +15,8 @@ import {
   useRef,
   useState,
 } from 'react'
-import orderBy from '../../utils/orderBy'
+import { orderBy } from '../../utils'
+import type { ComparableType } from '../../utils'
 import Pagination from '../Pagination'
 import type { PaginationProps } from '../Pagination'
 import type { UsePaginationReturn } from '../Pagination/usePagination'
@@ -225,7 +226,7 @@ export type ListProps<DataType> = {
    * @param {{page, perPage, sort, order}} params The params to sort the list
    */
   onSortClick?: (params: {
-    field?: string | ((item: DataType) => string) | null
+    field?: string | ((item: DataType) => ComparableType) | null
     order: ListOrder
     page: number
     // TODO Change this when Pagination migration is merged

--- a/packages/ui/src/components/List/types.ts
+++ b/packages/ui/src/components/List/types.ts
@@ -1,4 +1,5 @@
 import type { MouseEventHandler, ReactNode } from 'react'
+import type { ComparableType } from '../../utils'
 import type * as animations from '../../utils/animations'
 
 export type ListOrder = 'asc' | 'desc' | undefined
@@ -7,12 +8,12 @@ export type ListSort<T> = {
   index: number
   onSort?:
     | ((
-        prop: string | ((item: T) => string) | null,
+        prop: string | ((item: T) => ComparableType) | null,
         order: string,
       ) => (a: T, b: T) => number)
     | null
   order: ListOrder
-  prop: string | ((item: T) => string) | undefined
+  prop: string | ((item: T) => ComparableType) | undefined
 }
 
 export type ListColumn<T> = {
@@ -21,12 +22,12 @@ export type ListColumn<T> = {
   label?: string | null
   onSort?:
     | ((
-        prop: string | ((item: T) => string) | null,
+        prop: string | ((item: T) => ComparableType) | null,
         order: string,
       ) => (a: T, b: T) => number)
     | null
   padding?: string | null
-  sort?: string | ((item: T) => string) | null
+  sort?: string | ((item: T) => ComparableType) | null
   width?: string | null
   defaultSort?: ListOrder | null
 }

--- a/packages/ui/src/components/List/variants/variantExplorer.tsx
+++ b/packages/ui/src/components/List/variants/variantExplorer.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled'
 import type { KeyboardEvent, MouseEvent } from 'react'
 import { useCallback } from 'react'
+import type { ComparableType } from '../../../utils'
 import Checkbox from '../../Checkbox'
 import Tooltip from '../../Tooltip'
 import BaseCell from '../Cell'
@@ -91,7 +92,10 @@ export const Header = () => {
     (
       event: MouseEvent | KeyboardEvent,
       index: number,
-      sort?: string | ((item: Record<string, unknown>) => string) | null,
+      sort?:
+        | string
+        | ((item: Record<string, unknown>) => ComparableType)
+        | null,
     ) => {
       event.preventDefault()
       if (sort) {

--- a/packages/ui/src/components/List/variants/variantProduct.tsx
+++ b/packages/ui/src/components/List/variants/variantProduct.tsx
@@ -14,6 +14,7 @@ import {
   useCallback,
   useEffect,
 } from 'react'
+import type { ComparableType } from '../../../utils'
 import * as animations from '../../../utils/animations'
 import Checkbox from '../../Checkbox'
 import Tooltip from '../../Tooltip'
@@ -245,7 +246,10 @@ export const Header = () => {
     (
       event: MouseEvent | KeyboardEvent,
       index: number,
-      sort?: string | ((item: Record<string, unknown>) => string) | null,
+      sort?:
+        | string
+        | ((item: Record<string, unknown>) => ComparableType)
+        | null,
     ) => {
       event.preventDefault()
       if (sort) {

--- a/packages/ui/src/components/List/variants/variantTable.tsx
+++ b/packages/ui/src/components/List/variants/variantTable.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { KeyboardEvent, MouseEvent } from 'react'
 import { useCallback } from 'react'
+import type { ComparableType } from '../../../utils'
 import * as animations from '../../../utils/animations'
 import Checkbox from '../../Checkbox'
 import Tooltip from '../../Tooltip'
@@ -138,7 +139,10 @@ export const Header = () => {
     (
       event: MouseEvent | KeyboardEvent,
       index: number,
-      sort?: string | ((item: Record<string, unknown>) => string) | null,
+      sort?:
+        | string
+        | ((item: Record<string, unknown>) => ComparableType)
+        | null,
     ) => {
       event.preventDefault()
       if (sort) {

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -30,3 +30,5 @@ export {
 } from './animations'
 export { down, up, Breakpoint } from './responsive'
 export { default as normalize } from './normalize'
+export { orderBy } from './orderBy'
+export type { ComparableType } from './orderBy'

--- a/packages/ui/src/utils/orderBy.ts
+++ b/packages/ui/src/utils/orderBy.ts
@@ -1,6 +1,6 @@
-type ComparableType = string | number
+export type ComparableType = string | number
 
-function orderBy<T extends Record<string, unknown>>(
+export function orderBy<T extends Record<string, unknown>>(
   key: string | ((a: T) => ComparableType),
   order: 'asc' | 'desc',
 ): (a: T, b: T) => number {
@@ -21,5 +21,3 @@ function orderBy<T extends Record<string, unknown>>(
     return transformedB > transformedA ? -1 * direction : 0
   }
 }
-
-export default orderBy


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The `sort` prop didn't allow `number` as the return value when we use a function. This PR uses `ComparableType` everywhere to allow for `number | string`.