### PR TITLE
docs(Markdown): fix deprecated parmeters in storybook

### DIFF
--- a/packages/ui/src/components/Markdown/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Markdown/__stories__/index.stories.tsx
@@ -9,9 +9,9 @@ export default {
         component:
           'A wrapper for [react-markdown](https://github.com/remarkjs/react-markdown)',
       },
-      deprecated: true,
-      deprecatedReason: 'This component is deprecated please use Text instead.',
     },
+    deprecated: true,
+    deprecatedReason: 'This component is deprecated please use Text instead.',
   },
   title: 'Components/Typography/Markdown',
 } as ComponentMeta<typeof Markdown>


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Parmeters of Markdown deprecated where wrong, fixed them.

#### The following changes where made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1068" alt="Screenshot 2023-01-26 at 17 55 45" src="https://user-images.githubusercontent.com/15812968/214899324-bd2ba76f-6199-45b0-a8c5-0a16e394c6e4.png"> | <img width="1049" alt="Screenshot 2023-01-26 at 17 55 50" src="https://user-images.githubusercontent.com/15812968/214899348-a413f6f1-13e4-4999-b881-79c05bc8400b.png"> |
