### PR TITLE
fix(TextBoxField): forward `size` prop to TextBox

### DIFF
--- a/packages/form/src/components/TextInputField/index.tsx
+++ b/packages/form/src/components/TextInputField/index.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@scaleway/ui'
 import type { FieldState } from 'final-form'
-import type { ComponentProps, FocusEvent, Ref } from 'react'
+import type { ComponentProps, Ref } from 'react'
 import { forwardRef } from 'react'
 import { useFormField } from '../../hooks'
 import { useErrors } from '../../providers/ErrorContext'
@@ -173,7 +173,7 @@ export const TextInputField = forwardRef(
         multiline={multiline}
         name={input.name}
         notice={notice}
-        onBlur={(event: FocusEvent<HTMLInputElement>) => {
+        onBlur={event => {
           input.onBlur(event)
           onBlur?.(event)
         }}
@@ -181,7 +181,7 @@ export const TextInputField = forwardRef(
           input.onChange(event)
           onChange?.(event)
         }}
-        onFocus={(event: FocusEvent<HTMLInputElement>) => {
+        onFocus={event => {
           input.onFocus(event)
           onFocus?.(event)
         }}

--- a/packages/form/src/components/TextInputField/index.tsx
+++ b/packages/form/src/components/TextInputField/index.tsx
@@ -46,6 +46,7 @@ type TextInputFieldProps<T = TextInputValue, K = string> = BaseFieldProps<
       | 'noTopLabel'
       | 'unit'
       | 'valid'
+      | 'size'
     >
   > & {
     name: string
@@ -103,6 +104,7 @@ export const TextInputField = forwardRef(
       subscription,
       type,
       unit,
+      size,
       validate,
       validateFields,
       valid,
@@ -197,6 +199,7 @@ export const TextInputField = forwardRef(
         noTopLabel={noTopLabel}
         unit={unit}
         valid={valid}
+        size={size}
       />
     )
   },

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -346,6 +346,8 @@ type TextInputProps = {
   value?: string | number
   wrap?: string
   inputProps?: InputProps
+  max?: InputHTMLAttributes<HTMLInputElement>['max']
+  min?: InputHTMLAttributes<HTMLInputElement>['min']
 } & (
   | Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'>
   | Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'>


### PR DESCRIPTION
## Summary

## Type

- Bug
- 
### Summarise concisely:

#### What is expected?

Forward the `size` prop to `TextBox` inside `TextBoxField`