### PR TITLE
fix(ButtonV2): add `aria-label` and `name` properties

### DIFF
--- a/.changeset/shy-boxes-refuse.md
+++ b/.changeset/shy-boxes-refuse.md
@@ -1,0 +1,6 @@
+---
+'@scaleway/form': minor
+'@scaleway/ui': minor
+---
+
+Add `aria-label` and `name` properties to button

--- a/packages/ui/src/components/ButtonV2/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/ButtonV2/__tests__/__snapshots__/index.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonV2 render large 1`] = `
 <DocumentFragment>
-  .cache-myi3of-StyledButton-StyledFilledButton {
+  .cache-3mfvgf-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -39,18 +39,18 @@ exports[`ButtonV2 render large 1`] = `
   color: #ffffff;
 }
 
-.cache-myi3of-StyledButton-StyledFilledButton:active {
+.cache-3mfvgf-StyledButton-StyledFilledButton:active {
   box-shadow: 0px 0px 0px 3px #4F059940;
 }
 
-.cache-myi3of-StyledButton-StyledFilledButton:hover,
-.cache-myi3of-StyledButton-StyledFilledButton:active {
+.cache-3mfvgf-StyledButton-StyledFilledButton:hover,
+.cache-3mfvgf-StyledButton-StyledFilledButton:active {
   background: #390171;
   color: #ffffff;
 }
 
 <button
-    class="cache-myi3of-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-3mfvgf-StyledButton-StyledFilledButton e1su13oj2"
     type="button"
   >
     Hello
@@ -60,7 +60,7 @@ exports[`ButtonV2 render large 1`] = `
 
 exports[`ButtonV2 render medium 1`] = `
 <DocumentFragment>
-  .cache-260sr0-StyledButton-StyledFilledButton {
+  .cache-e5emwc-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -97,18 +97,18 @@ exports[`ButtonV2 render medium 1`] = `
   color: #ffffff;
 }
 
-.cache-260sr0-StyledButton-StyledFilledButton:active {
+.cache-e5emwc-StyledButton-StyledFilledButton:active {
   box-shadow: 0px 0px 0px 3px #4F059940;
 }
 
-.cache-260sr0-StyledButton-StyledFilledButton:hover,
-.cache-260sr0-StyledButton-StyledFilledButton:active {
+.cache-e5emwc-StyledButton-StyledFilledButton:hover,
+.cache-e5emwc-StyledButton-StyledFilledButton:active {
   background: #390171;
   color: #ffffff;
 }
 
 <button
-    class="cache-260sr0-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-e5emwc-StyledButton-StyledFilledButton e1su13oj2"
     type="button"
   >
     Hello
@@ -118,7 +118,7 @@ exports[`ButtonV2 render medium 1`] = `
 
 exports[`ButtonV2 render small 1`] = `
 <DocumentFragment>
-  .cache-1pir1ef-StyledButton-StyledFilledButton {
+  .cache-nzvjol-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -155,18 +155,18 @@ exports[`ButtonV2 render small 1`] = `
   color: #ffffff;
 }
 
-.cache-1pir1ef-StyledButton-StyledFilledButton:active {
+.cache-nzvjol-StyledButton-StyledFilledButton:active {
   box-shadow: 0px 0px 0px 3px #4F059940;
 }
 
-.cache-1pir1ef-StyledButton-StyledFilledButton:hover,
-.cache-1pir1ef-StyledButton-StyledFilledButton:active {
+.cache-nzvjol-StyledButton-StyledFilledButton:hover,
+.cache-nzvjol-StyledButton-StyledFilledButton:active {
   background: #390171;
   color: #ffffff;
 }
 
 <button
-    class="cache-1pir1ef-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-nzvjol-StyledButton-StyledFilledButton e1su13oj2"
     type="button"
   >
     Hello
@@ -176,7 +176,7 @@ exports[`ButtonV2 render small 1`] = `
 
 exports[`ButtonV2 render with fullWidth 1`] = `
 <DocumentFragment>
-  .cache-18l9cyw-StyledButton-StyledFilledButton {
+  .cache-a4lgjd-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -213,18 +213,18 @@ exports[`ButtonV2 render with fullWidth 1`] = `
   color: #ffffff;
 }
 
-.cache-18l9cyw-StyledButton-StyledFilledButton:active {
+.cache-a4lgjd-StyledButton-StyledFilledButton:active {
   box-shadow: 0px 0px 0px 3px #4F059940;
 }
 
-.cache-18l9cyw-StyledButton-StyledFilledButton:hover,
-.cache-18l9cyw-StyledButton-StyledFilledButton:active {
+.cache-a4lgjd-StyledButton-StyledFilledButton:hover,
+.cache-a4lgjd-StyledButton-StyledFilledButton:active {
   background: #390171;
   color: #ffffff;
 }
 
 <button
-    class="cache-18l9cyw-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-a4lgjd-StyledButton-StyledFilledButton e1su13oj2"
     type="button"
   >
     Hello
@@ -234,7 +234,7 @@ exports[`ButtonV2 render with fullWidth 1`] = `
 
 exports[`ButtonV2 render with icon 1`] = `
 <DocumentFragment>
-  .cache-cqsvoi-StyledButton-StyledFilledButton {
+  .cache-askfkg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -283,7 +283,7 @@ exports[`ButtonV2 render with icon 1`] = `
 }
 
 <button
-    class="cache-cqsvoi-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-askfkg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -302,7 +302,7 @@ exports[`ButtonV2 render with icon 1`] = `
 
 exports[`ButtonV2 render with icon on the right 1`] = `
 <DocumentFragment>
-  .cache-1c79nq5-StyledButton-StyledFilledButton {
+  .cache-1di9zuz-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -351,7 +351,7 @@ exports[`ButtonV2 render with icon on the right 1`] = `
 }
 
 <button
-    class="cache-1c79nq5-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1di9zuz-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -370,7 +370,7 @@ exports[`ButtonV2 render with icon on the right 1`] = `
 
 exports[`ButtonV2 render with icon only 1`] = `
 <DocumentFragment>
-  .cache-1c79nq5-StyledButton-StyledFilledButton {
+  .cache-1di9zuz-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -419,7 +419,7 @@ exports[`ButtonV2 render with icon only 1`] = `
 }
 
 <button
-    class="cache-1c79nq5-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1di9zuz-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -453,7 +453,7 @@ exports[`ButtonV2 render with isLoading with icon 1`] = `
   }
 }
 
-.cache-cqsvoi-StyledButton-StyledFilledButton {
+.cache-askfkg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -503,7 +503,7 @@ exports[`ButtonV2 render with isLoading with icon 1`] = `
 }
 
 <button
-    class="cache-cqsvoi-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-askfkg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -562,7 +562,7 @@ exports[`ButtonV2 render with isLoading without icon 1`] = `
   }
 }
 
-.cache-cqsvoi-StyledButton-StyledFilledButton {
+.cache-askfkg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -612,7 +612,7 @@ exports[`ButtonV2 render with isLoading without icon 1`] = `
 }
 
 <button
-    class="cache-cqsvoi-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-askfkg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -655,7 +655,7 @@ exports[`ButtonV2 render with isLoading without icon 1`] = `
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&danger 1`] = `
 <DocumentFragment>
-  .cache-1t86p37-StyledButton-StyledFilledButton {
+  .cache-1b6pxco-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -695,7 +695,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&danger 1`
 }
 
 <button
-    class="cache-1t86p37-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1b6pxco-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -706,7 +706,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&danger 1`
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&danger disabled 1`] = `
 <DocumentFragment>
-  .cache-1t86p37-StyledButton-StyledFilledButton {
+  .cache-1b6pxco-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -746,7 +746,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&danger di
 }
 
 <button
-    class="cache-1t86p37-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1b6pxco-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -757,7 +757,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&danger di
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&info 1`] = `
 <DocumentFragment>
-  .cache-1db60yp-StyledButton-StyledFilledButton {
+  .cache-1a02cm5-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -797,7 +797,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&info 1`] 
 }
 
 <button
-    class="cache-1db60yp-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1a02cm5-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -808,7 +808,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&info 1`] 
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&info disabled 1`] = `
 <DocumentFragment>
-  .cache-1db60yp-StyledButton-StyledFilledButton {
+  .cache-1a02cm5-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -848,7 +848,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&info disa
 }
 
 <button
-    class="cache-1db60yp-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1a02cm5-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -859,7 +859,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&info disa
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&neutral 1`] = `
 <DocumentFragment>
-  .cache-ai44sa-StyledButton-StyledFilledButton {
+  .cache-vf14uu-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -899,7 +899,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&neutral 1
 }
 
 <button
-    class="cache-ai44sa-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-vf14uu-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -910,7 +910,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&neutral 1
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&neutral disabled 1`] = `
 <DocumentFragment>
-  .cache-ai44sa-StyledButton-StyledFilledButton {
+  .cache-vf14uu-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -950,7 +950,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&neutral d
 }
 
 <button
-    class="cache-ai44sa-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-vf14uu-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -961,7 +961,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&neutral d
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&primary 1`] = `
 <DocumentFragment>
-  .cache-cqsvoi-StyledButton-StyledFilledButton {
+  .cache-askfkg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1001,7 +1001,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&primary 1
 }
 
 <button
-    class="cache-cqsvoi-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-askfkg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -1012,7 +1012,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&primary 1
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&primary disabled 1`] = `
 <DocumentFragment>
-  .cache-cqsvoi-StyledButton-StyledFilledButton {
+  .cache-askfkg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1052,7 +1052,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&primary d
 }
 
 <button
-    class="cache-cqsvoi-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-askfkg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -1063,7 +1063,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&primary d
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&success 1`] = `
 <DocumentFragment>
-  .cache-1dpi5yd-StyledButton-StyledFilledButton {
+  .cache-19d9jxg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1103,7 +1103,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&success 1
 }
 
 <button
-    class="cache-1dpi5yd-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-19d9jxg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -1114,7 +1114,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&success 1
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&success disabled 1`] = `
 <DocumentFragment>
-  .cache-1dpi5yd-StyledButton-StyledFilledButton {
+  .cache-19d9jxg-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1154,7 +1154,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&success d
 }
 
 <button
-    class="cache-1dpi5yd-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-19d9jxg-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -1165,7 +1165,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&success d
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&warning 1`] = `
 <DocumentFragment>
-  .cache-sczhe3-StyledButton-StyledFilledButton {
+  .cache-1x3m95m-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1205,7 +1205,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&warning 1
 }
 
 <button
-    class="cache-sczhe3-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1x3m95m-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -1216,7 +1216,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&warning 1
 
 exports[`ButtonV2 variant-sentiment-disabled combination render filled&warning disabled 1`] = `
 <DocumentFragment>
-  .cache-sczhe3-StyledButton-StyledFilledButton {
+  .cache-1x3m95m-StyledButton-StyledFilledButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1256,7 +1256,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&warning d
 }
 
 <button
-    class="cache-sczhe3-StyledButton-StyledFilledButton e1su13oj2"
+    class="cache-1x3m95m-StyledButton-StyledFilledButton e1su13oj2"
     disabled=""
     type="button"
   >
@@ -1267,7 +1267,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render filled&warning d
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&danger 1`] = `
 <DocumentFragment>
-  .cache-nlx975-StyledButton-StyledGhostButton {
+  .cache-46kxrg-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1306,7 +1306,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&danger 1`]
 }
 
 <button
-    class="cache-nlx975-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-46kxrg-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1317,7 +1317,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&danger 1`]
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&danger disabled 1`] = `
 <DocumentFragment>
-  .cache-nlx975-StyledButton-StyledGhostButton {
+  .cache-46kxrg-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1356,7 +1356,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&danger dis
 }
 
 <button
-    class="cache-nlx975-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-46kxrg-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1367,7 +1367,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&danger dis
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&info 1`] = `
 <DocumentFragment>
-  .cache-tok9j3-StyledButton-StyledGhostButton {
+  .cache-1vxxx19-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1406,7 +1406,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&info 1`] =
 }
 
 <button
-    class="cache-tok9j3-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-1vxxx19-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1417,7 +1417,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&info 1`] =
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&info disabled 1`] = `
 <DocumentFragment>
-  .cache-tok9j3-StyledButton-StyledGhostButton {
+  .cache-1vxxx19-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1456,7 +1456,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&info disab
 }
 
 <button
-    class="cache-tok9j3-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-1vxxx19-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1467,7 +1467,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&info disab
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&neutral 1`] = `
 <DocumentFragment>
-  .cache-1j6glqz-StyledButton-StyledGhostButton {
+  .cache-119l8eh-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1506,7 +1506,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&neutral 1`
 }
 
 <button
-    class="cache-1j6glqz-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-119l8eh-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1517,7 +1517,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&neutral 1`
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&neutral disabled 1`] = `
 <DocumentFragment>
-  .cache-1j6glqz-StyledButton-StyledGhostButton {
+  .cache-119l8eh-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1556,7 +1556,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&neutral di
 }
 
 <button
-    class="cache-1j6glqz-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-119l8eh-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1567,7 +1567,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&neutral di
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&primary 1`] = `
 <DocumentFragment>
-  .cache-1gwi2mv-StyledButton-StyledGhostButton {
+  .cache-uxclfj-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1606,7 +1606,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&primary 1`
 }
 
 <button
-    class="cache-1gwi2mv-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-uxclfj-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1617,7 +1617,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&primary 1`
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&primary disabled 1`] = `
 <DocumentFragment>
-  .cache-1gwi2mv-StyledButton-StyledGhostButton {
+  .cache-uxclfj-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1656,7 +1656,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&primary di
 }
 
 <button
-    class="cache-1gwi2mv-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-uxclfj-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1667,7 +1667,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&primary di
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&success 1`] = `
 <DocumentFragment>
-  .cache-1cdbuye-StyledButton-StyledGhostButton {
+  .cache-1f97730-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1706,7 +1706,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&success 1`
 }
 
 <button
-    class="cache-1cdbuye-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-1f97730-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1717,7 +1717,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&success 1`
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&success disabled 1`] = `
 <DocumentFragment>
-  .cache-1cdbuye-StyledButton-StyledGhostButton {
+  .cache-1f97730-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1756,7 +1756,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&success di
 }
 
 <button
-    class="cache-1cdbuye-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-1f97730-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1767,7 +1767,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&success di
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&warning 1`] = `
 <DocumentFragment>
-  .cache-1jkxz6c-StyledButton-StyledGhostButton {
+  .cache-q3kl6a-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1806,7 +1806,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&warning 1`
 }
 
 <button
-    class="cache-1jkxz6c-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-q3kl6a-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1817,7 +1817,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&warning 1`
 
 exports[`ButtonV2 variant-sentiment-disabled combination render ghost&warning disabled 1`] = `
 <DocumentFragment>
-  .cache-1jkxz6c-StyledButton-StyledGhostButton {
+  .cache-q3kl6a-StyledButton-StyledGhostButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1856,7 +1856,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&warning di
 }
 
 <button
-    class="cache-1jkxz6c-StyledButton-StyledGhostButton e1su13oj0"
+    class="cache-q3kl6a-StyledButton-StyledGhostButton e1su13oj0"
     disabled=""
     type="button"
   >
@@ -1867,7 +1867,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render ghost&warning di
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&danger 1`] = `
 <DocumentFragment>
-  .cache-14e9tmu-StyledButton-StyledOutlinedButton {
+  .cache-1k8k3g7-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1907,7 +1907,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&danger 
 }
 
 <button
-    class="cache-14e9tmu-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-1k8k3g7-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -1918,7 +1918,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&danger 
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&danger disabled 1`] = `
 <DocumentFragment>
-  .cache-14e9tmu-StyledButton-StyledOutlinedButton {
+  .cache-1k8k3g7-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1958,7 +1958,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&danger 
 }
 
 <button
-    class="cache-14e9tmu-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-1k8k3g7-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -1969,7 +1969,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&danger 
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&info 1`] = `
 <DocumentFragment>
-  .cache-4iv0ck-StyledButton-StyledOutlinedButton {
+  .cache-1eer2zg-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2009,7 +2009,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&info 1`
 }
 
 <button
-    class="cache-4iv0ck-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-1eer2zg-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2020,7 +2020,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&info 1`
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&info disabled 1`] = `
 <DocumentFragment>
-  .cache-4iv0ck-StyledButton-StyledOutlinedButton {
+  .cache-1eer2zg-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2060,7 +2060,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&info di
 }
 
 <button
-    class="cache-4iv0ck-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-1eer2zg-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2071,7 +2071,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&info di
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&neutral 1`] = `
 <DocumentFragment>
-  .cache-anhzt-StyledButton-StyledOutlinedButton {
+  .cache-1184urx-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2111,7 +2111,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&neutral
 }
 
 <button
-    class="cache-anhzt-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-1184urx-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2122,7 +2122,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&neutral
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&neutral disabled 1`] = `
 <DocumentFragment>
-  .cache-anhzt-StyledButton-StyledOutlinedButton {
+  .cache-1184urx-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2162,7 +2162,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&neutral
 }
 
 <button
-    class="cache-anhzt-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-1184urx-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2173,7 +2173,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&neutral
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&primary 1`] = `
 <DocumentFragment>
-  .cache-1edbo5l-StyledButton-StyledOutlinedButton {
+  .cache-4135he-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2213,7 +2213,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&primary
 }
 
 <button
-    class="cache-1edbo5l-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-4135he-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2224,7 +2224,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&primary
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&primary disabled 1`] = `
 <DocumentFragment>
-  .cache-1edbo5l-StyledButton-StyledOutlinedButton {
+  .cache-4135he-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2264,7 +2264,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&primary
 }
 
 <button
-    class="cache-1edbo5l-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-4135he-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2275,7 +2275,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&primary
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&success 1`] = `
 <DocumentFragment>
-  .cache-h0pu6d-StyledButton-StyledOutlinedButton {
+  .cache-15e3430-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2315,7 +2315,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&success
 }
 
 <button
-    class="cache-h0pu6d-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-15e3430-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2326,7 +2326,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&success
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&success disabled 1`] = `
 <DocumentFragment>
-  .cache-h0pu6d-StyledButton-StyledOutlinedButton {
+  .cache-15e3430-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2366,7 +2366,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&success
 }
 
 <button
-    class="cache-h0pu6d-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-15e3430-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2377,7 +2377,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&success
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&warning 1`] = `
 <DocumentFragment>
-  .cache-fmlo7t-StyledButton-StyledOutlinedButton {
+  .cache-r5uz24-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2417,7 +2417,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&warning
 }
 
 <button
-    class="cache-fmlo7t-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-r5uz24-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >
@@ -2428,7 +2428,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&warning
 
 exports[`ButtonV2 variant-sentiment-disabled combination render outlined&warning disabled 1`] = `
 <DocumentFragment>
-  .cache-fmlo7t-StyledButton-StyledOutlinedButton {
+  .cache-r5uz24-StyledButton-StyledOutlinedButton {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2468,7 +2468,7 @@ exports[`ButtonV2 variant-sentiment-disabled combination render outlined&warning
 }
 
 <button
-    class="cache-fmlo7t-StyledButton-StyledOutlinedButton e1su13oj1"
+    class="cache-r5uz24-StyledButton-StyledOutlinedButton e1su13oj1"
     disabled=""
     type="button"
   >

--- a/packages/ui/src/components/ButtonV2/index.tsx
+++ b/packages/ui/src/components/ButtonV2/index.tsx
@@ -99,7 +99,7 @@ const StyledFilledButton = styled(StyledButton)`
     disabled
       ? `
             background: ${theme.colors[sentiment].backgroundStrongDisabled};
-            color: 
+            color:
               ${
                 theme.colors[sentiment][
                   sentiment === 'neutral'
@@ -112,7 +112,7 @@ const StyledFilledButton = styled(StyledButton)`
             &:hover, &:active
             {
                 background: ${theme.colors[sentiment].backgroundStrongHover};
-                color: 
+                color:
                 ${
                   theme.colors[sentiment][
                     sentiment === 'neutral' ? 'textHover' : 'textStrongHover'
@@ -134,7 +134,7 @@ const StyledOutlinedButton = styled(StyledButton)`
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
-        color: 
+        color:
           ${
             theme.colors[sentiment][
               sentiment === 'neutral' ? 'textDisabled' : 'textWeakDisabled'
@@ -147,13 +147,13 @@ const StyledOutlinedButton = styled(StyledButton)`
               : 'borderWeakDisabled'
           ]
         };
-        
+
     `
       : `
         &:hover, &:active
        {
             background: ${theme.colors[sentiment].backgroundWeakHover};
-            color: 
+            color:
             ${
               theme.colors[sentiment][
                 sentiment === 'neutral' ? 'textHover' : 'textWeakHover'
@@ -179,7 +179,7 @@ const StyledGhostButton = styled(StyledButton)`
   ${({ theme, sentiment, disabled }) =>
     disabled
       ? `
-        color: 
+        color:
           ${
             theme.colors[sentiment][
               sentiment === 'neutral' ? 'textDisabled' : 'textWeakDisabled'
@@ -190,7 +190,7 @@ const StyledGhostButton = styled(StyledButton)`
         &:hover, &:active
         {
             background: ${theme.colors[sentiment].backgroundWeakHover};
-            color: 
+            color:
               ${
                 theme.colors[sentiment][
                   sentiment === 'neutral' ? 'textHover' : 'textWeakHover'
@@ -220,6 +220,8 @@ type ButtonProps = {
   iconPosition?: 'left' | 'right'
   fullWidth?: boolean
   isLoading?: boolean
+  name?: string
+  'aria-label'?: string
   onClick: ButtonHTMLAttributes<HTMLButtonElement>['onClick']
 } & (
   | { children: ReactNode; icon?: ComponentProps<typeof Icon>['name'] }
@@ -242,6 +244,8 @@ export const ButtonV2 = forwardRef(
       isLoading = false,
       onClick,
       children,
+      name,
+      'aria-label': ariaLabel,
     }: ButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
@@ -260,6 +264,8 @@ export const ButtonV2 = forwardRef(
         type={type}
         onClick={onClick}
         ref={ref}
+        name={name}
+        aria-label={ariaLabel}
       >
         {!isLoading && icon ? <Icon name={icon} size={16} /> : null}
         {isLoading ? (


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

I added `aria-label` and `name` properties to buttonV2. `aria-label` is required is there is no content set for accessibility.
