### PR TITLE
fix(Tooltip): improve accessibility the wrapper can now be focused for voiceover

### DIFF
--- a/.changeset/four-queens-buy.md
+++ b/.changeset/four-queens-buy.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': minor
+---
+
+Tooltip is now focusable for the voice over to be able to read it

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -1641,6 +1641,7 @@ exports[`Button should render correctly with a tooltip 1`] = `
 <div
     aria-describedby="test"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       aria-describedby="test"

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
@@ -50,6 +50,7 @@ exports[`CopyButton renders correctly 1`] = `
 <div
     aria-describedby=":r0:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -118,6 +119,7 @@ exports[`CopyButton renders correctly variant large 1`] = `
 <div
     aria-describedby=":r2:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-r06x4m-StyledButton e1go4oa30"
@@ -186,6 +188,7 @@ exports[`CopyButton renders correctly variant neutral 1`] = `
 <div
     aria-describedby=":r4:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-xsw6vc-StyledButton e1go4oa30"
@@ -254,6 +257,7 @@ exports[`CopyButton renders correctly variant primary 1`] = `
 <div
     aria-describedby=":r3:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -322,6 +326,7 @@ exports[`CopyButton renders correctly variant small 1`] = `
 <div
     aria-describedby=":r1:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -390,6 +395,7 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 <div
     aria-describedby=":r8:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="custom-class cache-16ljkze-StyledButton e1go4oa30"
@@ -458,6 +464,7 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 <div
     aria-describedby=":r7:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -526,6 +533,7 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 <div
     aria-describedby=":r6:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-16ljkze-StyledButton e1go4oa30"
@@ -594,6 +602,7 @@ exports[`CopyButton renders correctly with no border 1`] = `
 <div
     aria-describedby=":r5:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <button
       class="cache-1gy37wj-StyledButton e1go4oa30"

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -12023,6 +12023,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
               <div
                 aria-describedby="list-tooltip-row-0"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -12219,6 +12220,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
               <div
                 aria-describedby="list-tooltip-row-2"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -12320,6 +12322,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
               <div
                 aria-describedby="list-tooltip-row-3"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -12421,6 +12424,7 @@ exports[`List should render correctly multiselect with condition 1`] = `
               <div
                 aria-describedby="list-tooltip-row-4"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -13119,6 +13123,7 @@ exports[`List should render correctly multiselect with condition, table variant 
           <div
             aria-describedby="list-tooltip-row-0"
             class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+            tabindex="0"
           >
             <label
               aria-disabled="true"
@@ -13289,6 +13294,7 @@ exports[`List should render correctly multiselect with condition, table variant 
           <div
             aria-describedby="list-tooltip-row-2"
             class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+            tabindex="0"
           >
             <label
               aria-disabled="true"
@@ -13377,6 +13383,7 @@ exports[`List should render correctly multiselect with condition, table variant 
           <div
             aria-describedby="list-tooltip-row-3"
             class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+            tabindex="0"
           >
             <label
               aria-disabled="true"
@@ -13465,6 +13472,7 @@ exports[`List should render correctly multiselect with condition, table variant 
           <div
             aria-describedby="list-tooltip-row-4"
             class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+            tabindex="0"
           >
             <label
               aria-disabled="true"
@@ -22552,6 +22560,7 @@ exports[`List should render correctly with bad idKey 1`] = `
               <div
                 aria-describedby="list-tooltip-row-0"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -22659,6 +22668,7 @@ exports[`List should render correctly with bad idKey 1`] = `
               <div
                 aria-describedby="list-tooltip-row-1"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -22766,6 +22776,7 @@ exports[`List should render correctly with bad idKey 1`] = `
               <div
                 aria-describedby="list-tooltip-row-2"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -22873,6 +22884,7 @@ exports[`List should render correctly with bad idKey 1`] = `
               <div
                 aria-describedby="list-tooltip-row-3"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"
@@ -22980,6 +22992,7 @@ exports[`List should render correctly with bad idKey 1`] = `
               <div
                 aria-describedby="list-tooltip-row-4"
                 class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+                tabindex="0"
               >
                 <label
                   aria-disabled="true"

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -250,6 +250,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       <div
         aria-describedby="chart-legend-compute"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-exvtnx-ListItem enw618e7"
@@ -289,6 +290,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       <div
         aria-describedby="chart-legend-gpu"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -580,6 +582,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       <div
         aria-describedby="chart-legend-compute"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-exvtnx-ListItem enw618e7"
@@ -619,6 +622,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       <div
         aria-describedby="chart-legend-gpu"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1059,6 +1063,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       <div
         aria-describedby="chart-legend-compute"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1098,6 +1103,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       <div
         aria-describedby="chart-legend-gpu"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1342,6 +1348,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
       <div
         aria-describedby="chart-legend-discount"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1824,6 +1831,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-compute"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1863,6 +1871,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-gpu"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1902,6 +1911,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-functions"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1941,6 +1951,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-containers"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -1980,6 +1991,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-s3"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2019,6 +2031,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-dns"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2058,6 +2071,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-appleSilicon"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2097,6 +2111,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-baremetal"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2136,6 +2151,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-database"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"
@@ -2175,6 +2191,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       <div
         aria-describedby="chart-legend-lb"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <li
           class="cache-1klfns5-ListItem enw618e7"

--- a/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Tooltip should render correctly with component in content prop 1`] = `
 <div
     aria-describedby=":r4:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     Children
   </div>
@@ -24,6 +25,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 <div
     aria-describedby=":rf:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -43,6 +45,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 <div
     aria-describedby=":r9:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -62,6 +65,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 <div
     aria-describedby=":rc:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -81,6 +85,7 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 <div
     aria-describedby=":r6:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -100,6 +105,7 @@ exports[`Tooltip should render correctly with required props 1`] = `
 <div
     aria-describedby=":r0:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     Children
   </div>
@@ -115,6 +121,7 @@ exports[`Tooltip should render correctly with required props and visible 1`] = `
 <div
     aria-describedby=":r1:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     Children
   </div>
@@ -130,6 +137,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 <div
     aria-describedby=":ru:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -149,6 +157,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 <div
     aria-describedby=":rr:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -168,6 +177,7 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 <div
     aria-describedby=":ro:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -187,6 +197,7 @@ exports[`Tooltip should render correctly with variant should renders tooltip wit
 <div
     aria-describedby=":ri:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"
@@ -206,6 +217,7 @@ exports[`Tooltip should render correctly with variant should renders tooltip wit
 <div
     aria-describedby=":rl:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <p
       data-testid="children"

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -1375,6 +1375,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 <div
     aria-describedby=":rn:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <div
       class="cache-dgvm93-Container ejleepd1"
@@ -2919,6 +2920,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 <div
     aria-describedby=":rl:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <div
       class="cache-dgvm93-Container ejleepd1"

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -147,6 +147,7 @@ exports[`Snippet renders correctly 1`] = `
         <div
           aria-describedby=":r1:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -405,6 +406,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
         <div
           aria-describedby=":r3:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -700,6 +702,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
         <div
           aria-describedby=":r9:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -996,6 +999,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
         <div
           aria-describedby=":r6:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1186,6 +1190,7 @@ exports[`Snippet renders correctly with copiedText 1`] = `
         <div
           aria-describedby=":ri:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1354,6 +1359,7 @@ exports[`Snippet renders correctly with copyText 1`] = `
         <div
           aria-describedby=":rg:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1612,6 +1618,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
         <div
           aria-describedby=":rk:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -1892,6 +1899,7 @@ exports[`Snippet renders correctly with showText 1`] = `
         <div
           aria-describedby=":rn:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -2097,6 +2105,7 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
         <div
           aria-describedby=":rc:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -2281,6 +2290,7 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
         <div
           aria-describedby=":re:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"
@@ -2539,6 +2549,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
         <div
           aria-describedby=":rq:"
           class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+          tabindex="0"
         >
           <button
             class="cache-1nnm9m7-StyledButton e1go4oa30"

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -1268,6 +1268,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
 <div
     aria-describedby=":ra:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     <div
       style="display: inline-flex;"

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`TagList renders correctly 1`] = `
       <div
         aria-describedby=":r0:"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference ed8izcl2"
@@ -312,6 +313,7 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
       <div
         aria-describedby=":r1:"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference ed8izcl2"
@@ -423,6 +425,7 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
       <div
         aria-describedby=":r2:"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference ed8izcl2"
@@ -548,6 +551,7 @@ exports[`TagList renders correctly with multiline 1`] = `
       <div
         aria-describedby=":r3:"
         class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+        tabindex="0"
       >
         <span
           class="cache-15hi38u-StyledTooltipReference ed8izcl2"

--- a/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`Tooltip should render correctly 1`] = `
 <div
     aria-describedby=":r0:"
     class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
+    tabindex="0"
   >
     Hover me
   </div>

--- a/packages/ui/src/components/Tooltip/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Tooltip/__tests__/index.test.tsx
@@ -122,12 +122,28 @@ describe('Tooltip', () => {
           </Tooltip>,
         )
 
-        const input = screen.getByTestId('children')
-        await userEvent.hover(input)
+        const children = screen.getByTestId('children')
+        await userEvent.hover(children)
 
         const tooltipPortal = screen.getByText('test success!')
         expect(tooltipPortal).toBeVisible()
       })
     })
+  })
+
+  test(`should verify accessibility`, async () => {
+    renderWithTheme(
+      <Tooltip text="test success!" maxWidth={100}>
+        <p data-testid="children">Hover me</p>
+      </Tooltip>,
+    )
+
+    await userEvent.keyboard('{Tab}')
+
+    const tooltipPortal = screen.getByText('test success!')
+    expect(tooltipPortal).toBeVisible()
+
+    await userEvent.keyboard('{Escape}')
+    expect(tooltipPortal).not.toBeVisible()
   })
 })

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -1,6 +1,6 @@
 import { css, keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
-import type { ReactNode, Ref, RefObject } from 'react'
+import type { KeyboardEventHandler, ReactNode, Ref, RefObject } from 'react'
 import {
   forwardRef,
   useCallback,
@@ -266,6 +266,15 @@ export const Tooltip = forwardRef(
       }
     }, [isControlled, onPointerEvent, visible])
 
+    const onKeyDown: KeyboardEventHandler = useCallback(
+      event => {
+        if (event.code === 'Escape') {
+          unmountTooltip()
+        }
+      },
+      [unmountTooltip],
+    )
+
     /**
      * Will render children conditionally if children is a function or not.
      */
@@ -288,11 +297,13 @@ export const Tooltip = forwardRef(
           onPointerEnter={!isControlled ? onPointerEvent(true) : noop}
           onPointerLeave={!isControlled ? onPointerEvent(false) : noop}
           ref={childrenRef}
+          tabIndex={0}
+          onKeyDown={onKeyDown}
         >
           {children}
         </StyledChildrenContainer>
       )
-    }, [children, generatedId, isControlled, onPointerEvent])
+    }, [children, generatedId, isControlled, onKeyDown, onPointerEvent])
 
     if (!text) {
       if (typeof children === 'function') return null


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Tooltip wrapper can now be focused using the keyboard, once the tooltip wrapper is focused the tooltip itself is shown. It can then be removed  with `Escape` key.

Here are the specifications:
> A tooltip typically becomes visible, after a short delay of generally one to five seconds, in response to a mouse hover, or after the owning element receives keyboard focus. Just as it is opened automatically, without user request, it is closed automatically when the focus is lost or on mouse out. It should also close when the user presses the Escape key.
[https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)

We have to keep in mind an important statement:
> Because the tooltip itself never receives focus and is not in the tabbing order, a tooltip can not contain interactive elements like links, inputs, or buttons.
[https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role)


https://user-images.githubusercontent.com/15812968/234213731-3358f08f-d69c-42db-962c-0da912a60c99.mov



