### PR TITLE
feat(PieChart): using new data color

### DIFF
--- a/.changeset/eighty-owls-pretend.md
+++ b/.changeset/eighty-owls-pretend.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': minor
+---
+
+New data colors used into piechart and compatible with theme

--- a/packages/ui/src/components/PieChart/Legends.tsx
+++ b/packages/ui/src/components/PieChart/Legends.tsx
@@ -110,11 +110,12 @@ type LegendsProps = {
   data?: Data[]
   focused?: string
   onFocusChange(index?: string): void
+  colors: string[]
 }
 
-const Legends = ({ focused, data, onFocusChange }: LegendsProps) => (
+const Legends = ({ focused, data, onFocusChange, colors }: LegendsProps) => (
   <List>
-    {data?.map(item => {
+    {data?.map((item, index) => {
       const isSegmentFocused = focused !== undefined && item.id === focused
 
       const id = `chart-legend-${item.id}`
@@ -135,7 +136,7 @@ const Legends = ({ focused, data, onFocusChange }: LegendsProps) => (
               onBlur={() => onFocusChange()}
             />
             <Bullet
-              color={item.color}
+              color={colors[index]}
               isFocused={isSegmentFocused}
               needPattern={item.needPattern}
               id={`chart-legend-${item.id}`}

--- a/packages/ui/src/components/PieChart/__stories__/mockData.ts
+++ b/packages/ui/src/components/PieChart/__stories__/mockData.ts
@@ -1,11 +1,9 @@
 export const data = [
   {
-    color: '#4F1A81',
     id: 'compute',
     percent: 50,
   },
   {
-    color: '#F4306C',
     id: 'gpu',
     percent: 50,
   },
@@ -13,70 +11,60 @@ export const data = [
 
 export const dataWithLegends = [
   {
-    color: '#4F1A81',
     id: 'compute',
     name: 'Compute',
     percent: 50,
     value: '20',
   },
   {
-    color: '#F4306C',
     id: 'gpu',
     name: 'GPU Instances',
     percent: 50,
     value: '20',
   },
   {
-    color: '#F79E43',
     id: 'functions',
     name: 'Serverless Functions',
     percent: 50,
     value: '20',
   },
   {
-    color: '#8B3DD3',
     id: 'containers',
     name: 'Serverless Containers',
     percent: 50,
     value: '20',
   },
   {
-    color: '#EC5775',
     id: 's3',
     name: 'Object Storage',
     percent: 50,
     value: '20',
   },
   {
-    color: '#43C1A3',
     id: 'dns',
     name: 'Domain zones',
     percent: 50,
     value: '20',
   },
   {
-    color: '#76DFDE',
     id: 'appleSilicon',
     name: 'Apple Silicon',
     percent: 50,
     value: '20',
   },
   {
-    color: '#C2E457',
     id: 'baremetal',
     name: 'Baremetal',
     percent: 50,
     value: '20',
   },
   {
-    color: '#45d69e',
     id: 'database',
     name: 'Database',
     percent: 50,
     value: '20',
   },
   {
-    color: '#ff8c69',
     id: 'lb',
     name: 'Load Balancer',
     percent: 50,
@@ -86,7 +74,6 @@ export const dataWithLegends = [
 
 export const dataWithLegendsAndDetails = [
   {
-    color: '#4F1A81',
     details: [
       {
         name: 'Start-1S',
@@ -103,7 +90,6 @@ export const dataWithLegendsAndDetails = [
     value: '20',
   },
   {
-    color: '#F4306C',
     details: [
       {
         name: 'Start-1S',
@@ -123,7 +109,6 @@ export const dataWithLegendsAndDetails = [
 
 export const dataWithLegendsDetailsAndDiscount = [
   {
-    color: '#F4306C',
     details: [
       {
         name: 'Start-1S',

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -69,13 +69,13 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
   position: absolute;
 }
 
-.cache-z8sq21-Bullet-animationFlash {
+.cache-ujeidl-Bullet-animationFlash {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #4F1A81;
+  background: #5e47be;
   -webkit-animation: animation-0 linear 1500ms infinite;
   animation: animation-0 linear 1500ms infinite;
 }
@@ -138,13 +138,13 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
   color: #4a4f62;
 }
 
-.cache-1i73ppo-Bullet {
+.cache-1g7yh9y-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #F4306C;
+  background: #0083e6;
 }
 
 .cache-1o1agb-Text {
@@ -226,17 +226,17 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-3.560568890002063e-14,93L-2.8484551120016506e-14,74.4A74.4,74.4,0,1,0,4.555686092828154e-15,-74.4Z"
-                fill="#4F1A81"
+                d="M1.039313891827303,-92.99419243498087A93,93,0,0,1,1.039313891827303,92.99419243498087L1.0393138918272897,74.39274041621438A74.4,74.4,0,0,0,1.0393138918272897,-74.39274041621438Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(55, 18, 90)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
               <path
-                d="M-3.560568890002063e-14,93A93,93,0,1,1,6.551677018400607e-14,-93L5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-2.8484551120016506e-14,74.4Z"
-                fill="#F4306C"
+                d="M-1.0393138918272917,92.99419243498087A93,93,0,0,1,-1.039313891827273,-92.99419243498087L-1.0393138918273153,-74.39274041621438A74.4,74.4,0,0,0,-1.0393138918272806,74.39274041621438Z"
+                fill="#0083e6"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(0, 92, 161)"
                 stroke-width="0"
               />
             </g>
@@ -259,8 +259,8 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
             data-testid="chart-legend-compute"
           />
           <div
-            class="cache-z8sq21-Bullet-animationFlash enw618e6"
-            color="#4F1A81"
+            class="cache-ujeidl-Bullet-animationFlash enw618e6"
+            color="#5e47be"
             id="chart-legend-compute"
           />
           <div
@@ -298,8 +298,8 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
             data-testid="chart-legend-gpu"
           />
           <div
-            class="cache-1i73ppo-Bullet enw618e6"
-            color="#F4306C"
+            class="cache-1g7yh9y-Bullet enw618e6"
+            color="#0083e6"
             id="chart-legend-gpu"
           />
           <div
@@ -399,13 +399,13 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
   position: absolute;
 }
 
-.cache-z8sq21-Bullet-animationFlash {
+.cache-ujeidl-Bullet-animationFlash {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #4F1A81;
+  background: #5e47be;
   -webkit-animation: animation-0 linear 1500ms infinite;
   animation: animation-0 linear 1500ms infinite;
 }
@@ -468,13 +468,13 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
   color: #4a4f62;
 }
 
-.cache-1i73ppo-Bullet {
+.cache-1g7yh9y-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #F4306C;
+  background: #0083e6;
 }
 
 .cache-1o1agb-Text {
@@ -556,17 +556,17 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-3.560568890002063e-14,93L-2.8484551120016506e-14,74.4A74.4,74.4,0,1,0,4.555686092828154e-15,-74.4Z"
-                fill="#4F1A81"
+                d="M1.039313891827303,-92.99419243498087A93,93,0,0,1,1.039313891827303,92.99419243498087L1.0393138918272897,74.39274041621438A74.4,74.4,0,0,0,1.0393138918272897,-74.39274041621438Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(55, 18, 90)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
               <path
-                d="M-3.560568890002063e-14,93A93,93,0,1,1,6.551677018400607e-14,-93L5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-2.8484551120016506e-14,74.4Z"
-                fill="#F4306C"
+                d="M-1.0393138918272917,92.99419243498087A93,93,0,0,1,-1.039313891827273,-92.99419243498087L-1.0393138918273153,-74.39274041621438A74.4,74.4,0,0,0,-1.0393138918272806,74.39274041621438Z"
+                fill="#0083e6"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(0, 92, 161)"
                 stroke-width="0"
               />
             </g>
@@ -589,8 +589,8 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
             data-testid="chart-legend-compute"
           />
           <div
-            class="cache-z8sq21-Bullet-animationFlash enw618e6"
-            color="#4F1A81"
+            class="cache-ujeidl-Bullet-animationFlash enw618e6"
+            color="#5e47be"
             id="chart-legend-compute"
           />
           <div
@@ -628,8 +628,8 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
             data-testid="chart-legend-gpu"
           />
           <div
-            class="cache-1i73ppo-Bullet enw618e6"
-            color="#F4306C"
+            class="cache-1g7yh9y-Bullet enw618e6"
+            color="#0083e6"
             id="chart-legend-gpu"
           />
           <div
@@ -729,17 +729,17 @@ exports[`PieChart renders correctly with data 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-3.560568890002063e-14,93L-2.8484551120016506e-14,74.4A74.4,74.4,0,1,0,4.555686092828154e-15,-74.4Z"
-                fill="#4F1A81"
+                d="M1.039313891827303,-92.99419243498087A93,93,0,0,1,1.039313891827303,92.99419243498087L1.0393138918272897,74.39274041621438A74.4,74.4,0,0,0,1.0393138918272897,-74.39274041621438Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(55, 18, 90)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
               <path
-                d="M-3.560568890002063e-14,93A93,93,0,1,1,6.551677018400607e-14,-93L5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-2.8484551120016506e-14,74.4Z"
-                fill="#F4306C"
+                d="M-1.0393138918272917,92.99419243498087A93,93,0,0,1,-1.039313891827273,-92.99419243498087L-1.0393138918273153,-74.39274041621438A74.4,74.4,0,0,0,-1.0393138918272806,74.39274041621438Z"
+                fill="#0083e6"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(0, 92, 161)"
                 stroke-width="0"
               />
             </g>
@@ -836,17 +836,17 @@ exports[`PieChart renders correctly with data and content 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-3.560568890002063e-14,93L-2.8484551120016506e-14,74.4A74.4,74.4,0,1,0,4.555686092828154e-15,-74.4Z"
-                fill="#4F1A81"
+                d="M1.039313891827303,-92.99419243498087A93,93,0,0,1,1.039313891827303,92.99419243498087L1.0393138918272897,74.39274041621438A74.4,74.4,0,0,0,1.0393138918272897,-74.39274041621438Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(55, 18, 90)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
               <path
-                d="M-3.560568890002063e-14,93A93,93,0,1,1,6.551677018400607e-14,-93L5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-2.8484551120016506e-14,74.4Z"
-                fill="#F4306C"
+                d="M-1.0393138918272917,92.99419243498087A93,93,0,0,1,-1.039313891827273,-92.99419243498087L-1.0393138918273153,-74.39274041621438A74.4,74.4,0,0,0,-1.0393138918272806,74.39274041621438Z"
+                fill="#0083e6"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(0, 92, 161)"
                 stroke-width="0"
               />
             </g>
@@ -918,13 +918,13 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
   position: absolute;
 }
 
-.cache-j5ggws-Bullet {
+.cache-1cfwawe-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #4F1A81;
+  background: #5e47be;
 }
 
 .cache-s9pm9i-Label {
@@ -971,13 +971,13 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
   font-weight: 400;
 }
 
-.cache-1i73ppo-Bullet {
+.cache-1g7yh9y-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #F4306C;
+  background: #0083e6;
 }
 
 <div
@@ -1035,17 +1035,17 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-3.560568890002063e-14,93L-2.8484551120016506e-14,74.4A74.4,74.4,0,1,0,4.555686092828154e-15,-74.4Z"
-                fill="#4F1A81"
+                d="M1.039313891827303,-92.99419243498087A93,93,0,0,1,1.039313891827303,92.99419243498087L1.0393138918272897,74.39274041621438A74.4,74.4,0,0,0,1.0393138918272897,-74.39274041621438Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(55, 18, 90)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
               <path
-                d="M-3.560568890002063e-14,93A93,93,0,1,1,6.551677018400607e-14,-93L5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-2.8484551120016506e-14,74.4Z"
-                fill="#F4306C"
+                d="M-1.0393138918272917,92.99419243498087A93,93,0,0,1,-1.039313891827273,-92.99419243498087L-1.0393138918273153,-74.39274041621438A74.4,74.4,0,0,0,-1.0393138918272806,74.39274041621438Z"
+                fill="#0083e6"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(0, 92, 161)"
                 stroke-width="0"
               />
             </g>
@@ -1068,8 +1068,8 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
             data-testid="chart-legend-compute"
           />
           <div
-            class="cache-j5ggws-Bullet enw618e6"
-            color="#4F1A81"
+            class="cache-1cfwawe-Bullet enw618e6"
+            color="#5e47be"
             id="chart-legend-compute"
           />
           <div
@@ -1107,8 +1107,8 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
             data-testid="chart-legend-gpu"
           />
           <div
-            class="cache-1i73ppo-Bullet enw618e6"
-            color="#F4306C"
+            class="cache-1g7yh9y-Bullet enw618e6"
+            color="#0083e6"
             id="chart-legend-gpu"
           />
           <div
@@ -1194,13 +1194,13 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
   position: absolute;
 }
 
-.cache-1i73ppo-Bullet {
+.cache-1cfwawe-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #F4306C;
+  background: #5e47be;
 }
 
 .cache-s9pm9i-Label {
@@ -1291,12 +1291,12 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
             </pattern>
             <pattern
               height="5"
-              id="lines.bg.#F4306C"
+              id="lines.bg.#5e47be"
               patternUnits="userSpaceOnUse"
               width="5"
             >
               <rect
-                fill="#F4306C"
+                fill="#5e47be"
                 height="5"
                 stroke="rgba(255, 0, 0, 0.1)"
                 stroke-width="0"
@@ -1325,10 +1325,10 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-5.694607616035192e-15,93A93,93,0,1,1,5.694607616035192e-15,-93M5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-5.241341614720486e-14,74.4A74.4,74.4,0,1,0,5.241341614720486e-14,-74.4Z"
-                fill="url(#lines.bg.#F4306C)"
+                d="M5.694607616035192e-15,-93A93,93,0,1,1,-5.694607616035192e-15,93A93,93,0,1,1,5.694607616035192e-15,-93M-1.3667058278484462e-14,-74.4A74.4,74.4,0,1,0,1.3667058278484462e-14,74.4A74.4,74.4,0,1,0,-1.3667058278484462e-14,-74.4Z"
+                fill="url(#lines.bg.#5e47be)"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
             </g>
@@ -1351,8 +1351,8 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
             data-testid="chart-legend-discount"
           />
           <div
-            class="cache-1i73ppo-Bullet enw618e6"
-            color="#F4306C"
+            class="cache-1cfwawe-Bullet enw618e6"
+            color="#5e47be"
             id="chart-legend-discount"
           />
           <div
@@ -1476,10 +1476,10 @@ exports[`PieChart renders correctly with empty legend placeholder 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-5.694607616035192e-15,93A93,93,0,1,1,5.694607616035192e-15,-93M5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-5.241341614720486e-14,74.4A74.4,74.4,0,1,0,5.241341614720486e-14,-74.4Z"
-                fill="#f6f6f8"
+                d="M5.694607616035192e-15,-93A93,93,0,1,1,-5.694607616035192e-15,93A93,93,0,1,1,5.694607616035192e-15,-93M-1.3667058278484462e-14,-74.4A74.4,74.4,0,1,0,1.3667058278484462e-14,74.4A74.4,74.4,0,1,0,-1.3667058278484462e-14,-74.4Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(172, 172, 174)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
             </g>
@@ -1555,13 +1555,13 @@ exports[`PieChart renders correctly with legend 1`] = `
   position: absolute;
 }
 
-.cache-j5ggws-Bullet {
+.cache-1cfwawe-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #4F1A81;
+  background: #5e47be;
 }
 
 .cache-s9pm9i-Label {
@@ -1608,85 +1608,85 @@ exports[`PieChart renders correctly with legend 1`] = `
   font-weight: 400;
 }
 
-.cache-1i73ppo-Bullet {
+.cache-1g7yh9y-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #F4306C;
+  background: #0083e6;
 }
 
-.cache-68enpz-Bullet {
+.cache-6pbji3-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #F79E43;
+  background: #3ebd8f;
 }
 
-.cache-1m99j70-Bullet {
+.cache-yllxpd-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #8B3DD3;
+  background: #ac2740;
 }
 
-.cache-1x0e3f6-Bullet {
+.cache-mjyzfk-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #EC5775;
+  background: #9a85ec;
 }
 
-.cache-p6fp1c-Bullet {
+.cache-n3bgj3-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #43C1A3;
+  background: #ff602e;
 }
 
-.cache-17y1mb5-Bullet {
+.cache-lrilyo-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #76DFDE;
+  background: #483800;
 }
 
-.cache-1hjr387-Bullet {
+.cache-115bg7p-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #C2E457;
+  background: #02a5ad;
 }
 
-.cache-1obih8n-Bullet {
+.cache-1xmmojm-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #45d69e;
+  background: #ffa488;
 }
 
-.cache-1emtqap-Bullet {
+.cache-1qfqtub-Bullet {
   display: inline-block;
   border-radius: 100%;
   width: 10px;
   height: 10px;
   margin: 0 8px;
-  background: #ff8c69;
+  background: #96edf2;
 }
 
 <div
@@ -1744,73 +1744,73 @@ exports[`PieChart renders correctly with legend 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,0,1,54.664028463200005,-75.23858047687011L43.73122277056,-60.1908643814961A74.4,74.4,0,0,0,4.555686092828154e-15,-74.4Z"
-                fill="#4F1A81"
+                d="M1.039313891827303,-92.99419243498087A93,93,0,0,1,53.81979226115179,-75.84477543619248L42.88613309329479,-60.7958846329602A74.4,74.4,0,0,0,1.0393138918272897,-74.39274041621438Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(55, 18, 90)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
               <path
-                d="M54.664028463200005,-75.23858047687011A93,93,0,0,1,88.44825601544927,-28.73858047687011L70.75860481235942,-22.99086438149609A74.4,74.4,0,0,0,43.73122277056,-60.1908643814961Z"
-                fill="#F4306C"
+                d="M55.501437463108275,-74.62298867995493A93,93,0,0,1,88.12156703782944,-29.725232089881683L70.43053488282992,-23.977067296032654A74.4,74.4,0,0,0,44.567778295251266,-59.574097876722654Z"
+                fill="#0083e6"
                 opacity="1"
-                stroke="rgb(171, 34, 76)"
+                stroke="rgb(0, 92, 161)"
                 stroke-width="0"
               />
               <path
-                d="M88.44825601544927,-28.73858047687011A93,93,0,0,1,88.44825601544927,28.73858047687011L70.75860481235942,22.99086438149609A74.4,74.4,0,0,0,70.75860481235942,-22.99086438149609Z"
-                fill="#F79E43"
+                d="M88.76389834795864,-27.748339591284847A93,93,0,0,1,88.76389834795864,27.748339591284847L71.07286619295911,22.000174797435825A74.4,74.4,0,0,0,71.07286619295911,-22.000174797435825Z"
+                fill="#3ebd8f"
                 opacity="1"
-                stroke="rgb(173, 111, 47)"
+                stroke="rgb(43, 132, 100)"
                 stroke-width="0"
               />
               <path
-                d="M88.44825601544927,28.73858047687011A93,93,0,0,1,54.664028463200005,75.23858047687011L43.73122277056,60.1908643814961A74.4,74.4,0,0,0,70.75860481235942,22.99086438149609Z"
-                fill="#8B3DD3"
+                d="M88.12156703782944,29.725232089881683A93,93,0,0,1,55.501437463108275,74.62298867995493L44.567778295251266,59.574097876722654A74.4,74.4,0,0,0,70.43053488282992,23.977067296032654Z"
+                fill="#ac2740"
                 opacity="1"
-                stroke="rgb(97, 43, 148)"
+                stroke="rgb(120, 27, 45)"
                 stroke-width="0"
               />
               <path
-                d="M54.664028463200005,75.23858047687011A93,93,0,0,1,5.694607616035192e-15,93L4.555686092828154e-15,74.4A74.4,74.4,0,0,0,43.73122277056,60.1908643814961Z"
-                fill="#EC5775"
+                d="M53.81979226115179,75.84477543619248A93,93,0,0,1,1.039313891827303,92.99419243498087L1.0393138918272897,74.39274041621438A74.4,74.4,0,0,0,42.88613309329479,60.7958846329602Z"
+                fill="#9a85ec"
                 opacity="1"
-                stroke="rgb(165, 61, 82)"
+                stroke="rgb(108, 93, 165)"
                 stroke-width="0"
               />
               <path
-                d="M5.694607616035192e-15,93A93,93,0,0,1,-54.66402846319999,75.23858047687011L-43.731222770559995,60.1908643814961A74.4,74.4,0,0,0,4.555686092828154e-15,74.4Z"
-                fill="#43C1A3"
+                d="M-1.0393138918272917,92.99419243498087A93,93,0,0,1,-53.819792261151775,75.84477543619249L-42.886133093294774,60.79588463296021A74.4,74.4,0,0,0,-1.0393138918272806,74.39274041621438Z"
+                fill="#ff602e"
                 opacity="1"
-                stroke="rgb(47, 135, 114)"
+                stroke="rgb(179, 67, 32)"
                 stroke-width="0"
               />
               <path
-                d="M-54.66402846319999,75.23858047687011A93,93,0,0,1,-88.44825601544927,28.73858047687012L-70.75860481235942,22.990864381496095A74.4,74.4,0,0,0,-43.731222770559995,60.1908643814961Z"
-                fill="#76DFDE"
+                d="M-55.501437463108275,74.62298867995493A93,93,0,0,1,-88.12156703782944,29.725232089881704L-70.4305348828299,23.97706729603268A74.4,74.4,0,0,0,-44.56777829525128,59.57409787672265Z"
+                fill="#483800"
                 opacity="1"
-                stroke="rgb(83, 156, 155)"
+                stroke="rgb(50, 39, 0)"
                 stroke-width="0"
               />
               <path
-                d="M-88.44825601544927,28.73858047687012A93,93,0,0,1,-88.44825601544929,-28.738580476870098L-70.75860481235944,-22.99086438149608A74.4,74.4,0,0,0,-70.75860481235942,22.990864381496095Z"
-                fill="#C2E457"
+                d="M-88.76389834795864,27.748339591284847A93,93,0,0,1,-88.76389834795864,-27.748339591284825L-71.07286619295913,-22.0001747974358A74.4,74.4,0,0,0,-71.07286619295911,22.000174797435818Z"
+                fill="#02a5ad"
                 opacity="1"
-                stroke="rgb(136, 160, 61)"
+                stroke="rgb(1, 115, 121)"
                 stroke-width="0"
               />
               <path
-                d="M-88.44825601544929,-28.738580476870098A93,93,0,0,1,-54.66402846320001,-75.2385804768701L-43.73122277056002,-60.190864381496084A74.4,74.4,0,0,0,-70.75860481235944,-22.99086438149608Z"
-                fill="#45d69e"
+                d="M-88.12156703782944,-29.72523208988168A93,93,0,0,1,-55.50143746310825,-74.62298867995493L-44.567778295251294,-59.57409787672264A74.4,74.4,0,0,0,-70.43053488282992,-23.977067296032665Z"
+                fill="#ffa488"
                 opacity="1"
-                stroke="rgb(48, 150, 111)"
+                stroke="rgb(179, 115, 95)"
                 stroke-width="0"
               />
               <path
-                d="M-54.66402846320001,-75.2385804768701A93,93,0,0,1,-1.7083822848105575e-14,-93L-1.3667058278484462e-14,-74.4A74.4,74.4,0,0,0,-43.73122277056002,-60.190864381496084Z"
-                fill="#ff8c69"
+                d="M-53.819792261151825,-75.84477543619245A93,93,0,0,1,-1.039313891827273,-92.99419243498087L-1.0393138918273153,-74.39274041621438A74.4,74.4,0,0,0,-42.88613309329479,-60.7958846329602Z"
+                fill="#96edf2"
                 opacity="1"
-                stroke="rgb(179, 98, 74)"
+                stroke="rgb(105, 166, 169)"
                 stroke-width="0"
               />
             </g>
@@ -1833,8 +1833,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-compute"
           />
           <div
-            class="cache-j5ggws-Bullet enw618e6"
-            color="#4F1A81"
+            class="cache-1cfwawe-Bullet enw618e6"
+            color="#5e47be"
             id="chart-legend-compute"
           />
           <div
@@ -1872,8 +1872,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-gpu"
           />
           <div
-            class="cache-1i73ppo-Bullet enw618e6"
-            color="#F4306C"
+            class="cache-1g7yh9y-Bullet enw618e6"
+            color="#0083e6"
             id="chart-legend-gpu"
           />
           <div
@@ -1911,8 +1911,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-functions"
           />
           <div
-            class="cache-68enpz-Bullet enw618e6"
-            color="#F79E43"
+            class="cache-6pbji3-Bullet enw618e6"
+            color="#3ebd8f"
             id="chart-legend-functions"
           />
           <div
@@ -1950,8 +1950,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-containers"
           />
           <div
-            class="cache-1m99j70-Bullet enw618e6"
-            color="#8B3DD3"
+            class="cache-yllxpd-Bullet enw618e6"
+            color="#ac2740"
             id="chart-legend-containers"
           />
           <div
@@ -1989,8 +1989,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-s3"
           />
           <div
-            class="cache-1x0e3f6-Bullet enw618e6"
-            color="#EC5775"
+            class="cache-mjyzfk-Bullet enw618e6"
+            color="#9a85ec"
             id="chart-legend-s3"
           />
           <div
@@ -2028,8 +2028,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-dns"
           />
           <div
-            class="cache-p6fp1c-Bullet enw618e6"
-            color="#43C1A3"
+            class="cache-n3bgj3-Bullet enw618e6"
+            color="#ff602e"
             id="chart-legend-dns"
           />
           <div
@@ -2067,8 +2067,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-appleSilicon"
           />
           <div
-            class="cache-17y1mb5-Bullet enw618e6"
-            color="#76DFDE"
+            class="cache-lrilyo-Bullet enw618e6"
+            color="#483800"
             id="chart-legend-appleSilicon"
           />
           <div
@@ -2106,8 +2106,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-baremetal"
           />
           <div
-            class="cache-1hjr387-Bullet enw618e6"
-            color="#C2E457"
+            class="cache-115bg7p-Bullet enw618e6"
+            color="#02a5ad"
             id="chart-legend-baremetal"
           />
           <div
@@ -2145,8 +2145,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-database"
           />
           <div
-            class="cache-1obih8n-Bullet enw618e6"
-            color="#45d69e"
+            class="cache-1xmmojm-Bullet enw618e6"
+            color="#ffa488"
             id="chart-legend-database"
           />
           <div
@@ -2184,8 +2184,8 @@ exports[`PieChart renders correctly with legend 1`] = `
             data-testid="chart-legend-lb"
           />
           <div
-            class="cache-1emtqap-Bullet enw618e6"
-            color="#ff8c69"
+            class="cache-1qfqtub-Bullet enw618e6"
+            color="#96edf2"
             id="chart-legend-lb"
           />
           <div
@@ -2285,10 +2285,10 @@ exports[`PieChart renders correctly with no props 1`] = `
               transform="translate(93,93)"
             >
               <path
-                d="M5.694607616035192e-15,-93A93,93,0,1,1,-5.694607616035192e-15,93A93,93,0,1,1,5.694607616035192e-15,-93M5.241341614720486e-14,-74.4A74.4,74.4,0,1,0,-5.241341614720486e-14,74.4A74.4,74.4,0,1,0,5.241341614720486e-14,-74.4Z"
-                fill="#f6f6f8"
+                d="M5.694607616035192e-15,-93A93,93,0,1,1,-5.694607616035192e-15,93A93,93,0,1,1,5.694607616035192e-15,-93M-1.3667058278484462e-14,-74.4A74.4,74.4,0,1,0,1.3667058278484462e-14,74.4A74.4,74.4,0,1,0,-1.3667058278484462e-14,-74.4Z"
+                fill="#5e47be"
                 opacity="1"
-                stroke="rgb(172, 172, 174)"
+                stroke="rgb(66, 50, 133)"
                 stroke-width="0"
               />
             </g>

--- a/packages/ui/src/components/PieChart/index.tsx
+++ b/packages/ui/src/components/PieChart/index.tsx
@@ -87,11 +87,8 @@ export const PieChart = ({
       if (Number(a.replace('data', '')) < Number(b.replace('data', ''))) {
         return -1
       }
-      if (Number(a.replace('data', '')) > Number(b.replace('data', ''))) {
-        return 1
-      }
 
-      return 0
+      return 1
     })
     .map(
       key =>

--- a/packages/ui/src/components/PieChart/index.tsx
+++ b/packages/ui/src/components/PieChart/index.tsx
@@ -81,6 +81,23 @@ export const PieChart = ({
     [emptyLegend],
   )
 
+  const localColors = Object.keys(colors.other.data.charts)
+    .filter(key => !['success', 'danger'].includes(key))
+    .sort((a, b) => {
+      if (Number(a.replace('data', '')) < Number(b.replace('data', ''))) {
+        return -1
+      }
+      if (Number(a.replace('data', '')) > Number(b.replace('data', ''))) {
+        return 1
+      }
+
+      return 0
+    })
+    .map(
+      key =>
+        colors.other.data.charts[key as keyof typeof colors.other.data.charts],
+    )
+
   const LegendDisplayer = useCallback(
     () =>
       isEmpty ? (
@@ -90,16 +107,17 @@ export const PieChart = ({
           focused={currentFocusIndex}
           data={data}
           onFocusChange={setCurrentFocusIndex}
+          colors={localColors}
         />
       ),
-    [isEmpty, currentFocusIndex, data, EmptyLegendDisplayed],
+    [isEmpty, currentFocusIndex, data, EmptyLegendDisplayed, localColors],
   )
 
   return (
     <Container height={height}>
       <div style={{ position: 'relative' }}>
         <Pie
-          colors={d => d.data.color}
+          colors={localColors}
           height={height}
           width={width}
           value="percent"
@@ -110,7 +128,6 @@ export const PieChart = ({
               ? data
               : [
                   {
-                    color: colors.neutral.backgroundStrong,
                     id: 'empty',
                     percent: 100,
                   },
@@ -138,6 +155,7 @@ export const PieChart = ({
           margin={margin}
           innerRadius={0.8}
           cornerRadius={0}
+          padAngle={1}
           activeOuterRadiusOffset={!isEmpty ? 4 : 0}
           tooltip={emptyTooltip}
           onMouseEnter={(datum, event) => {

--- a/packages/ui/src/components/PieChart/types.tsx
+++ b/packages/ui/src/components/PieChart/types.tsx
@@ -1,5 +1,4 @@
 export type Data = {
-  color: string
   name?: string | null
   needPattern?: boolean | null
   percent: number


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

#### What is expected?

PieChart integrate new chart colors we won't need to set them in data anymore they will be get from theme automatically making theme dark theme compatible.

<img width="981" alt="Screenshot 2023-04-24 at 11 46 39" src="https://user-images.githubusercontent.com/15812968/233962531-dcd175a4-3f0b-4731-9c20-a841ce985cf8.png">

<img width="971" alt="Screenshot 2023-04-24 at 11 51 33" src="https://user-images.githubusercontent.com/15812968/233962964-1a889d9a-219a-44fa-a00f-7e6d2e92afa1.png">


