### PR TITLE
chore: remove linked config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,12 +7,7 @@
     }
   ],
   "commit": false,
-  "linked": [
-    [
-      "@scaleway/ui",
-      "@scaleway/form"
-    ]
-  ],
+  "linked": [],
   "fixed": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
Remove linked, changeset is capable of updating packages automatically.