### PR TITLE
fix(actionBar): remove padding and center content from list action bar

### DIFF
--- a/packages/ui/src/components/ActionBar/__stories__/Ranks.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/Ranks.stories.tsx
@@ -1,13 +1,24 @@
+import styled from '@emotion/styled'
 import type { ComponentStory } from '@storybook/react'
 import ActionBar from '..'
+import Stack from '../../Stack'
+
+const FullHeightStack = styled(Stack)`
+  height: 100%;
+  padding: 0 ${({ theme }) => theme.space['2']};
+`
 
 export const Ranks: ComponentStory<typeof ActionBar> = props => (
   <>
     <ActionBar {...props} rank={1}>
-      I am an Action Bar with rank 1
+      <FullHeightStack alignItems="center" direction="row">
+        I am an Action Bar with rank 1
+      </FullHeightStack>
     </ActionBar>
     <ActionBar {...props} rank={2}>
-      I am an Action Bar with rank 2
+      <FullHeightStack alignItems="center" direction="row">
+        I am an Action Bar with rank 2
+      </FullHeightStack>
     </ActionBar>
   </>
 )

--- a/packages/ui/src/components/ActionBar/__stories__/Ranks.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/Ranks.stories.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled'
 import type { ComponentStory } from '@storybook/react'
 import ActionBar from '..'
-import Stack from '../../Stack'
 
-const FullHeightStack = styled(Stack)`
+const FullHeightDiv = styled.div`
+  display: flex;
+  align-items: center;
   height: 100%;
   padding: 0 ${({ theme }) => theme.space['2']};
 `
@@ -11,14 +12,10 @@ const FullHeightStack = styled(Stack)`
 export const Ranks: ComponentStory<typeof ActionBar> = props => (
   <>
     <ActionBar {...props} rank={1}>
-      <FullHeightStack alignItems="center" direction="row">
-        I am an Action Bar with rank 1
-      </FullHeightStack>
+      <FullHeightDiv>I am an Action Bar with rank 1</FullHeightDiv>
     </ActionBar>
     <ActionBar {...props} rank={2}>
-      <FullHeightStack alignItems="center" direction="row">
-        I am an Action Bar with rank 2
-      </FullHeightStack>
+      <FullHeightDiv>I am an Action Bar with rank 2</FullHeightDiv>
     </ActionBar>
   </>
 )

--- a/packages/ui/src/components/ActionBar/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/Template.stories.tsx
@@ -4,7 +4,9 @@ import ActionBar from '..'
 import Button from '../../Button'
 import Stack from '../../Stack'
 
-const StyledStack = styled(Stack)`
+const StyledFlexDiv = styled.div`
+  display: flex;
+  align-items: flex-end;
   flex: 1;
 `
 
@@ -17,9 +19,9 @@ export const Template: ComponentStory<typeof ActionBar> = args => (
   <ActionBar {...args}>
     <FullHeightStack alignItems="center" direction="row">
       I am the Playground Action Bar
-      <StyledStack alignItems="flex-end">
+      <StyledFlexDiv>
         <Button action variant="warning-bordered" icon="delete" />
-      </StyledStack>
+      </StyledFlexDiv>
     </FullHeightStack>
   </ActionBar>
 )

--- a/packages/ui/src/components/ActionBar/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/Template.stories.tsx
@@ -1,6 +1,25 @@
+import styled from '@emotion/styled'
 import type { ComponentStory } from '@storybook/react'
 import ActionBar from '..'
+import Button from '../../Button'
+import Stack from '../../Stack'
+
+const StyledStack = styled(Stack)`
+  flex: 1;
+`
+
+const FullHeightStack = styled(Stack)`
+  height: 100%;
+  padding: 0 ${({ theme }) => theme.space['2']};
+`
 
 export const Template: ComponentStory<typeof ActionBar> = args => (
-  <ActionBar {...args}>I am the Playground Action Bar</ActionBar>
+  <ActionBar {...args}>
+    <FullHeightStack alignItems="center" direction="row">
+      I am the Playground Action Bar
+      <StyledStack alignItems="flex-end">
+        <Button action variant="warning-bordered" icon="delete" />
+      </StyledStack>
+    </FullHeightStack>
+  </ActionBar>
 )

--- a/packages/ui/src/components/ActionBar/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/ActionBar/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ActionBar renders correctly  1`] = `
 <DocumentFragment>
-  .cache-nmxi06-StyledDiv {
+  .cache-1gb9fuz-StyledDiv {
   background: #ffffff;
   border: 1px solid #e6e9f0;
   border-radius: 4px;
@@ -10,7 +10,6 @@ exports[`ActionBar renders correctly  1`] = `
   box-shadow: 0px 0px 8px 2px #D4DAE766;
   height: 56px;
   left: 50%;
-  padding: 16px;
   position: fixed;
   -webkit-transform: translate(-50%, 0);
   -moz-transform: translate(-50%, 0);
@@ -21,7 +20,7 @@ exports[`ActionBar renders correctly  1`] = `
 }
 
 <div
-    class="cache-nmxi06-StyledDiv e1qbxe4b0"
+    class="cache-1gb9fuz-StyledDiv e1qbxe4b0"
   >
     Hello
   </div>
@@ -30,7 +29,7 @@ exports[`ActionBar renders correctly  1`] = `
 
 exports[`ActionBar renders correctly with custom rank 1`] = `
 <DocumentFragment>
-  .cache-ydwxx6-StyledDiv {
+  .cache-19drksu-StyledDiv {
   background: #ffffff;
   border: 1px solid #e6e9f0;
   border-radius: 4px;
@@ -38,7 +37,6 @@ exports[`ActionBar renders correctly with custom rank 1`] = `
   box-shadow: 0px 0px 8px 2px #D4DAE766;
   height: 56px;
   left: 50%;
-  padding: 16px;
   position: fixed;
   -webkit-transform: translate(-50%, 0);
   -moz-transform: translate(-50%, 0);
@@ -49,7 +47,7 @@ exports[`ActionBar renders correctly with custom rank 1`] = `
 }
 
 <div
-    class="cache-ydwxx6-StyledDiv e1qbxe4b0"
+    class="cache-19drksu-StyledDiv e1qbxe4b0"
   >
     I am rank 2
   </div>

--- a/packages/ui/src/components/ActionBar/index.tsx
+++ b/packages/ui/src/components/ActionBar/index.tsx
@@ -12,7 +12,6 @@ const StyledDiv = styled.div<{ rank: number }>`
   box-shadow: ${({ theme }) => theme.shadows.defaultShadow};
   height: ${HEIGHT}px;
   left: 50%;
-  padding: ${({ theme }) => theme.space['2']};
   position: fixed;
   transform: translate(-50%, 0);
   width: 600px;

--- a/packages/ui/src/components/List/SelectBar.tsx
+++ b/packages/ui/src/components/List/SelectBar.tsx
@@ -6,6 +6,11 @@ import Stack from '../Stack'
 import Text from '../Text'
 import { useListContext } from './context'
 
+const StyledStack = styled(Stack)`
+  height: 100%;
+  padding: 0 ${({ theme }) => theme.space['2']};
+`
+
 const StyledCheckbox = styled(Checkbox)`
   justify-content: center;
   display: flex;
@@ -56,7 +61,7 @@ function SelectBar<T extends Record<string, unknown>>({
   // Don't display the pop-in if there aren't an item selected
   return selectedItems.length > 0 ? (
     <ActionBar {...props} role="dialog" aria-modal="true">
-      <Stack alignItems="center" direction="row">
+      <StyledStack alignItems="center" direction="row">
         <StyledCheckbox
           checked
           onChange={unselectAll}
@@ -72,7 +77,7 @@ function SelectBar<T extends Record<string, unknown>>({
             ? children({ selectedItems, unselectAll })
             : children}
         </StyledContainer>
-      </Stack>
+      </StyledStack>
     </ActionBar>
   ) : null
 }

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -5558,7 +5558,7 @@ exports[`List should render correctly multiselect and with click 1`] = `
   padding-left: 0px;
 }
 
-.cache-nmxi06-StyledDiv {
+.cache-1gb9fuz-StyledDiv {
   background: #ffffff;
   border: 1px solid #e6e9f0;
   border-radius: 4px;
@@ -5566,7 +5566,6 @@ exports[`List should render correctly multiselect and with click 1`] = `
   box-shadow: 0px 0px 8px 2px #D4DAE766;
   height: 56px;
   left: 50%;
-  padding: 16px;
   position: fixed;
   -webkit-transform: translate(-50%, 0);
   -moz-transform: translate(-50%, 0);
@@ -5576,7 +5575,7 @@ exports[`List should render correctly multiselect and with click 1`] = `
   z-index: 2;
 }
 
-.cache-1i7e9sg-Stack {
+.cache-1qajn5t-Stack-StyledStack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5597,6 +5596,8 @@ exports[`List should render correctly multiselect and with click 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  height: 100%;
+  padding: 0 16px;
 }
 
 .cache-15v7v24-CheckboxContainer-StyledCheckbox {
@@ -6347,11 +6348,11 @@ exports[`List should render correctly multiselect and with click 1`] = `
     </div>
     <div
       aria-modal="true"
-      class="cache-nmxi06-StyledDiv e1qbxe4b0"
+      class="cache-1gb9fuz-StyledDiv e1qbxe4b0"
       role="dialog"
     >
       <div
-        class="cache-1i7e9sg-Stack e1sgck4o0"
+        class="cache-1qajn5t-Stack-StyledStack e1fla99k4"
       >
         <label
           aria-disabled="false"
@@ -6882,7 +6883,7 @@ exports[`List should render correctly multiselect and with click and not functio
   padding-left: 0px;
 }
 
-.cache-nmxi06-StyledDiv {
+.cache-1gb9fuz-StyledDiv {
   background: #ffffff;
   border: 1px solid #e6e9f0;
   border-radius: 4px;
@@ -6890,7 +6891,6 @@ exports[`List should render correctly multiselect and with click and not functio
   box-shadow: 0px 0px 8px 2px #D4DAE766;
   height: 56px;
   left: 50%;
-  padding: 16px;
   position: fixed;
   -webkit-transform: translate(-50%, 0);
   -moz-transform: translate(-50%, 0);
@@ -6900,7 +6900,7 @@ exports[`List should render correctly multiselect and with click and not functio
   z-index: 2;
 }
 
-.cache-1i7e9sg-Stack {
+.cache-1qajn5t-Stack-StyledStack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6921,6 +6921,8 @@ exports[`List should render correctly multiselect and with click and not functio
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  height: 100%;
+  padding: 0 16px;
 }
 
 .cache-15v7v24-CheckboxContainer-StyledCheckbox {
@@ -7671,11 +7673,11 @@ exports[`List should render correctly multiselect and with click and not functio
     </div>
     <div
       aria-modal="true"
-      class="cache-nmxi06-StyledDiv e1qbxe4b0"
+      class="cache-1gb9fuz-StyledDiv e1qbxe4b0"
       role="dialog"
     >
       <div
-        class="cache-1i7e9sg-Stack e1sgck4o0"
+        class="cache-1qajn5t-Stack-StyledStack e1fla99k4"
       >
         <label
           aria-disabled="false"
@@ -14325,7 +14327,7 @@ exports[`List should render correctly multiselect, explorer variant and with cli
   opacity: 1;
 }
 
-.cache-nmxi06-StyledDiv {
+.cache-1gb9fuz-StyledDiv {
   background: #ffffff;
   border: 1px solid #e6e9f0;
   border-radius: 4px;
@@ -14333,7 +14335,6 @@ exports[`List should render correctly multiselect, explorer variant and with cli
   box-shadow: 0px 0px 8px 2px #D4DAE766;
   height: 56px;
   left: 50%;
-  padding: 16px;
   position: fixed;
   -webkit-transform: translate(-50%, 0);
   -moz-transform: translate(-50%, 0);
@@ -14343,7 +14344,7 @@ exports[`List should render correctly multiselect, explorer variant and with cli
   z-index: 2;
 }
 
-.cache-1i7e9sg-Stack {
+.cache-1qajn5t-Stack-StyledStack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14364,6 +14365,8 @@ exports[`List should render correctly multiselect, explorer variant and with cli
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  height: 100%;
+  padding: 0 16px;
 }
 
 .cache-15v7v24-CheckboxContainer-StyledCheckbox {
@@ -15110,11 +15113,11 @@ exports[`List should render correctly multiselect, explorer variant and with cli
     </div>
     <div
       aria-modal="true"
-      class="cache-nmxi06-StyledDiv e1qbxe4b0"
+      class="cache-1gb9fuz-StyledDiv e1qbxe4b0"
       role="dialog"
     >
       <div
-        class="cache-1i7e9sg-Stack e1sgck4o0"
+        class="cache-1qajn5t-Stack-StyledStack e1fla99k4"
       >
         <label
           aria-disabled="false"
@@ -16522,7 +16525,7 @@ exports[`List should render correctly multiselect, table variant and with click 
   opacity: 1;
 }
 
-.cache-nmxi06-StyledDiv {
+.cache-1gb9fuz-StyledDiv {
   background: #ffffff;
   border: 1px solid #e6e9f0;
   border-radius: 4px;
@@ -16530,7 +16533,6 @@ exports[`List should render correctly multiselect, table variant and with click 
   box-shadow: 0px 0px 8px 2px #D4DAE766;
   height: 56px;
   left: 50%;
-  padding: 16px;
   position: fixed;
   -webkit-transform: translate(-50%, 0);
   -moz-transform: translate(-50%, 0);
@@ -16540,7 +16542,7 @@ exports[`List should render correctly multiselect, table variant and with click 
   z-index: 2;
 }
 
-.cache-1i7e9sg-Stack {
+.cache-1qajn5t-Stack-StyledStack {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16561,6 +16563,8 @@ exports[`List should render correctly multiselect, table variant and with click 
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  height: 100%;
+  padding: 0 16px;
 }
 
 .cache-15v7v24-CheckboxContainer-StyledCheckbox {
@@ -17307,11 +17311,11 @@ exports[`List should render correctly multiselect, table variant and with click 
     </div>
     <div
       aria-modal="true"
-      class="cache-nmxi06-StyledDiv e1qbxe4b0"
+      class="cache-1gb9fuz-StyledDiv e1qbxe4b0"
       role="dialog"
     >
       <div
-        class="cache-1i7e9sg-Stack e1sgck4o0"
+        class="cache-1qajn5t-Stack-StyledStack e1fla99k4"
       >
         <label
           aria-disabled="false"


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

ActionBar is having a padding of 16px inside of the component while the component shouldn't impose any padding it should be done in children. I removed it and added it into List, it should also fix the alignement issue present on every ActionBar.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="618" alt="Screenshot 2023-01-03 at 15 07 08" src="https://user-images.githubusercontent.com/15812968/210379053-85be64b0-d6fa-4c2a-b20a-7bccddb0679d.png"> | <img width="632" alt="Screenshot 2023-01-03 at 15 31 42" src="https://user-images.githubusercontent.com/15812968/210379085-2023f6eb-4c74-46e2-a09b-4aea92ca28f6.png"> |
