### PR TITLE
fix(Separator): background color in dark theme

### DIFF
--- a/packages/ui/src/components/Separator/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Separator/__tests__/__snapshots__/index.tsx.snap
@@ -93,14 +93,13 @@ exports[`Separator renders correctly with custom icon 1`] = `
   flex: 1;
 }
 
-.cache-8ema7z-StyledIcon-sizeStyles-StyledIcon {
+.cache-2qe93b-StyledIcon-sizeStyles-StyledIcon {
   vertical-align: middle;
   fill: #4a4f62;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  background-color: #ffffff;
   fill: #e6e9f0;
 }
 
@@ -113,7 +112,7 @@ exports[`Separator renders correctly with custom icon 1`] = `
       class="cache-1du1e5o-StyledHr eoti1h20"
     />
     <svg
-      class="eoti1h21 cache-8ema7z-StyledIcon-sizeStyles-StyledIcon etwatq50"
+      class="eoti1h21 cache-2qe93b-StyledIcon-sizeStyles-StyledIcon etwatq50"
       viewBox="0 0 24 24"
     >
       <path
@@ -158,14 +157,13 @@ exports[`Separator renders correctly with custom icon horizontally 1`] = `
   flex: 1;
 }
 
-.cache-8ema7z-StyledIcon-sizeStyles-StyledIcon {
+.cache-2qe93b-StyledIcon-sizeStyles-StyledIcon {
   vertical-align: middle;
   fill: #4a4f62;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  background-color: #ffffff;
   fill: #e6e9f0;
 }
 
@@ -178,7 +176,7 @@ exports[`Separator renders correctly with custom icon horizontally 1`] = `
       class="cache-1du1e5o-StyledHr eoti1h20"
     />
     <svg
-      class="eoti1h21 cache-8ema7z-StyledIcon-sizeStyles-StyledIcon etwatq50"
+      class="eoti1h21 cache-2qe93b-StyledIcon-sizeStyles-StyledIcon etwatq50"
       viewBox="0 0 24 24"
     >
       <path
@@ -223,14 +221,13 @@ exports[`Separator renders correctly with custom icon vertically 1`] = `
   flex: 1;
 }
 
-.cache-8ema7z-StyledIcon-sizeStyles-StyledIcon {
+.cache-2qe93b-StyledIcon-sizeStyles-StyledIcon {
   vertical-align: middle;
   fill: #4a4f62;
   height: 24px;
   width: 24px;
   min-width: 24px;
   min-height: 24px;
-  background-color: #ffffff;
   fill: #e6e9f0;
 }
 
@@ -243,7 +240,7 @@ exports[`Separator renders correctly with custom icon vertically 1`] = `
       class="cache-3xv3x8-StyledHr eoti1h20"
     />
     <svg
-      class="eoti1h21 cache-8ema7z-StyledIcon-sizeStyles-StyledIcon etwatq50"
+      class="eoti1h21 cache-2qe93b-StyledIcon-sizeStyles-StyledIcon etwatq50"
       viewBox="0 0 24 24"
     >
       <path

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -19,7 +19,6 @@ const StyledIconWrapper = styled('div', {
 `
 
 const StyledIcon = styled(Icon)`
-  background-color: ${({ theme }) => theme.colors.neutral.background};
   fill: ${({ theme }) => theme.colors.neutral.border};
 `
 


### PR DESCRIPTION
## Summary

## Type

- Bug
- 
### Summarise concisely:

#### What is expected?

Background of separator icon is wrong.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | ![Screenshot 2023-01-23 at 12 58 35](https://user-images.githubusercontent.com/15812968/214040510-59ce5aa6-c3d9-42fd-bcfa-4dd7166c13b3.png) | ![Screenshot 2023-01-23 at 12 58 39](https://user-images.githubusercontent.com/15812968/214040536-4827ee58-cf60-4b38-8d6f-1ff9ed488d4b.png) |
