### PR TITLE
chore: fixed releases for `@scaleway/ui` and `@scaleway/form`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,12 @@
     }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@scaleway/ui",
+      "@scaleway/form"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
Make sure `@scaleway/ui` and `@scaleway/form` are bumped together, similar to what we had before.

Learn more about `fixed`: https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md