### PR TITLE
docs(ComponentState): add link to each component main story

### DIFF
--- a/packages/ui/src/__stories__/ComponentState/ComponentState.tsx
+++ b/packages/ui/src/__stories__/ComponentState/ComponentState.tsx
@@ -1,4 +1,6 @@
+import { linkTo } from '@storybook/addon-links'
 import * as components from '../../components'
+import { Button } from '../../components/Button'
 import { Stack } from '../../components/Stack'
 import { Table } from '../../components/Table'
 import { Text } from '../../components/Text'
@@ -64,7 +66,12 @@ const ComponentState = () => (
               <Table.Row>
                 <Table.BodyCell>
                   <Text as="span" variant="bodyStrong">
-                    {componentName}
+                    <Button
+                      onClick={linkTo(module?.value?.default?.title)}
+                      variant="link"
+                    >
+                      {componentName}
+                    </Button>
                   </Text>
                 </Table.BodyCell>
                 <Table.BodyCell>


### PR DESCRIPTION
## Summary

Add link to each component main story in component state doc page.

## Type

- Documentation

(Describe what you did)

1. Add Link component on component name that refers to component story title

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1021" alt="Screenshot 2023-02-14 at 15 21 25" src="https://user-images.githubusercontent.com/2362139/218765345-6d4f4987-ec72-4b92-9f30-b8bce02d99e5.png">  | <img width="1031" alt="Screenshot 2023-02-14 at 15 21 03" src="https://user-images.githubusercontent.com/2362139/218765434-cc7a3047-3323-47ec-8a42-a4201bb6c4ad.png"> |
