### PR TITLE
fix(RichSelect): storybook play selector is wrong

### DIFF
--- a/packages/ui/src/components/RichSelect/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/RichSelect/__stories__/Playground.stories.tsx
@@ -15,7 +15,7 @@ Playground.args = {
 }
 
 Playground.play = () => {
-  fireEvent.click(screen.getByRole('button'))
+  fireEvent.click(screen.getByRole('combobox'))
 }
 
 Playground.decorators = [


### PR DESCRIPTION
## Summary

Closes #2195 

## Type

- Bug

### Summarise concisely:

#### What is expected?

The selector in play of RichSelect story is searching for the wrong selector `button` while it should be `combobox`. This was causing errors in chromatic visual testing (and any other tools that visual test storybook).

Thanks to @benjamin-carriou for finding this issue 🙏 
