### PR TITLE
fix: update snapshots with last node version

### DIFF
--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -4572,7 +4572,7 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
                   <p
                     class="e17s8tvr0 cache-1re7cvs-StyledText-StyledText e1tg3t120"
                   >
-                    январь 2021 г.
+                    январь 2021 г.
                   </p>
                 </div>
                 <span


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

CI is using last version of Node (18.15.0) while we usually use earlier version which leads to error on CI. I updated unit tests with last version of node.
