### PR TITLE
fix(Button): wrong overflow on extend

### DIFF
--- a/packages/ui/src/components/Button/__stories__/Extend.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/Extend.stories.tsx
@@ -5,6 +5,7 @@ export const Extend = Template.bind({})
 Extend.args = {
   icon: 'plus',
   extend: true,
+  children: 'Extend button !',
 }
 
 Extend.parameters = {

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -1058,7 +1058,7 @@ exports[`Button should render correctly when disabled 1`] = `
 
 exports[`Button should render correctly when extendable 1`] = `
 <DocumentFragment>
-  .cache-1sr0ppc-StyledButton-StyledButton {
+  .cache-njmq3k-StyledButton-StyledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1099,33 +1099,33 @@ exports[`Button should render correctly when extendable 1`] = `
   display: inline-flex;
 }
 
-.cache-1sr0ppc-StyledButton-StyledButton:hover,
-.cache-1sr0ppc-StyledButton-StyledButton:focus {
+.cache-njmq3k-StyledButton-StyledButton:hover,
+.cache-njmq3k-StyledButton-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.cache-1sr0ppc-StyledButton-StyledButton:hover,
-.cache-1sr0ppc-StyledButton-StyledButton:focus {
+.cache-njmq3k-StyledButton-StyledButton:hover,
+.cache-njmq3k-StyledButton-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-1sr0ppc-StyledButton-StyledButton:focus {
+.cache-njmq3k-StyledButton-StyledButton:focus {
   box-shadow: 0 0 0 2px #39017140;
 }
 
-.cache-1sr0ppc-StyledButton-StyledButton .em6gco83 {
+.cache-njmq3k-StyledButton-StyledButton .em6gco83 {
   -webkit-transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   max-width: 0;
   margin-right: 0;
   padding-left: 0;
-  overflow: hidden;
+  overflow-x: clip;
 }
 
-.cache-1sr0ppc-StyledButton-StyledButton:focus .em6gco83,
-.cache-1sr0ppc-StyledButton-StyledButton:hover .em6gco83 {
+.cache-njmq3k-StyledButton-StyledButton:focus .em6gco83,
+.cache-njmq3k-StyledButton-StyledButton:hover .em6gco83 {
   max-width: 275px;
   margin-right: 8px;
   padding-left: 8px;
@@ -1149,7 +1149,7 @@ exports[`Button should render correctly when extendable 1`] = `
 
 <button
     aria-disabled="false"
-    class="cache-1sr0ppc-StyledButton-StyledButton em6gco80"
+    class="cache-njmq3k-StyledButton-StyledButton em6gco80"
     type="button"
   >
     <div
@@ -1163,7 +1163,7 @@ exports[`Button should render correctly when extendable 1`] = `
 
 exports[`Button should render correctly when extendable with an icon 1`] = `
 <DocumentFragment>
-  .cache-g3z5ll-StyledButton-StyledButton {
+  .cache-a98791-StyledButton-StyledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1204,33 +1204,33 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
   display: inline-flex;
 }
 
-.cache-g3z5ll-StyledButton-StyledButton:hover,
-.cache-g3z5ll-StyledButton-StyledButton:focus {
+.cache-a98791-StyledButton-StyledButton:hover,
+.cache-a98791-StyledButton-StyledButton:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.cache-g3z5ll-StyledButton-StyledButton:hover,
-.cache-g3z5ll-StyledButton-StyledButton:focus {
+.cache-a98791-StyledButton-StyledButton:hover,
+.cache-a98791-StyledButton-StyledButton:focus {
   color: #ffffff;
   background-color: #390171;
 }
 
-.cache-g3z5ll-StyledButton-StyledButton:focus {
+.cache-a98791-StyledButton-StyledButton:focus {
   box-shadow: 0 0 0 2px #39017140;
 }
 
-.cache-g3z5ll-StyledButton-StyledButton .em6gco83 {
+.cache-a98791-StyledButton-StyledButton .em6gco83 {
   -webkit-transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   transition: max-width 450ms ease,padding 150ms ease,margin 150ms ease;
   max-width: 0;
   margin-right: 0;
   padding-right: 0;
-  overflow: hidden;
+  overflow-x: clip;
 }
 
-.cache-g3z5ll-StyledButton-StyledButton:focus .em6gco83,
-.cache-g3z5ll-StyledButton-StyledButton:hover .em6gco83 {
+.cache-a98791-StyledButton-StyledButton:focus .em6gco83,
+.cache-a98791-StyledButton-StyledButton:hover .em6gco83 {
   max-width: 275px;
   margin-right: 8px;
   padding-right: 8x;
@@ -1272,7 +1272,7 @@ exports[`Button should render correctly when extendable with an icon 1`] = `
 
 <button
     aria-disabled="false"
-    class="cache-g3z5ll-StyledButton-StyledButton em6gco80"
+    class="cache-a98791-StyledButton-StyledButton em6gco80"
     type="button"
   >
     <div

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -350,7 +350,7 @@ const StyledButton = styled('button', {
         max-width: 0;
         margin-right: 0;
         ${icon ? 'padding-right: 0;' : 'padding-left: 0;'};
-        overflow: hidden;
+        overflow-x: clip; // hidden create a weird white square when size is small
       }
 
       &:focus ${StyledContent}, &:hover ${StyledContent} {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Button with the `extend` prop could have an overflow issue if the font size was too big.

## Relevant logs and/or screenshots

|   Before   |      After |
| :--------: | ---------: |
| ![Capture d’écran 2023-01-10 à 13 51 11](https://user-images.githubusercontent.com/1339931/211559604-5efdaf02-a105-47e1-baff-4473823d4272.png) | ![Capture d’écran 2023-01-10 à 13 51 37](https://user-images.githubusercontent.com/1339931/211559649-e8310bf0-0ce1-4680-8709-9db099af39c0.png) |

