### PR TITLE
fix(Text): show tooltip on ellipsis only when needed

### DIFF
--- a/packages/ui/src/components/Text/index.tsx
+++ b/packages/ui/src/components/Text/index.tsx
@@ -132,7 +132,7 @@ const Text = ({
   useEffect(() => {
     if (oneLine && elementRef && elementRef.current) {
       const { offsetWidth, scrollWidth } = elementRef.current
-      setIsTruncated(offsetWidth <= scrollWidth)
+      setIsTruncated(offsetWidth < scrollWidth)
     }
   }, [oneLine])
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

When using `oneLine` prop in Text it was using tooltip on hover even when not needed. I fixed it.

## Relevant logs and/or screenshots

Before:

https://user-images.githubusercontent.com/15812968/211562821-fc998b9d-85cf-4aad-b0e8-dd1b6edc04e5.mov


After:

https://user-images.githubusercontent.com/15812968/211562889-440eae96-a8ae-48d2-8ac7-999a365ed0be.mov

