### PR TITLE
fix(Button): remove gap when not extend

### DIFF
--- a/packages/ui/src/components/Button/__stories__/Extend.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/Extend.stories.tsx
@@ -1,12 +1,16 @@
-import { Template } from './Template.stories'
+import type { ComponentStory } from '@storybook/react'
+import Button from '..'
 
-export const Extend = Template.bind({})
-
-Extend.args = {
-  icon: 'plus',
-  extend: true,
-  children: 'Extend button !',
-}
+export const Extend: ComponentStory<typeof Button> = ({ ...props }) => (
+  <>
+    <Button icon="plus" extend {...props}>
+      Extend button !
+    </Button>
+    <Button icon="plus" href="https://scaleway.com" extend {...props}>
+      Extend button with Link !
+    </Button>
+  </>
+)
 
 Extend.parameters = {
   docs: {

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -310,7 +310,7 @@ const StyledButton = styled('button', {
   font-weight: 500;
 
   transition: color 150ms ease-in-out, background-color 150ms ease-in-out,
-    border-color 150ms ease-in-out;
+    border-color 150ms ease-in-out, gap 150ms ease;
 
   &:hover,
   &:focus {
@@ -341,10 +341,15 @@ const StyledButton = styled('button', {
     box-shadow: none;
     `}
 
-  ${({ extend, icon }) =>
+  ${({ extend, icon, theme }) =>
     extend &&
     css`
       display: inline-flex;
+      &:focus,
+      &:hover {
+        gap: ${theme.space['1']};
+      }
+      gap: 0;
       & ${StyledContent} {
         transition: max-width 450ms ease, padding 150ms ease, margin 150ms ease;
         max-width: 0;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

- Remove the gap when the button is a link and it's collapsed.
- Add a gap to the button when the `extend` prop is true.

## Relevant logs and/or screenshots

|   Before   |      After |
| :--------: | ---------: |
|  ![Capture d’écran 2023-01-13 à 16 41 08](https://user-images.githubusercontent.com/1339931/212372605-f4d46a15-8d43-48ab-bdc0-6417c737efb4.png) | ![Capture d’écran 2023-01-13 à 17 34 10](https://user-images.githubusercontent.com/1339931/212372659-fef941f1-08f9-45b5-bd35-cfc0107cdc8f.png) |

