### PR TITLE
fix: text to accept hmtlFor

### DIFF
--- a/packages/ui/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
@@ -30,6 +30,33 @@ exports[`Text renders correctly with dir 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Text renders correctly with htmlFor 1`] = `
+<DocumentFragment>
+  .cache-rr62n5-StyledText {
+  color: #4a4f62;
+  font-size: 16px;
+  font-family: Asap;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 24px;
+  text-transform: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<div
+    style="margin-bottom: 16px; margin-top: 8px; width: 500px;"
+  >
+    <div
+      class="cache-rr62n5-StyledText e1tg3t120"
+      for="test"
+    >
+      This text is quite long. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Text renders correctly with tooltip 1`] = `
 <DocumentFragment>
   .cache-gbpmfn-StyledText {

--- a/packages/ui/src/components/Text/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Text/__tests__/index.test.tsx
@@ -32,6 +32,17 @@ describe('Text', () => {
       </div>,
     ))
 
+  test(`renders correctly with htmlFor`, () =>
+    shouldMatchEmotionSnapshot(
+      <div style={{ marginBottom: 16, marginTop: 8, width: 500 }}>
+        <Text as="div" variant="body" htmlFor="test">
+          This text is quite long. Lorem ipsum dolor sit amet, consectetur
+          adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </Text>
+      </div>,
+    ))
+
   test(`with multiple nested chidldren renders correctly`, () =>
     shouldMatchEmotionSnapshot(
       <Text as="div" variant="body">

--- a/packages/ui/src/components/Text/index.tsx
+++ b/packages/ui/src/components/Text/index.tsx
@@ -88,6 +88,7 @@ type TextProps = {
   underline?: boolean
   id?: string
   dir?: 'ltr' | 'rtl' | 'auto'
+  htmlFor?: string
 }
 
 const StyledText = styled('div', {
@@ -110,6 +111,7 @@ const StyledText = styled('div', {
   disabled: boolean
   italic: boolean
   underline: boolean
+  htmlFor?: string
 }>(generateStyles)
 
 export const Text = ({
@@ -125,6 +127,7 @@ export const Text = ({
   underline = false,
   id,
   dir,
+  htmlFor,
 }: TextProps) => {
   const [isTruncated, setIsTruncated] = useState(false)
   const elementRef = useRef(null)
@@ -153,6 +156,7 @@ export const Text = ({
         underline={underline}
         id={id}
         dir={dir}
+        htmlFor={htmlFor}
       >
         {children}
       </StyledText>


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Added htmlFor property on Text as we are going to remove Label component to use Text instead.

```tsx
// Old usage
<Label htmlFor="myinputid">My Label</Label>

// New usage
<Text as="label" variant="bodyStrong" htmlFor="myinputid">My Label</Text>
```
