### PR TITLE
docs: new experimentals components in storybook

### DIFF
--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -50,10 +50,26 @@ export const fonts = css`
 `
 
 type ExtraProps = {
+  /**
+   * When a component is deprecated we can set this property to true
+   */
   deprecated: boolean
+  /**
+   * When a component is deprecated we can why and by what to replace it
+   */
   deprecatedReason: string
+  /**
+   * When a component is deprecated we can add a link to the migration guide
+   */
   migrationLink: string
+  /**
+   * This prop, if set to true, will hide the args table where you have the props definition and controls
+   */
   hideArgsTable?: boolean
+  /**
+   * This prop can be used to define if a component is being tested and not prod ready
+   */
+  experimental?: boolean
 }
 
 const CustomBaseContainer = BaseContainer as unknown as FunctionComponent<
@@ -95,6 +111,7 @@ const DocsContainer: typeof CustomBaseContainer = ({ context, children }) => {
               deprecatedReason: context.parameters?.deprecatedReason,
               migrationLink: context.parameters?.migrationLink,
               hideArgsTable: context.parameters?.hideArgsTable,
+              experimental: context.parameters?.experimental,
             })
           : children}
       </CustomBaseContainer>

--- a/.storybook/components/Page.tsx
+++ b/.storybook/components/Page.tsx
@@ -7,13 +7,10 @@ import {
   Stories,
   PRIMARY_STORY,
 } from '@storybook/addon-docs'
-import { Badge, Button } from '../../packages/ui/src'
+import { Badge, Button, Text, Stack, Link } from '../../packages/ui/src'
 import styled from '@emotion/styled'
 import { linkTo } from '@storybook/addon-links'
-
-const StyledText = styled.p`
-  color: ${({ theme }) => theme.colors.warning.text};
-`
+import { useMemo } from 'react'
 
 const StyledHeaderContainer = styled.div`
   display: flex;
@@ -22,9 +19,9 @@ const StyledHeaderContainer = styled.div`
 `
 
 const StyledTitle = styled.div`
-  &[data-deprecated='true'] h1 {
+  &[data-state='deprecated'] h1 {
     text-decoration: line-through;
-    text-decoration-color: ${({ theme }) => theme.colors.warning.text};
+    text-decoration-color: ${({ theme }) => theme.colors.danger.text};
   }
 `
 
@@ -38,6 +35,7 @@ type PageProps = {
   deprecatedReason?: string
   migrationLink?: string
   hideArgsTable?: boolean
+  experimental?: boolean
 }
 
 const Page = ({
@@ -45,43 +43,79 @@ const Page = ({
   deprecatedReason,
   migrationLink,
   hideArgsTable,
-}: PageProps) => (
-  <>
-    <StyledHeaderContainer>
-      <StyledTitle data-deprecated={deprecated}>
-        <Title />
-      </StyledTitle>
+  experimental,
+}: PageProps) => {
+  const state = useMemo(() => {
+    if (deprecated) {
+      return 'deprecated'
+    }
+    if (experimental) {
+      return 'experimental'
+    }
+    return 'stable'
+  }, [])
+
+  return (
+    <>
+      <StyledHeaderContainer>
+        <StyledTitle data-state={state}>
+          <Title />
+        </StyledTitle>
+        {deprecated ? (
+          <Badge variant="danger" size="large" icon="alert">
+            Deprecated
+          </Badge>
+        ) : null}
+        {experimental ? (
+          <Badge variant="warning" size="large">
+            <Stack direction="row" alignItems="center" gap={1}>
+              <svg viewBox="0 0 100 100" role="img" width="18px">
+                <path
+                  d="M90.72 82.34c4.4 7 1.29 12.66-7 12.66H16.25C8 95 4.88 89.31 9.28 82.34l29.47-46.46V12.5H35A3.75 3.75 0 0135 5h30a3.75 3.75 0 010 7.5h-3.75v23.38zM45.08 39.86L29.14 65h41.72L54.92 39.86l-1.17-1.81V12.5h-7.5v25.55z"
+                  fill="currentColor"
+                />
+              </svg>{' '}
+              Experimental
+            </Stack>
+          </Badge>
+        ) : null}
+      </StyledHeaderContainer>
       {deprecated ? (
-        <Badge variant="warning" size="large">
-          <b>Deprecated</b>
-        </Badge>
-      ) : null}
-    </StyledHeaderContainer>
-    {deprecated ? (
-      <FlexDiv>
-        <StyledText>
-          <b>
+        <FlexDiv>
+          <Text as="h2" variant="bodyStronger" color="danger">
             {deprecatedReason
               ? deprecatedReason
               : 'This component is deprecated please do not use it any more.'}
-          </b>
-        </StyledText>
-        {migrationLink ? (
-          <p>
-            <Button onClick={linkTo(migrationLink)} variant="link">
-              How to migrate?
-            </Button>
-          </p>
-        ) : null}
-      </FlexDiv>
-    ) : (
-      <Subtitle />
-    )}
-    <Description />
-    <Primary />
-    {!hideArgsTable ? <ArgsTable story={PRIMARY_STORY} /> : null}
-    <Stories />
-  </>
-)
+          </Text>
+          {migrationLink ? (
+            <p>
+              <Button onClick={linkTo(migrationLink)} variant="link">
+                How to migrate?
+              </Button>
+            </p>
+          ) : null}
+        </FlexDiv>
+      ) : (
+        <Subtitle />
+      )}
+      {experimental ? (
+        <Text as="h2" variant="bodyStronger" color="warning">
+          This component is at an unstable stage and is subject to change in
+          future releases.{' '}
+          <Link
+            href="/?path=/docs/state-components-state--page"
+            iconPosition="right"
+          >
+            Learn more about component states
+          </Link>
+        </Text>
+      ) : null}
+      <Description />
+      <Primary />
+      {!hideArgsTable ? <ArgsTable story={PRIMARY_STORY} /> : null}
+      <Stories />
+    </>
+  )
+}
 
 export default Page

--- a/packages/ui/src/__stories__/ComponentState/ComponentState.tsx
+++ b/packages/ui/src/__stories__/ComponentState/ComponentState.tsx
@@ -5,6 +5,21 @@ import { Stack } from '../../components/Stack'
 import { Table } from '../../components/Table'
 import { Text } from '../../components/Text'
 
+const findComponentState = (parameters: {
+  deprecated?: boolean
+  experimental?: boolean
+}) => {
+  if (parameters?.deprecated) {
+    return '⚠️ Deprecated'
+  }
+
+  if (parameters?.experimental) {
+    return '🧪 Experimental'
+  }
+
+  return '✅ Stable'
+}
+
 const componentsNames = Object.keys(components)
 let modules: PromiseSettledResult<{
   default: {
@@ -26,74 +41,131 @@ Promise.allSettled(
   .catch(() => {})
 
 const ComponentState = () => (
-  <Stack gap={3}>
-    <Stack gap={1}>
-      <Text as="p" variant="body">
-        Here you will find all our components and their states. They are updated
-        automatically based on configuration of the component story.
+  <Stack gap={4}>
+    <Text as="p" variant="body">
+      Here you will find all our components and their states. They are updated
+      automatically based on configuration of the component story.
+    </Text>
+
+    <Stack gap={3}>
+      <Text as="h2" variant="heading">
+        Definition of states
       </Text>
-      <Text as="p" variant="body">
-        <Text as="span" variant="bodyStronger">
-          Number of components
+      <Stack gap={1}>
+        <Text as="h3" variant="headingSmall">
+          ✅ Stable
         </Text>
-        : {componentsNames.length}
-      </Text>
+        <Text as="p" variant="body">
+          Stable state means the component is ready for production. If a
+          breaking change occurs it will generate a major version.
+        </Text>
+      </Stack>
+
+      <Stack gap={1}>
+        <Text as="h3" variant="headingSmall">
+          🧪 Experimental
+        </Text>
+        <Text as="p" variant="body">
+          Experimental state means the component is being tested and props might
+          change in the future. The component itself might even disappear if we
+          don&apos;t find a real purpose for it. This state is also used for new
+          version of a component (ex: Button v2) that we want to test before
+          replacing the old one. In any case{' '}
+          <Text as="span" variant="bodyStronger">
+            this state means the component is not ready for production
+          </Text>
+          .
+        </Text>
+        <Text variant="body" as="p">
+          An experimental component won&apos;t generate major version when
+          having a breaking change.
+        </Text>
+      </Stack>
+
+      <Stack gap={1}>
+        <Text as="h3" variant="headingSmall">
+          ⚠️ Deprecated
+        </Text>
+        <Text as="p" variant="body">
+          Deprecated state means the component is not recommended for use and
+          will be removed in the future. When seeing a component you use being
+          deprecated you should start migrating to another component as soon as
+          possible. To know what to use instead you can check the story of the
+          deprecated component.
+        </Text>
+      </Stack>
     </Stack>
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.HeadCell>Name</Table.HeadCell>
-          <Table.HeadCell>Category</Table.HeadCell>
-          <Table.HeadCell>State</Table.HeadCell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body striped>
-        {modules.map(module => {
-          if (module.status === 'fulfilled') {
-            const desctructuredName: string[] =
-              module?.value?.default?.title
-                ?.replace('Components/', '')
-                .split('/') ?? []
+    <Stack gap={3}>
+      <Text as="h2" variant="heading">
+        Components list
+      </Text>
 
-            const componentCategory = desctructuredName[1]
-              ? desctructuredName[0]
-              : 'Others'
-            const componentName = desctructuredName[1]
-              ? desctructuredName[1]
-              : desctructuredName[0]
+      <Stack gap={1}>
+        <Text as="p" variant="body">
+          <Text as="span" variant="bodyStronger">
+            Number of components
+          </Text>
+          : {componentsNames.length}
+        </Text>
+        <Table>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeadCell>Name</Table.HeadCell>
+              <Table.HeadCell>Category</Table.HeadCell>
+              <Table.HeadCell>State</Table.HeadCell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body striped>
+            {modules.map(module => {
+              if (module.status === 'fulfilled') {
+                const desctructuredName: string[] =
+                  module?.value?.default?.title
+                    ?.replace('Components/', '')
+                    .split('/') ?? []
 
-            return (
-              <Table.Row>
-                <Table.BodyCell>
-                  <Text as="span" variant="bodyStrong">
-                    <Button
-                      onClick={linkTo(module?.value?.default?.title)}
-                      variant="link"
-                    >
-                      {componentName}
-                    </Button>
-                  </Text>
-                </Table.BodyCell>
-                <Table.BodyCell>
-                  <Text as="span" variant="body">
-                    {componentCategory}
-                  </Text>
-                </Table.BodyCell>
-                <Table.BodyCell>
-                  <Text as="span" variant="body">
-                    {module?.value?.default?.parameters?.deprecated
-                      ? 'Deprecated ❌'
-                      : 'Healthy ✅'}
-                  </Text>
-                </Table.BodyCell>
-              </Table.Row>
-            )
-          }
+                const componentCategory = desctructuredName[1]
+                  ? desctructuredName[0]
+                  : 'Others'
+                const componentName = desctructuredName[1]
+                  ? desctructuredName[1]
+                  : desctructuredName[0]
 
-          return null
-        })}
-      </Table.Body>
-    </Table>
+                const componentState = findComponentState(
+                  module?.value?.default?.parameters,
+                )
+
+                return (
+                  <Table.Row>
+                    <Table.BodyCell>
+                      <Text as="span" variant="bodyStrong">
+                        <Button
+                          onClick={linkTo(module?.value?.default?.title)}
+                          variant="link"
+                        >
+                          {componentName}
+                        </Button>
+                      </Text>
+                    </Table.BodyCell>
+                    <Table.BodyCell>
+                      <Text as="span" variant="body">
+                        {componentCategory}
+                      </Text>
+                    </Table.BodyCell>
+                    <Table.BodyCell>
+                      <Text as="span" variant="body">
+                        {componentState}
+                      </Text>
+                    </Table.BodyCell>
+                  </Table.Row>
+                )
+              }
+
+              return null
+            })}
+          </Table.Body>
+        </Table>
+      </Stack>
+    </Stack>
   </Stack>
 )
 

--- a/packages/ui/src/components/BarChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/index.stories.tsx
@@ -4,6 +4,7 @@ import { BarChart } from '..'
 export default {
   component: BarChart,
   parameters: {
+    experimental: true,
     docs: {
       description: {
         component: 'BarChart is a chart component that renders bars.',

--- a/packages/ui/src/components/BarChart/index.tsx
+++ b/packages/ui/src/components/BarChart/index.tsx
@@ -29,6 +29,9 @@ type BarChartProps = {
   chartProps?: Partial<BarSvgProps<BarDatum>>
 }
 
+/**
+ * @experimental This component is experimental and may be subject to breaking changes in the future.
+ */
 export const BarChart = ({
   height = '537px', // to maintain aspect ratio based on our standard 1074px width,
   margin = { bottom: 50, left: 60, right: 25, top: 50 },

--- a/packages/ui/src/components/LineChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/LineChart/__stories__/index.stories.tsx
@@ -4,6 +4,9 @@ import { LineChart } from '..'
 export default {
   component: LineChart,
   title: 'Components/Data Display/Chart/LineChart',
+  parameters: {
+    experimental: true,
+  },
 } as Meta
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/LineChart/index.tsx
+++ b/packages/ui/src/components/LineChart/index.tsx
@@ -30,6 +30,9 @@ type LineChartProps = {
   chartProps?: Partial<LineSvgProps>
 }
 
+/**
+ * @experimental This component is experimental and may be subject to breaking changes in the future.
+ */
 export const LineChart = ({
   height = '537px', // to maintain aspect ratio based on our standard 1074px width
   margin = { bottom: 50, left: 60, right: 25, top: 50 },

--- a/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
@@ -5,6 +5,9 @@ export default {
   component: PieChart,
   decorators: [StoryComponent => <StoryComponent />],
   title: 'Components/Data Display/Chart/PieChart',
+  parameters: {
+    experimental: true,
+  },
 } as ComponentMeta<typeof PieChart>
 
 export { Playground } from './Playground.stories'

--- a/packages/ui/src/components/PieChart/index.tsx
+++ b/packages/ui/src/components/PieChart/index.tsx
@@ -48,6 +48,9 @@ type PieChartProps = {
   margin?: Box
 }
 
+/**
+ * @experimental This component is experimental and may be subject to breaking changes in the future.
+ */
 export const PieChart = ({
   height = 206,
   width = 206,

--- a/packages/ui/src/components/StepList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/StepList/__stories__/index.stories.tsx
@@ -13,6 +13,7 @@ export default {
         component: 'Make a list with sub components in it.',
       },
     },
+    experimental: true,
   },
   title: 'Components/Data Display/StepList',
 } as Meta

--- a/packages/ui/src/components/StepList/index.tsx
+++ b/packages/ui/src/components/StepList/index.tsx
@@ -81,6 +81,9 @@ type StepListProps = {
   className?: string
 }
 
+/**
+ * @experimental This component is experimental and may be subject to breaking changes in the future.
+ */
 export const StepList = ({ children, className }: StepListProps) => (
   <Steps className={className}>{children}</Steps>
 )

--- a/packages/ui/src/components/TagInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TagInput/__stories__/index.stories.tsx
@@ -9,6 +9,7 @@ export default {
         component: 'Text input with multiple tag component in a row.',
       },
     },
+    experimental: true,
   },
   title: 'Components/Data Entry/TagInput',
 } as Meta

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -107,6 +107,9 @@ type TagInputProps = {
   className?: string
 }
 
+/**
+ * @experimental This component is experimental and may be subject to breaking changes in the future.
+ */
 export const TagInput = ({
   disabled = false,
   id,

--- a/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
@@ -9,6 +9,7 @@ export default {
         component: 'A simple input to choose a time in a list.',
       },
     },
+    experimental: true,
   },
   title: 'Components/Data Entry/TimeInput',
   decorators: [

--- a/packages/ui/src/components/TimeInput/index.tsx
+++ b/packages/ui/src/components/TimeInput/index.tsx
@@ -205,6 +205,9 @@ type TimeInputType = ((props: TimeInputProps) => JSX.Element) & {
   options: typeof options
 }
 
+/**
+ * @experimental This component is experimental and may be subject to breaking changes in the future.
+ */
 export const TimeInput: TimeInputType = ({
   value = defaultValue,
   schedule = 'hours',


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

Introducing new state for components: **Experimental**

This state defines components who are unstable and not prod ready, they also means no major when breaking change. This state exists to give us more flexibility and testing period for newly created component while adding a little warning on them for external users. There is also a `@experimental` that has been added in comment for each concerned component.

I also updated components states in storybook to have a clear definition of those states.

## Relevant logs and/or screenshots

![Screenshot 2023-03-01 at 14 00 41](https://user-images.githubusercontent.com/15812968/222205777-db0f26c9-2d4b-4c50-91fc-d049c6f74446.png)
![Screenshot 2023-03-01 at 17 52 15](https://user-images.githubusercontent.com/15812968/222207631-ed03a1e0-6e33-45eb-8fa3-43962f45efc8.png)
![Screenshot 2023-03-01 at 17 48 12](https://user-images.githubusercontent.com/15812968/222206596-3d126e51-9cdc-4172-a14d-5c39b5375d02.png)

