### PR TITLE
fix(form): don't check regex on empty value

### DIFF
--- a/packages/form/src/validators/regex.ts
+++ b/packages/form/src/validators/regex.ts
@@ -6,6 +6,7 @@ const validator: ValidatorFn<string, (RegExp | RegExp[])[]> = regexes => ({
     regexes.every(
       regex =>
         value === undefined ||
+        value === '' ||
         (Array.isArray(regex)
           ? regex.some(regexOr => regexOr.test(value))
           : regex.test(value)),


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### Problem

if a initialValue was set to an empty string,  the regex was considering field as invalid, preventing from submit field even if this field isn't required
```
 <Form<{ email: string }>
      errors={errrors}
      initialValues={{ email: '' }} // email is not undefined but set with an empty string
      onRawSubmit={() => {}}
    >
      <TextBoxField
        name="email"
        label="Email"
        placeholder="test@test.fr"
        regex={[emailRegex]}
      />
      <SubmitErrorAlert />
      <Submit>Submit</Submit>
    </Form>
```

#### The following changes where made:

Instead of checking regex if value is not undefined, check regex only is value isn't undefined/emptyString/false