### PR TITLE
docs: add main README and updated documentation usages

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -27,6 +27,8 @@ const STORY_SORT = {
     ['Dark mode', 'Colors', 'Typography', 'Shadows', 'Spaces and Radii'],
     'Responsive',
     'Components',
+    'Form',
+    ['Introduction', 'Changelog', 'Components'],
   ],
 }
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,136 @@
+![](.storybook/assets/logo-dark.svg#gh-dark-mode-only)
+![](.storybook/assets/logo-light.svg#gh-light-mode-only)
+
+![Codecov](https://img.shields.io/codecov/c/github/scaleway/scaleway-ui)
+![GitHub last commit](https://img.shields.io/github/last-commit/scaleway/scaleway-ui)
+![GitHub closed issues](https://img.shields.io/github/issues-closed/scaleway/scaleway-ui)
+![GitHub contributors](https://img.shields.io/github/contributors/scaleway/scaleway-ui)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/scaleway/scaleway-ui)
+![GitHub](https://img.shields.io/github/license/scaleway/scaleway-ui)
+
+# Scaleway UI Core
+
+Scaleway UI Core contains the core features of the Scaleway UI library. 
+It is set of React library that can be used to build fast application.
+
+- [Scaleway UI](./packages/ui): The main library that includes a set of components and utilities to build fast application.
+- [Scaleway Form](./packages/form): A library to build forms with Scaleway UI components, it is using React Final Form under the hood.
+
+## Installation
+
+### Scaleway UI
+
+```sh
+$ pnpm add @scaleway/ui @emotion/react @emotion/styled
+```
+
+#### Usage
+
+See [Scaleway UI](./packages/ui) documentation.
+
+### Scaleway Form
+
+```sh
+$ pnpm add @scaleway/form @emotion/react @emotion/styled
+```
+
+#### Usage
+
+See [Scaleway Form](./packages/form) documentation.
+
+## Development
+
+Before any command, install dependencies running following command:
+
+```sh
+$ pnpm install
+```
+
+### Storybook
+
+You can easily start Storybook by running:
+
+```sh
+$ pnpm run start
+```
+
+Storybook documentation will then be available on [http://localhost:6006](http://localhost:6006)
+
+### Test
+
+#### Unit
+
+```sh
+$ pnpm run test:unit # Will run all tests
+$ pnpm run test:unit:update # Will update all snapshots
+$ pnpm run test:unit:watch # Will watch tests and only rerun the one who are modified
+$ pnpm run test:unit:coverage # Will generate a coverage report
+$ pnpm run testunit::coverage --coverageReporters lcov && open coverage/lcov-report/index.html # Will generate an open an html code coverage report
+```
+
+#### Accessibility
+
+```sh
+$ pnpm run test:a11y # Will run all accessibility tests
+$ pnpm run test:a11y src/components/Alert # Will run accessibility test of Alert component only
+```
+
+#### Lint
+
+```sh
+$ pnpm run lint
+$ pnpm run lint:fix
+```
+
+### Build
+
+```sh
+$ pnpm run build
+$ pnpm run build:profile # Will open a visual representation of the modules inside the compile package
+```
+
+### Use a locally built package
+
+You might want to test your local changes against a React application.
+
+> [`yalc`](https://github.com/whitecolor/yalc) is a tool aiming to simplify working with local npm packages by providing a different workflow than `npm/pnpm link`, hence avoiding most of their issues with module resolving.
+
+```bash
+$ pnpm install --global yalc # Make sure to have the yalc binary
+```
+
+Here is an example for using `@scaleway/ui` as a local package:
+
+```bash
+$ pnpm run build && cd packages/ui && yalc publish
+$ # Now it's ready to install in your project
+$ cd ../project-something
+$ yalc add @scaleway/ui
+$ cd ../scaleway-ui
+$ # If you do some changes into your package
+$ pnpm run build && yalc publish --push --sig # --push will automatically update the package on projects where it have been added, --sig updates the signature hash to trigger webpack update
+```
+
+You can redo the same with `@scaleway/form` if you want to test it.
+
+> :warning: since [1.0.0.pre.51 (2021-04-23)](https://github.com/wclr/yalc/blob/master/CHANGELOG.md#100pre51-2021-04-23), `yalc publish` needs the `--sig` option to trigger webpack module actual update.
+
+> :warning: `yalc` create a `yalc.lock` and updates the `package.json` in the target project. **Make sure to not commit these changes**
+
+---
+
+## Versioning
+
+We enforce the [conventionnal commits](https://www.conventionalcommits.org) convention in order to infer package bump versions and generate changelog.
+
+Only the `feat`, `fix` and `perf` types will generate a new package on the `main` branch
+
+## Documentation
+
+Checkout our [documentation website](https://storybook.ui.scaleway.com/).
+
+## Thanks
+
+<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
+
+Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,5 +1,36 @@
 # Scaleway Form
 
+[![npm version](https://badge.fury.io/js/%40scaleway%2Fform.svg)](https://badge.fury.io/js/%40scaleway%2Fform)
+
+Scaleway Form is an extension of Scaleway UI including everything to build forms using React.
+It is using [React Final Form](https://final-form.org/react) under the hood.
+
+## Installation
+
+```sh
+$ pnpm add @scaleway/form @emotion/react @emotion/styled
+```
+
+### Usage
+
+To use the library you need to put a `ThemeProvider` from `@emotion/react` with the theme that comes from `@scaleway/ui` then wrap all your fields inside a `Form`:
+
+```tsx
+import { ThemeProvider } from '@emotion/react'
+import { Form, TextBoxField } from '@scaleway/form'
+import { theme } from '@scaleway/ui'
+
+export default function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Form>
+        <TextBoxField name="example" />
+      </Form>
+    </ThemeProvider>
+  )
+}
+```
+
 ## Contribute
 
 ### Add a validator
@@ -9,3 +40,7 @@
 - Export it into `src/validators/index.ts`
 - Add the key into the `ValidatorProps` type in `src/types.ts`
 - Add tests into `src/validators/__tests__` folder
+
+## Documentation
+
+Checkout our [documentation website](https://storybook.ui.scaleway.com/).

--- a/packages/form/src/__stories__/Introduction.stories.mdx
+++ b/packages/form/src/__stories__/Introduction.stories.mdx
@@ -1,35 +1,6 @@
-import { Meta } from '@storybook/addon-docs'
+import { Meta, Description } from '@storybook/addon-docs'
+import Readme from '../../README.md'
 
 <Meta title="Form/Introduction" />
 
-# Welcome to Scaleway Form
-
-Scaleway Form is a set of React components you can use to build your application. It is used to build our [Scaleway Console](https://console.scaleway.com).
-
-## Getting started
-
-### Installation
-
-```bash
-pnpm add @scaleway/form
-```
-
-### Add a ThemeProvider
-
-To use the library you need to put a `ThemeProvider` from `@emotion/react` with the theme that comes from `@scaleway/ui` then wrap all your fields inside a `Form` :
-
-```jsx
-import { ThemeProvider } from '@emotion/react'
-import { Form, TextBoxField } from '@scaleway/form'
-import { theme } from '@scaleway/ui'
-
-export default function App() {
-  return (
-    <ThemeProvider theme={theme}>
-      <Form>
-        <TextBoxField name="example" />
-      </Form>
-    </ThemeProvider>
-  )
-}
-```
+<Description markdown={Readme} />

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,26 +1,22 @@
-![Codecov](https://img.shields.io/codecov/c/github/scaleway/scaleway-ui)
-![GitHub closed issues](https://img.shields.io/github/issues-closed/scaleway/scaleway-ui)
-![dependencies](https://david-dm.org/scaleway/scaleway-ui.svg)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/scaleway/scaleway-ui)
+# Scaleway UI
 
-![](.storybook/assets/logo-dark.svg#gh-dark-mode-only)
-![](.storybook/assets/logo-light.svg#gh-light-mode-only)
+[![npm version](https://badge.fury.io/js/%40scaleway%2Fui.svg)](https://badge.fury.io/js/%40scaleway%2Fui)
 
-# Scaleway UI library.
+Scaleway UI is a set of React components and utilities to build fast application.
 
----
+> :warning: This library is still WIP. We are actively working on it. Our goal is to have an easy to use UI system. This includes an exhaustive documentation, improved DX, confidence in testing and a lot of refactoring to have consistency across our components.
 
-⚠️ This library is still WIP. We are actively working on it. Our goal is to have an easy to use UI system. This includes an exhaustive documentation, improved DX, confidence in testing and a lot of refactoring to have consistency across our components.
-
-⚠️ We are going to break a lot of things towards V1. This library is not yet production ready.
+> :warning: We are going to break a lot of things towards V1. This library is not yet production ready.
 
 📝 You can still participate in its development and [start contributing](/CONTRIBUTING.md) to it.
 
-## Quick Start
+## Installation
 
 ```sh
 $ pnpm add @scaleway/ui @emotion/react @emotion/styled
 ```
+
+### Usage
 
 ```js
 import { theme, normalize, Button } from '@scaleway/ui'
@@ -64,104 +60,6 @@ declare module '@emotion/react' {
 }
 ```
 
-## Development
+## Documentation
 
-Before any command, install dependencies running following command:
-
-```sh
-$ pnpm install
-```
-
-### Storybook
-
-You can easily start Storybook by running:
-
-```sh
-$ pnpm run start
-```
-
-Storybook documentation will then be available on [http://localhost:6006](http://localhost:6006)
-
-### Test
-
-#### Unit
-
-```sh
-$ pnpm run test:unit # Will run all tests
-$ pnpm run test:unit:update # Will update all snapshots
-$ pnpm run test:unit:watch # Will watch tests and only rerun the one who are modified
-$ pnpm run test:unit:coverage # Will generate a coverage report
-$ pnpm run testunit::coverage --coverageReporters lcov && open coverage/lcov-report/index.html # Will generate an open an html code coverage report
-```
-
-#### Accessibility
-
-```sh
-$ pnpm run test:a11y # Will run all accessibility tests
-$ pnpm run test:a11y src/components/Alert # Will run accessibility test of Alert component only
-```
-
-#### Lint
-
-```sh
-$ pnpm run lint
-$ pnpm run lint:fix
-```
-
-#### Visual
-
-```sh
-$ pnpm run test:visual # Build the storybook and launch visual tests
-$ pnpm run test:visual:update # Build the storybook, launch visual tests and update screenshots
-$ pnpm run test:visual:nobuild # Launch visual tests without (re)building the storybook
-```
-
-### Build
-
-```sh
-$ pnpm run build
-$ pnpm run build:profile # Will open a visual representation of the modules inside the compile package
-```
-
-### Use a locally built package
-
-You might want to test your local changes against a React application.
-
-> [`yalc`](https://github.com/whitecolor/yalc) is a tool aiming to simplify working with local npm packages by providing a different workflow than `npm/pnpm link`, hence avoiding most of their issues with module resolving.
-
-```bash
-$ pnpm install --global yalc # Make sure to have the yalc binary
-```
-
-```bash
-$ cd scaleway-ui
-$ pnpm run build && yalc publish
-$ # Now it's ready to install in your project
-$ cd ../project-something
-$ yalc add @scaleway/ui
-$ cd ../scaleway-ui
-$ # If you do some changes into your package
-$ pnpm run build && yalc publish --push --sig # --push will automatically update the package on projects where it have been added, --sig updates the signature hash to trigger webpack update
-```
-
-> :warning: since [1.0.0.pre.51 (2021-04-23)](https://github.com/wclr/yalc/blob/master/CHANGELOG.md#100pre51-2021-04-23), `yalc publish` needs the `--sig` option to trigger webpack module actual update.
-
-> :warning: `yalc` create a `yalc.lock` and updates the `package.json` in the target project. **Make sure to not commit these changes**
-
----
-
-### Versioning
-
-We enforce the [conventionnal commits](https://www.conventionalcommits.org) convention in order to infer package bump versions and generate changelog.
-
-Only the `feat`, `fix` and `perf` types will generate a new package on the `main` branch
-
-### Documentation
-
-Checkout our [documentation website](https://main.ui.scaleway.com/).
-
-### Thanks
-
-<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
-
-Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.
+Checkout our [documentation website](https://storybook.ui.scaleway.com/).

--- a/packages/ui/src/__stories__/GetStarted.stories.mdx
+++ b/packages/ui/src/__stories__/GetStarted.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Description } from '@storybook/addon-docs'
-import Readme from '../../README.md'
+import Readme from '../../../../README.md'
 
 <Meta title="Get started" />
 


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

I added a main README for Scaleway UI Core (all the packages in this monorepo) explaining how to install / test / build / etc. For usages it will redirect to README of each individual packages.