### PR TITLE
fix(deps): downgrade final-form-arrays to 3.0.2

### DIFF
--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -51,7 +51,7 @@
     "@emotion/styled": "11.10.6",
     "@scaleway/ui": "workspace:*",
     "final-form": "4.20.9",
-    "final-form-arrays": "3.1.0",
+    "final-form-arrays": "3.0.2",
     "final-form-focus": "1.1.2",
     "react-final-form": "6.5.9",
     "react-final-form-arrays": "3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       final-form: 4.20.9
-      final-form-arrays: 3.1.0
+      final-form-arrays: 3.0.2
       final-form-focus: 1.1.2
       react: 18.2.0
       react-dom: 18.2.0
@@ -224,10 +224,10 @@ importers:
       '@emotion/styled': 11.10.6_oouaibmszuch5k64ms7uxp2aia
       '@scaleway/ui': link:../ui
       final-form: 4.20.9
-      final-form-arrays: 3.1.0_final-form@4.20.9
+      final-form-arrays: 3.0.2_final-form@4.20.9
       final-form-focus: 1.1.2_final-form@4.20.9
       react-final-form: 6.5.9_zunk57bvr2t5bgdbaxawch3xh4
-      react-final-form-arrays: 3.1.4_aow5e6qsraapsvmuz6go5r432e
+      react-final-form-arrays: 3.1.4_q2za4bw4cstnp42a2pterukblu
       react-select: 5.7.1_zula6vjvt3wdocc4mwcxqa6nzi
     devDependencies:
       '@babel/core': 7.21.3
@@ -11303,10 +11303,10 @@ packages:
       to-regex-range: 5.0.1
     dev: true
 
-  /final-form-arrays/3.1.0_final-form@4.20.9:
-    resolution: {integrity: sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==}
+  /final-form-arrays/3.0.2_final-form@4.20.9:
+    resolution: {integrity: sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==}
     peerDependencies:
-      final-form: ^4.20.8
+      final-form: ^4.18.2
     dependencies:
       final-form: 4.20.9
     dev: false
@@ -17578,7 +17578,7 @@ packages:
   /react-fast-compare/3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
 
-  /react-final-form-arrays/3.1.4_aow5e6qsraapsvmuz6go5r432e:
+  /react-final-form-arrays/3.1.4_q2za4bw4cstnp42a2pterukblu:
     resolution: {integrity: sha512-siVFAolUAe29rMR6u8VwepoysUcUdh6MLV2OWnCtKpsPRUdT9VUgECjAPaVMAH2GROZNiVB9On1H9MMrm9gdpg==}
     peerDependencies:
       final-form: ^4.15.0
@@ -17588,7 +17588,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       final-form: 4.20.9
-      final-form-arrays: 3.1.0_final-form@4.20.9
+      final-form-arrays: 3.0.2_final-form@4.20.9
       react: 18.2.0
       react-final-form: 6.5.9_zunk57bvr2t5bgdbaxawch3xh4
     dev: false


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Downgrade final-form-arrays to 3.0.2.

The 3.1.0 version of final-form-arrays introduce the following change:

`Change remove and removeBatch behavior to set array value to undefined when all items have been removed.`

This change breaks forms when deleting all fields of a field array.

The 3.0.2 version set an empty array when all items are removed.
