### PR TITLE
fix: component props names

### DIFF
--- a/.changeset/odd-queens-pump.md
+++ b/.changeset/odd-queens-pump.md
@@ -1,0 +1,6 @@
+---
+'@scaleway/ui': minor
+---
+
+- In `Alert` rename `onButtonClick` into `onClickButton`
+- In `Banner` rename prop `type` into `variant`

--- a/packages/ui/src/components/Alert/__stories__/Button.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Button.stories.tsx
@@ -5,7 +5,7 @@ export const Button = Template.bind({})
 Button.args = {
   variant: 'info',
   buttonText: 'More info',
-  onButtonClick: () => alert('Button clicked'),
+  onClickButton: () => alert('Button clicked'),
   title: 'Information',
   children: 'This is an alert content.',
 }
@@ -13,6 +13,6 @@ Button.args = {
 Button.parameters = {
   docs: {
     storyDescription:
-      'Using `Button` prop you can add a custom Button and use `onButtonClick` prop to handle the click event.',
+      'Using `Button` prop you can add a custom Button and use `onClickButton` prop to handle the click event.',
   },
 }

--- a/packages/ui/src/components/Alert/__stories__/Closable.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Closable.stories.tsx
@@ -7,7 +7,7 @@ Closable.args = {
   variant: 'info',
   title: 'Information',
   buttonText: 'More info',
-  onButtonClick: () => alert('Button clicked'),
+  onClickButton: () => alert('Button clicked'),
   isClosable: true,
 }
 

--- a/packages/ui/src/components/Alert/__stories__/LongChildren.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/LongChildren.stories.tsx
@@ -8,7 +8,7 @@ LongChildren.args = {
   variant: 'info',
   title: 'Information',
   buttonText: 'More info',
-  onButtonClick: () => alert('Button clicked'),
+  onClickButton: () => alert('Button clicked'),
   isClosable: true,
 }
 

--- a/packages/ui/src/components/Alert/__stories__/Variants.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/Variants.stories.tsx
@@ -10,7 +10,7 @@ export const Variants = (props: ComponentProps<typeof Alert>) =>
       title={`${variant.charAt(0).toUpperCase() + variant.slice(1)} title`}
       variant={variant}
       buttonText="More info"
-      onButtonClick={() => alert('Button clicked')}
+      onClickButton={() => alert('Button clicked')}
     >
       This is an Alert with the {variant} variant.
     </Alert>

--- a/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Alert/__tests__/__snapshots__/index.test.tsx.snap
@@ -644,7 +644,7 @@ exports[`Alert renders correctly with all variants renders correctly variant war
 </DocumentFragment>
 `;
 
-exports[`Alert renders correctly with buttonText and onButtonClick 1`] = `
+exports[`Alert renders correctly with buttonText and onClickButton 1`] = `
 <DocumentFragment>
   .cache-19cmpom-Stack-StyledStackContainer-alertStyles {
   display: -webkit-box;

--- a/packages/ui/src/components/Alert/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Alert/__tests__/index.test.tsx
@@ -28,9 +28,9 @@ describe('Alert', () => {
   test('renders correctly with title', () =>
     shouldMatchEmotionSnapshot(<Alert title="title">Sample Alert</Alert>))
 
-  test('renders correctly with buttonText and onButtonClick', () =>
+  test('renders correctly with buttonText and onClickButton', () =>
     shouldMatchEmotionSnapshot(
-      <Alert buttonText="Button" onButtonClick={() => 'ok'}>
+      <Alert buttonText="Button" onClickButton={() => 'ok'}>
         Sample Alert
       </Alert>,
     ))

--- a/packages/ui/src/components/Alert/index.tsx
+++ b/packages/ui/src/components/Alert/index.tsx
@@ -70,7 +70,7 @@ type AlertProps = {
   title?: string
   variant?: AlertType
   buttonText?: ComponentProps<typeof ButtonV2>['children']
-  onButtonClick?: () => void
+  onClickButton?: () => void
   onClose?: () => void
   isClosable?: boolean
   className?: string
@@ -82,7 +82,7 @@ export const Alert = ({
   title,
   variant = 'danger',
   buttonText,
-  onButtonClick,
+  onClickButton,
   isClosable,
   onClose,
   className,
@@ -130,7 +130,7 @@ export const Alert = ({
         {buttonText ? (
           <StyledButton
             sentiment={variant}
-            onClick={onButtonClick}
+            onClick={onClickButton}
             size="small"
           >
             {buttonText}

--- a/packages/ui/src/components/Banner/__stories__/Variants.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/Variants.stories.tsx
@@ -2,14 +2,14 @@ import type { Story } from '@storybook/react'
 import { Banner } from '..'
 import image from './Image.png'
 
-export const Types: Story = () => (
+export const Variants: Story = () => (
   <>
     <Banner
       title="Apply to Scaleway Startup programs"
       image={<img src={image} alt="" />}
       buttonText="Apply now"
       linkText="Learn more"
-      type="intro"
+      variant="intro"
     >
       The Scaleway Startup programs offer the perfect combination of cloud
       credits, infrastructure advisors and startup experts to develop your
@@ -20,7 +20,7 @@ export const Types: Story = () => (
       image={<img src={image} alt="" />}
       buttonText="Apply now"
       linkText="Learn more"
-      type="promotional"
+      variant="promotional"
     >
       The Scaleway Startup programs offer the perfect combination of cloud
       credits, infrastructure advisors and startup experts to develop your
@@ -29,14 +29,14 @@ export const Types: Story = () => (
   </>
 )
 
-Types.parameters = {
+Variants.parameters = {
   docs: {
     storyDescription:
-      'We have two different type of Banner: intro and promotional.',
+      'We have two different variant of Banner: intro and promotional.',
   },
 }
 
-Types.decorators = [
+Variants.decorators = [
   StoryComponent => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
       <StoryComponent />

--- a/packages/ui/src/components/Banner/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/index.stories.tsx
@@ -7,6 +7,6 @@ export default {
 } as ComponentMeta<typeof Banner>
 
 export { Playground } from './Playground.stories'
-export { Types } from './Types.stories'
+export { Variants } from './Variants.stories'
 export { Sizes } from './Sizes.stories'
 export { Directions } from './Directions.stories'

--- a/packages/ui/src/components/Banner/__tests__/index.tsx
+++ b/packages/ui/src/components/Banner/__tests__/index.tsx
@@ -36,7 +36,7 @@ describe('Banner', () => {
 
   test('renders correctly with type promotional', () =>
     shouldMatchEmotionSnapshot(
-      <Banner title="Title" type="promotional">
+      <Banner title="Title" variant="promotional">
         Description
       </Banner>,
     ))

--- a/packages/ui/src/components/Banner/index.tsx
+++ b/packages/ui/src/components/Banner/index.tsx
@@ -6,16 +6,16 @@ import { Link } from '../Link'
 import { Stack } from '../Stack'
 import { Text } from '../Text'
 
-type Type = 'intro' | 'promotional'
+type Variant = 'intro' | 'promotional'
 type Size = 'small' | 'medium'
 
 const Container = styled('div', {
-  shouldForwardProp: prop => !['type', 'size'].includes(prop),
-})<{ type: Type; size: Size }>`
+  shouldForwardProp: prop => !['variant', 'size'].includes(prop),
+})<{ variant: Variant; size: Size }>`
   padding: ${({ theme, size }) => theme.space[size === 'small' ? '2' : '3']};
   border-radius: ${({ theme }) => theme.radii.large};
-  background: ${({ theme, type }) =>
-    type === 'intro'
+  background: ${({ theme, variant }) =>
+    variant === 'intro'
       ? theme.colors.primary.background
       : theme.colors.primary.backgroundStrong};
   display: flex;
@@ -31,7 +31,7 @@ const Container = styled('div', {
 `
 
 type BannerProps = {
-  type?: Type
+  variant?: Variant
   size?: 'small' | 'medium'
   title: string
   children: ReactNode
@@ -46,7 +46,7 @@ type BannerProps = {
 }
 
 export const Banner = ({
-  type = 'intro',
+  variant = 'intro',
   size = 'medium',
   title,
   children,
@@ -64,7 +64,7 @@ export const Banner = ({
   if (!opened) return null
 
   return (
-    <Container type={type} size={size} className={className}>
+    <Container variant={variant} size={size} className={className}>
       {image}
       <Stack
         direction={direction}
@@ -78,7 +78,7 @@ export const Banner = ({
             as="p"
             variant={size === 'medium' ? 'headingSmall' : 'bodyStronger'}
             color="primary"
-            prominence={type === 'intro' ? 'default' : 'strong'}
+            prominence={variant === 'intro' ? 'default' : 'strong'}
           >
             {title}
           </Text>
@@ -86,7 +86,7 @@ export const Banner = ({
             as="p"
             variant="body"
             color="neutral"
-            prominence={type === 'intro' ? 'default' : 'stronger'}
+            prominence={variant === 'intro' ? 'default' : 'stronger'}
           >
             {children}
           </Text>
@@ -95,7 +95,7 @@ export const Banner = ({
           {buttonText ? (
             <ButtonV2
               size="medium"
-              sentiment={type === 'intro' ? 'primary' : 'neutral'}
+              sentiment={variant === 'intro' ? 'primary' : 'neutral'}
               onClick={onClickButton}
             >
               {buttonText}
@@ -107,7 +107,7 @@ export const Banner = ({
               size="small"
               target="_blank"
               href={linkHref ?? ''}
-              prominence={type === 'intro' ? 'default' : 'strong'}
+              prominence={variant === 'intro' ? 'default' : 'strong'}
             >
               {linkText}
             </Link>
@@ -117,8 +117,8 @@ export const Banner = ({
       <ButtonV2
         icon="close"
         size="small"
-        variant={type === 'intro' ? 'ghost' : 'filled'}
-        sentiment={type === 'intro' ? 'neutral' : 'primary'}
+        variant={variant === 'intro' ? 'ghost' : 'filled'}
+        sentiment={variant === 'intro' ? 'neutral' : 'primary'}
         onClick={() => {
           setOpened(false)
           onClose?.()


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

- In `Alert` rename `onButtonClick` into `onClickButton`
- In `Banner` rename prop `type` into `variant`
