### PR TITLE
fix(tooltip): flickering effect due to animation going backwards

### DIFF
--- a/.changeset/rare-hotels-try.md
+++ b/.changeset/rare-hotels-try.md
@@ -1,0 +1,6 @@
+---
+'@scaleway/ui': patch
+'@scaleway/form': patch
+---
+
+Fix flickering effect on tooltip when un-hovering

--- a/packages/ui/src/components/Tooltip/helpers.ts
+++ b/packages/ui/src/components/Tooltip/helpers.ts
@@ -1,8 +1,8 @@
 import type { RefObject } from 'react'
 
 export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left' | 'auto'
-export const ARROW_WIDTH = 6 // in px
-const SPACE = 6 // in px
+export const ARROW_WIDTH = 8 // in px
+const SPACE = 4 // in px
 const TOTAL_USED_SPACE = ARROW_WIDTH + SPACE // in px
 export const DEFAULT_POSITIONS = {
   arrowLeft: -999,

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -72,7 +72,7 @@ const StyledTooltip = styled.div<StyledTooltipProps>`
     css`
       ${ANIMATION_DURATION}ms ${!reverseAnimation
         ? animation(positions)
-        : exitAnimation(positions)}
+        : exitAnimation(positions)} forwards
     `};
 
   &::after {
@@ -181,7 +181,6 @@ export const Tooltip = ({
   const unmountTooltip = useCallback(() => {
     setVisibleInDom(false)
     setReverseAnimation(false)
-    timer.current = undefined
 
     window.removeEventListener('scroll', onScrollDetected, true)
   }, [onScrollDetected])
@@ -200,7 +199,7 @@ export const Tooltip = ({
           setReverseAnimation(true)
           timer.current = setTimeout(() => unmountTooltip(), ANIMATION_DURATION)
         }, 200)
-      } else {
+      } else if (isVisible) {
         // This condition is for when we want to mount the tooltip
         // If the timer exists it means the tooltip was about to umount, but we hovered the children again,
         // so we clear the timer and the tooltip will not be unmounted
@@ -215,7 +214,7 @@ export const Tooltip = ({
           clearTimeout(debounceTimer.current)
           debounceTimer.current = undefined
         }
-        setVisibleInDom(isVisible)
+        setVisibleInDom(true)
       }
     },
     [unmountTooltip],


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### Flickering Bug on Tooltip when un-hovering 🐞

This is an actual bug we have on Tooltip causing a flicker effect. This is because our animation is going back to its initial state once completed. In some cases this can cause the flickering.

To fix it I simply added `forwards` to the animation in CSS, forcing the animation to keep its last position at the end of the animation solving the issue.

| Before  | After |
| ------------- | ------------- |
|  ![Screen Recording 2023-03-30 at 17 57 44](https://user-images.githubusercontent.com/15812968/228898920-dd1b65f7-e880-4685-a2ee-823f63713352.gif) | ![ezgif-4-96aeef49aa](https://user-images.githubusercontent.com/15812968/228897483-c611fa9c-7fe7-4f84-8f11-5509a76cd742.gif) |


