### PR TITLE
fix(form): meta type error function

### DIFF
--- a/.changeset/quick-dodos-tan.md
+++ b/.changeset/quick-dodos-tan.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/form': minor
+---
+
+fix type issue with meta field from getErrors function

--- a/.changeset/quick-dodos-tan.md
+++ b/.changeset/quick-dodos-tan.md
@@ -2,4 +2,4 @@
 '@scaleway/form': minor
 ---
 
-fix type issue with meta field from getErrors function
+Fix type issue with meta field from `getErrors` function

--- a/packages/form/src/components/NumberInputField/index.tsx
+++ b/packages/form/src/components/NumberInputField/index.tsx
@@ -49,7 +49,7 @@ export const NumberInputField = ({
   value,
   className,
 }: NumberInputValueFieldProps) => {
-  const { input } = useFormField(name, {
+  const { input } = useFormField<number>(name, {
     disabled,
     required,
     type: 'number',

--- a/packages/form/src/providers/ErrorContext/__tests__/index.spec.tsx
+++ b/packages/form/src/providers/ErrorContext/__tests__/index.spec.tsx
@@ -11,12 +11,6 @@ const HookWrapper = ({ children }: { children: ReactNode }) => (
     render={() => <ErrorProvider errors={mockErrors}>{children}</ErrorProvider>}
   />
 )
-const baseMeta = {
-  blur: () => {},
-  change: () => {},
-  focus: () => {},
-  name: 'test',
-}
 
 describe('ErrorProvider', () => {
   test('renders correctly ', () =>
@@ -36,7 +30,6 @@ describe('ErrorProvider', () => {
     const requiredTouchedAndEmpty = {
       label: 'test',
       meta: {
-        ...baseMeta,
         error: ['REQUIRED'],
         touched: true,
       },
@@ -50,7 +43,6 @@ describe('ErrorProvider', () => {
     const minLengthTouchedAndInvalid = {
       label: 'test',
       meta: {
-        ...baseMeta,
         error: ['MIN_LENGTH'],
         touched: true,
       },
@@ -65,7 +57,6 @@ describe('ErrorProvider', () => {
     const minLengthWithInvalidInitialValue = {
       label: 'test',
       meta: {
-        ...baseMeta,
         dirty: false,
         error: ['MIN_LENGTH'],
         touched: false,
@@ -82,7 +73,6 @@ describe('ErrorProvider', () => {
     const minLengthWithInvalidValueAndCustomErrorMessage = {
       label: 'test',
       meta: {
-        ...baseMeta,
         error: customErrorString,
         touched: true,
       },
@@ -111,7 +101,6 @@ describe('ErrorProvider', () => {
     const requiredAndNotEmpty = {
       label: 'test',
       meta: {
-        ...baseMeta,
         touched: true,
       },
       name: 'test',
@@ -124,7 +113,6 @@ describe('ErrorProvider', () => {
     const requiredDirtyAndEmpty = {
       label: 'test',
       meta: {
-        ...baseMeta,
         dirty: true,
         error: ['REQUIRED'],
         touched: false,
@@ -142,11 +130,7 @@ describe('ErrorProvider', () => {
         allValues: {},
         label: 'test',
         meta: {
-          blur: () => {},
-          change: () => {},
           error: [],
-          focus: () => {},
-          name: 'test',
         },
         minLength: 3,
         name: 'test',

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -1,17 +1,12 @@
-import type {
-  AnyObject,
-  FieldState,
-  FieldSubscription,
-  FieldValidator,
-} from 'final-form'
-import type { UseFieldConfig } from 'react-final-form'
+import type { AnyObject, FieldSubscription, FieldValidator } from 'final-form'
+import type { FieldMetaState, UseFieldConfig } from 'react-final-form'
 
 export type FormErrorFunctionParams<InputValue = unknown> = {
   label: string
   name: string
   value: InputValue
   allValues: AnyObject
-  meta?: FieldState<InputValue>
+  meta?: FieldMetaState<InputValue>
 }
 
 type RequiredErrors = {
@@ -58,7 +53,7 @@ export type ValidatorObject<InputValue = unknown> = {
   validate: (
     value: InputValue,
     allValues?: AnyObject,
-    meta?: FieldState<InputValue>,
+    meta?: FieldMetaState<InputValue>,
   ) => boolean
   error: keyof RequiredErrors
 }


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

use the right type for meta FieldMetaState instead of FieldState.

This will avoid cast error like this: 

``` javascript
 const { input, meta } = useField(`${name}-buffer`, {
      type,
      value: '',
      validate: validateFn,
    })

    const error = getError({
      meta: meta as FieldState<unknown>,

```

=> 
``` javascript
 const { input, meta } = useField(`${name}-buffer`, {
      type,
      value: '',
      validate: validateFn,
    })

    const error = getError({
      meta,

```

