### PR TITLE
fix: expose rowV2 component

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -63,6 +63,7 @@ export {
   Grid,
   Row,
   Col,
+  RowV2,
 } from './components'
 export { darkTheme, default as theme, extendTheme } from './theme'
 export type { SCWUITheme } from './theme'


### PR DESCRIPTION
## Summary

### Summarise concisely:

RowV2 is now exposed as library component (before that it was only available internally) 