### PR TITLE
fix(verification_code): set the right color

### DIFF
--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -4572,7 +4572,7 @@ exports[`DateInput renders correctly with date-fns locale ru 1`] = `
                   <p
                     class="e17s8tvr0 cache-1re7cvs-StyledText-StyledText e1tg3t120"
                   >
-                    январь 2021 г.
+                    январь 2021 г.
                   </p>
                 </div>
                 <span

--- a/packages/ui/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`VerificationCode renders correctly with default values 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -12,32 +12,44 @@ exports[`VerificationCode renders correctly with default values 1`] = `
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -47,7 +59,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -57,7 +69,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -67,7 +79,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -81,7 +93,7 @@ exports[`VerificationCode renders correctly with default values 1`] = `
 
 exports[`VerificationCode renders correctly with initial value and placeholder and 6 fields 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -91,32 +103,44 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -126,7 +150,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -136,7 +160,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -146,7 +170,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -156,7 +180,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="4"
       id="verification-code-4"
       pattern="[0-9]*"
@@ -166,7 +190,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="5"
       id="verification-code-5"
       pattern="[0-9]*"
@@ -180,7 +204,7 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
 
 exports[`VerificationCode should handle and replace non number with "" when type is number 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -190,32 +214,44 @@ exports[`VerificationCode should handle and replace non number with "" when type
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -225,7 +261,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -235,7 +271,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -245,7 +281,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -259,7 +295,7 @@ exports[`VerificationCode should handle and replace non number with "" when type
 
 exports[`VerificationCode should handle error 1`] = `
 <DocumentFragment>
-  .cache-wnn471-StyledInput-VerificationCode {
+  .cache-vbeqix-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #dd3252;
   font-size: 24px;
@@ -269,32 +305,44 @@ exports[`VerificationCode should handle error 1`] = `
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-wnn471-StyledInput-VerificationCode:last-child {
+.cache-vbeqix-StyledInput-VerificationCode:hover,
+.cache-vbeqix-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-vbeqix-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-vbeqix-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-wnn471-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-vbeqix-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-wnn471-StyledInput-VerificationCode::-moz-placeholder {
+.cache-vbeqix-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-wnn471-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-vbeqix-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-wnn471-StyledInput-VerificationCode::placeholder {
+.cache-vbeqix-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="true"
-      class="cache-wnn471-StyledInput-VerificationCode e1odpyad0"
+      class="cache-vbeqix-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -304,7 +352,7 @@ exports[`VerificationCode should handle error 1`] = `
     />
     <input
       aria-invalid="true"
-      class="cache-wnn471-StyledInput-VerificationCode e1odpyad0"
+      class="cache-vbeqix-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -314,7 +362,7 @@ exports[`VerificationCode should handle error 1`] = `
     />
     <input
       aria-invalid="true"
-      class="cache-wnn471-StyledInput-VerificationCode e1odpyad0"
+      class="cache-vbeqix-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -324,7 +372,7 @@ exports[`VerificationCode should handle error 1`] = `
     />
     <input
       aria-invalid="true"
-      class="cache-wnn471-StyledInput-VerificationCode e1odpyad0"
+      class="cache-vbeqix-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -338,7 +386,7 @@ exports[`VerificationCode should handle error 1`] = `
 
 exports[`VerificationCode should handle keyDown and special key cases and focus/change events 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -348,32 +396,44 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -383,7 +443,7 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -393,7 +453,7 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -403,7 +463,7 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -417,7 +477,7 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
 
 exports[`VerificationCode should handle paste when type is not number 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -427,32 +487,44 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       placeholder=""
@@ -461,7 +533,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       placeholder=""
@@ -470,7 +542,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       placeholder=""
@@ -479,7 +551,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       placeholder=""
@@ -488,7 +560,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="4"
       id="verification-code-4"
       placeholder=""
@@ -497,7 +569,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="5"
       id="verification-code-5"
       placeholder=""
@@ -510,7 +582,7 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
 
 exports[`VerificationCode should handle paste with no overflowing values 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -520,32 +592,44 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -555,7 +639,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -565,7 +649,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -575,7 +659,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -589,7 +673,7 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
 
 exports[`VerificationCode should handle paste with overflowing values 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -599,32 +683,44 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -634,7 +730,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -644,7 +740,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -654,7 +750,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -668,7 +764,7 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
 
 exports[`VerificationCode should handle paste with overflowing values at different index than 0 1`] = `
 <DocumentFragment>
-  .cache-1kx0bbi-StyledInput-VerificationCode {
+  .cache-uxqmnp-StyledInput-VerificationCode {
   background: #ffffff;
   border: solid 1px #d4dae7;
   font-size: 24px;
@@ -678,32 +774,44 @@ exports[`VerificationCode should handle paste with overflowing values at differe
   margin-right: 8px;
   width: 56px;
   height: 64px;
+  outline-style: none;
+  -webkit-transition: border-color 0.2s ease,box-shadow 0.2s ease;
+  transition: border-color 0.2s ease,box-shadow 0.2s ease;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:last-child {
+.cache-uxqmnp-StyledInput-VerificationCode:hover,
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  border-color: #4f0599;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:focus {
+  box-shadow: 0px 0px 0px 3px #4F059940;
+}
+
+.cache-uxqmnp-StyledInput-VerificationCode:last-child {
   margin-right: 0;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-webkit-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-webkit-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::-moz-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::-moz-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode:-ms-input-placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode:-ms-input-placeholder {
   color: #b2b6c3;
 }
 
-.cache-1kx0bbi-StyledInput-VerificationCode::placeholder {
+.cache-uxqmnp-StyledInput-VerificationCode::placeholder {
   color: #b2b6c3;
 }
 
 <div>
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -713,7 +821,7 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -723,7 +831,7 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -733,7 +841,7 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
-      class="cache-1kx0bbi-StyledInput-VerificationCode e1odpyad0"
+      class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-id="3"
       id="verification-code-3"
       pattern="[0-9]*"

--- a/packages/ui/src/components/VerificationCode/index.tsx
+++ b/packages/ui/src/components/VerificationCode/index.tsx
@@ -20,6 +20,17 @@ const StyledInput = styled.input`
   margin-right: ${({ theme }) => theme.space['1']};
   width: 56px;
   height: 64px;
+  outline-style: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.primary.borderWeakHover};
+  }
+
+  &:focus {
+    box-shadow: ${({ theme: { shadows } }) => shadows.focusPrimary};
+  }
 
   &:last-child {
     margin-right: 0;


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Set the right color while hovering and focusing VerificationCode component

## Relevant logs and/or screenshots

| Page |   Screenshot   |
| :--- | :--------: |
| VerificationCode  | ![Screenshot 2023-03-17 at 12 19 55](https://user-images.githubusercontent.com/12233044/225890905-e0462f59-08cc-4c4b-ac6a-233d73816521.png) | 
