### PR TITLE
refactor(VerificationCode): change state management

### DIFF
--- a/.changeset/calm-moons-judge.md
+++ b/.changeset/calm-moons-judge.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': minor
+---
+
+change state handle of `VerificationCode`

--- a/packages/ui/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
@@ -50,7 +50,6 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -61,7 +60,6 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -72,7 +70,6 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -83,7 +80,6 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -145,7 +141,6 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -156,7 +151,6 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -167,7 +161,6 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -178,7 +171,6 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -189,7 +181,6 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="4"
       data-testid="4"
       id="verification-code-4"
       pattern="[0-9]*"
@@ -200,7 +191,6 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="5"
       data-testid="5"
       id="verification-code-5"
       pattern="[0-9]*"
@@ -262,7 +252,6 @@ exports[`VerificationCode should handle and replace non number with "" when type
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -273,7 +262,6 @@ exports[`VerificationCode should handle and replace non number with "" when type
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -284,7 +272,6 @@ exports[`VerificationCode should handle and replace non number with "" when type
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -295,7 +282,6 @@ exports[`VerificationCode should handle and replace non number with "" when type
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -357,7 +343,6 @@ exports[`VerificationCode should handle error 1`] = `
     <input
       aria-invalid="true"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -368,7 +353,6 @@ exports[`VerificationCode should handle error 1`] = `
     <input
       aria-invalid="true"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -379,7 +363,6 @@ exports[`VerificationCode should handle error 1`] = `
     <input
       aria-invalid="true"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -390,7 +373,6 @@ exports[`VerificationCode should handle error 1`] = `
     <input
       aria-invalid="true"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -452,7 +434,6 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -463,7 +444,6 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -474,7 +454,6 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -485,7 +464,6 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -547,7 +525,6 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       placeholder=""
@@ -557,7 +534,6 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       placeholder=""
@@ -567,7 +543,6 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       placeholder=""
@@ -577,7 +552,6 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       placeholder=""
@@ -587,7 +561,6 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="4"
       data-testid="4"
       id="verification-code-4"
       placeholder=""
@@ -597,7 +570,6 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="5"
       data-testid="5"
       id="verification-code-5"
       placeholder=""
@@ -658,7 +630,6 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -669,7 +640,6 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -680,7 +650,6 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -691,7 +660,6 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -753,7 +721,6 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -764,7 +731,6 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -775,7 +741,6 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -786,7 +751,6 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"
@@ -848,7 +812,6 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="0"
       data-testid="0"
       id="verification-code-0"
       pattern="[0-9]*"
@@ -859,7 +822,6 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="1"
       data-testid="1"
       id="verification-code-1"
       pattern="[0-9]*"
@@ -870,7 +832,6 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="2"
       data-testid="2"
       id="verification-code-2"
       pattern="[0-9]*"
@@ -881,7 +842,6 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     <input
       aria-invalid="false"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
-      data-id="3"
       data-testid="3"
       id="verification-code-3"
       pattern="[0-9]*"


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

I remove `data-id` in `VerificationCode` as it was confusing and not type safe. This prop was used to manage state of the input, instead I'm passing `index` directly in the functions who needs it.
