### PR TITLE
ci: add lockfile and CHANGELOG to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,8 @@
 node_modules/
 storybook-static
 dist/
+pnpm-lock.yaml
 
 # Specific to prettier
 package.json
+CHANGELOG.md


### PR DESCRIPTION
Otherwise lerna runs on them when releasing, which results in conflict in further renovate/PR