### PR TITLE
fix: improve accessibility on components and enable more a11y testing

### DIFF
--- a/.changeset/six-snails-hope.md
+++ b/.changeset/six-snails-hope.md
@@ -1,0 +1,9 @@
+---
+'@scaleway/ui': minor
+---
+
+- Add unique `id` into `<Toggle />` component
+- Add `aria-label` into `<Snippet />` component on copy button
+- Add unique `id` into `<VerificationCode />` component
+- Add `label`, `aria-label` and `aria-labelledby` into `<NumberInput />` component
+

--- a/packages/form/src/components/NumberInputField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/NumberInputField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,7 +2,30 @@
 
 exports[`NumberInputField should render correctly 1`] = `
 <DocumentFragment>
-  .cache-od36vv {
+  .cache-kwbqjp {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-od36vv {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -144,52 +167,57 @@ exports[`NumberInputField should render correctly 1`] = `
     novalidate=""
   >
     <div
-      aria-disabled="false"
-      class="cache-od36vv eiawj1g0"
+      class="cache-kwbqjp e1sgck4o0"
     >
-      <button
-        aria-label="Minus"
-        class="cache-bkq66r eiawj1g4"
-        disabled=""
-        type="button"
-      >
-        <svg
-          class="cache-xmmyxm-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19,13H5V11H19V13Z"
-          />
-        </svg>
-      </button>
       <div
-        aria-live="assertive"
-        class="cache-192mx7g eiawj1g3"
-        role="status"
+        aria-disabled="false"
+        class="cache-od36vv eiawj1g0"
       >
-        <input
-          aria-label="Input"
-          class="cache-1lq3jx2 eiawj1g2"
-          name="test"
-          style="width: 25px;"
-          type="number"
-          value="0"
-        />
-      </div>
-      <button
-        aria-label="Plus"
-        class="cache-1mh6k42 eiawj1g4"
-        type="button"
-      >
-        <svg
-          class="cache-18ka304-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
+        <button
+          aria-label="Minus"
+          class="cache-bkq66r eiawj1g4"
+          disabled=""
+          type="button"
         >
-          <path
-            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          <svg
+            class="cache-xmmyxm-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H5V11H19V13Z"
+            />
+          </svg>
+        </button>
+        <div
+          aria-live="assertive"
+          class="cache-192mx7g eiawj1g3"
+          role="status"
+        >
+          <input
+            aria-label="Number Input"
+            class="cache-1lq3jx2 eiawj1g2"
+            id=":r0:"
+            name="test"
+            style="width: 25px;"
+            type="number"
+            value="0"
           />
-        </svg>
-      </button>
+        </div>
+        <button
+          aria-label="Plus"
+          class="cache-1mh6k42 eiawj1g4"
+          type="button"
+        >
+          <svg
+            class="cache-18ka304-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </form>
 </DocumentFragment>
@@ -197,7 +225,30 @@ exports[`NumberInputField should render correctly 1`] = `
 
 exports[`NumberInputField should render correctly disabled 1`] = `
 <DocumentFragment>
-  .cache-od36vv {
+  .cache-kwbqjp {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-od36vv {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -316,54 +367,59 @@ exports[`NumberInputField should render correctly disabled 1`] = `
     novalidate=""
   >
     <div
-      aria-disabled="true"
-      class="cache-od36vv eiawj1g0"
+      class="cache-kwbqjp e1sgck4o0"
     >
-      <button
-        aria-label="Minus"
-        class="cache-bkq66r eiawj1g4"
-        disabled=""
-        type="button"
-      >
-        <svg
-          class="cache-xmmyxm-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19,13H5V11H19V13Z"
-          />
-        </svg>
-      </button>
       <div
-        aria-live="assertive"
-        class="cache-192mx7g eiawj1g3"
-        role="status"
+        aria-disabled="true"
+        class="cache-od36vv eiawj1g0"
       >
-        <input
-          aria-label="Input"
-          class="cache-1lq3jx2 eiawj1g2"
+        <button
+          aria-label="Minus"
+          class="cache-bkq66r eiawj1g4"
           disabled=""
-          name="test"
-          style="width: 25px;"
-          type="number"
-          value="0"
-        />
-      </div>
-      <button
-        aria-label="Plus"
-        class="cache-bkq66r eiawj1g4"
-        disabled=""
-        type="button"
-      >
-        <svg
-          class="cache-xmmyxm-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
+          type="button"
         >
-          <path
-            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          <svg
+            class="cache-xmmyxm-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H5V11H19V13Z"
+            />
+          </svg>
+        </button>
+        <div
+          aria-live="assertive"
+          class="cache-192mx7g eiawj1g3"
+          role="status"
+        >
+          <input
+            aria-label="Number Input"
+            class="cache-1lq3jx2 eiawj1g2"
+            disabled=""
+            id=":r3:"
+            name="test"
+            style="width: 25px;"
+            type="number"
+            value="0"
           />
-        </svg>
-      </button>
+        </div>
+        <button
+          aria-label="Plus"
+          class="cache-bkq66r eiawj1g4"
+          disabled=""
+          type="button"
+        >
+          <svg
+            class="cache-xmmyxm-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </form>
 </DocumentFragment>
@@ -371,7 +427,30 @@ exports[`NumberInputField should render correctly disabled 1`] = `
 
 exports[`NumberInputField should trigger event onMinCrossed & onMaxCrossed 1`] = `
 <DocumentFragment>
-  .cache-od36vv {
+  .cache-kwbqjp {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-od36vv {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -513,52 +592,57 @@ exports[`NumberInputField should trigger event onMinCrossed & onMaxCrossed 1`] =
     novalidate=""
   >
     <div
-      aria-disabled="false"
-      class="cache-od36vv eiawj1g0"
+      class="cache-kwbqjp e1sgck4o0"
     >
-      <button
-        aria-label="Minus"
-        class="cache-1mh6k42 eiawj1g4"
-        type="button"
-      >
-        <svg
-          class="cache-18ka304-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19,13H5V11H19V13Z"
-          />
-        </svg>
-      </button>
       <div
-        aria-live="assertive"
-        class="cache-192mx7g eiawj1g3"
-        role="status"
+        aria-disabled="false"
+        class="cache-od36vv eiawj1g0"
       >
-        <input
-          aria-label="Input"
-          class="cache-1lq3jx2 eiawj1g2"
-          name="test"
-          style="width: 35px;"
-          type="number"
-          value="20"
-        />
-      </div>
-      <button
-        aria-label="Plus"
-        class="cache-bkq66r eiawj1g4"
-        disabled=""
-        type="button"
-      >
-        <svg
-          class="cache-xmmyxm-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
+        <button
+          aria-label="Minus"
+          class="cache-1mh6k42 eiawj1g4"
+          type="button"
         >
-          <path
-            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          <svg
+            class="cache-18ka304-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H5V11H19V13Z"
+            />
+          </svg>
+        </button>
+        <div
+          aria-live="assertive"
+          class="cache-192mx7g eiawj1g3"
+          role="status"
+        >
+          <input
+            aria-label="Number Input"
+            class="cache-1lq3jx2 eiawj1g2"
+            id=":r9:"
+            name="test"
+            style="width: 35px;"
+            type="number"
+            value="20"
           />
-        </svg>
-      </button>
+        </div>
+        <button
+          aria-label="Plus"
+          class="cache-bkq66r eiawj1g4"
+          disabled=""
+          type="button"
+        >
+          <svg
+            class="cache-xmmyxm-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </form>
 </DocumentFragment>
@@ -566,7 +650,30 @@ exports[`NumberInputField should trigger event onMinCrossed & onMaxCrossed 1`] =
 
 exports[`NumberInputField should trigger events correctly 1`] = `
 <DocumentFragment>
-  .cache-od36vv {
+  .cache-kwbqjp {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-od36vv {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -685,51 +792,56 @@ exports[`NumberInputField should trigger events correctly 1`] = `
     novalidate=""
   >
     <div
-      aria-disabled="false"
-      class="cache-od36vv eiawj1g0"
+      class="cache-kwbqjp e1sgck4o0"
     >
-      <button
-        aria-label="Minus"
-        class="cache-1mh6k42 eiawj1g4"
-        type="button"
-      >
-        <svg
-          class="cache-18ka304-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19,13H5V11H19V13Z"
-          />
-        </svg>
-      </button>
       <div
-        aria-live="assertive"
-        class="cache-192mx7g eiawj1g3"
-        role="status"
+        aria-disabled="false"
+        class="cache-od36vv eiawj1g0"
       >
-        <input
-          aria-label="Input"
-          class="cache-1lq3jx2 eiawj1g2"
-          name="test"
-          style="width: 35px;"
-          type="number"
-          value="10"
-        />
-      </div>
-      <button
-        aria-label="Plus"
-        class="cache-1mh6k42 eiawj1g4"
-        type="button"
-      >
-        <svg
-          class="cache-18ka304-sizeStyles etwatq50"
-          viewBox="0 0 24 24"
+        <button
+          aria-label="Minus"
+          class="cache-1mh6k42 eiawj1g4"
+          type="button"
         >
-          <path
-            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          <svg
+            class="cache-18ka304-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H5V11H19V13Z"
+            />
+          </svg>
+        </button>
+        <div
+          aria-live="assertive"
+          class="cache-192mx7g eiawj1g3"
+          role="status"
+        >
+          <input
+            aria-label="Number Input"
+            class="cache-1lq3jx2 eiawj1g2"
+            id=":r6:"
+            name="test"
+            style="width: 35px;"
+            type="number"
+            value="10"
           />
-        </svg>
-      </button>
+        </div>
+        <button
+          aria-label="Plus"
+          class="cache-1mh6k42 eiawj1g4"
+          type="button"
+        >
+          <svg
+            class="cache-18ka304-sizeStyles etwatq50"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
   </form>
 </DocumentFragment>

--- a/packages/form/src/components/NumberInputField/__tests__/index.spec.tsx
+++ b/packages/form/src/components/NumberInputField/__tests__/index.spec.tsx
@@ -19,7 +19,7 @@ describe('NumberInputField', () => {
       <NumberInputField name="test" value={10} disabled />,
       {
         transform: () => {
-          const input = screen.getByLabelText('Input')
+          const input = screen.getByLabelText('Number Input')
           expect(input).toBeDisabled()
 
           const inputMinus = screen.getByLabelText('Minus')
@@ -51,7 +51,7 @@ describe('NumberInputField', () => {
       </Form>,
       {
         transform: () => {
-          const input = screen.getByLabelText('Input')
+          const input = screen.getByLabelText('Number Input')
           act(() => {
             input.focus()
           })
@@ -91,7 +91,8 @@ describe('NumberInputField', () => {
       </Form>,
       {
         transform: async () => {
-          const input = screen.getByLabelText<HTMLTextAreaElement>('Input')
+          const input =
+            screen.getByLabelText<HTMLTextAreaElement>('Number Input')
           // eslint-disable-next-line testing-library/no-node-access
           if (input.parentElement) await userEvent.click(input.parentElement)
 

--- a/packages/form/src/components/ToggleField/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/ToggleField/__tests__/__snapshots__/index.spec.tsx.snap
@@ -125,9 +125,8 @@ exports[`ToggleField should render correctly 1`] = `
       >
         <input
           aria-checked="false"
-          aria-label="test"
           class="cache-p9zju0 e6hn8de1"
-          id="test"
+          id=":r0:"
           name="test"
           type="checkbox"
         />
@@ -262,10 +261,9 @@ exports[`ToggleField should render correctly checked 1`] = `
       >
         <input
           aria-checked="true"
-          aria-label="test"
           checked=""
           class="cache-p9zju0 e6hn8de1"
-          id="test"
+          id=":r4:"
           name="test"
           type="checkbox"
         />
@@ -400,10 +398,9 @@ exports[`ToggleField should render correctly disabled 1`] = `
       >
         <input
           aria-checked="false"
-          aria-label="test"
           class="cache-p9zju0 e6hn8de1"
           disabled=""
-          id="test"
+          id=":r2:"
           name="test"
           type="checkbox"
         />
@@ -538,10 +535,9 @@ exports[`ToggleField should render correctly with label and checked 1`] = `
       >
         <input
           aria-checked="true"
-          aria-label="test"
           checked=""
           class="cache-p9zju0 e6hn8de1"
-          id="test"
+          id=":r6:"
           name="test"
           type="checkbox"
         />

--- a/packages/ui/src/__tests__/a11y.test.tsx
+++ b/packages/ui/src/__tests__/a11y.test.tsx
@@ -29,7 +29,14 @@ const testedComponents = [
   'Tag',
   'TagInput',
   'TextInput',
+  'Tooltip',
   'Radio',
+  'VerificationCode',
+  'DatInput',
+  'NumberInput',
+  'Toggle',
+  'Snippet',
+  'SwitchButton',
 ]
 
 const foundFiles: string[] = []

--- a/packages/ui/src/__tests__/a11y.test.tsx
+++ b/packages/ui/src/__tests__/a11y.test.tsx
@@ -41,7 +41,11 @@ const testedComponents = [
 
 const foundFiles: string[] = []
 
-const searchFileFromDir = (startPath: string, filter: string) => {
+const searchFileFromDir = (
+  startPath: string,
+  filter: string,
+  exclude?: string[],
+) => {
   const files = fs.readdirSync(startPath)
 
   for (const fileName of files) {
@@ -50,8 +54,11 @@ const searchFileFromDir = (startPath: string, filter: string) => {
 
     if (stat.isDirectory()) {
       // recursive search in case if directory
-      searchFileFromDir(filePath, filter)
-    } else if (filePath.includes(filter)) {
+      searchFileFromDir(filePath, filter, exclude)
+    } else if (
+      filePath.includes(filter) &&
+      !exclude?.find(e => filePath.includes(e))
+    ) {
       const isTested = testedComponents.some(component =>
         filePath.match(`^packages/ui/src/components/${component}/`),
       )
@@ -64,9 +71,12 @@ const searchFileFromDir = (startPath: string, filter: string) => {
 }
 // Check if a path was given as input argument, if not we check all stories
 if (process.argv[4]) {
-  searchFileFromDir(process.argv[4], '.stories.tsx')
+  searchFileFromDir(process.argv[4], '.stories.tsx', ['index', 'Template'])
 } else {
-  searchFileFromDir('packages/ui/src/components', '.stories.tsx')
+  searchFileFromDir('packages/ui/src/components', '.stories.tsx', [
+    'index',
+    'Template',
+  ])
 }
 
 expect.extend(toHaveNoViolations)

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
@@ -53,6 +53,7 @@ exports[`CopyButton renders correctly 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-16ljkze-StyledButton e1go4oa30"
       type="button"
     >
@@ -122,6 +123,7 @@ exports[`CopyButton renders correctly variant large 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-r06x4m-StyledButton e1go4oa30"
       type="button"
     >
@@ -191,6 +193,7 @@ exports[`CopyButton renders correctly variant neutral 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-xsw6vc-StyledButton e1go4oa30"
       type="button"
     >
@@ -260,6 +263,7 @@ exports[`CopyButton renders correctly variant primary 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-16ljkze-StyledButton e1go4oa30"
       type="button"
     >
@@ -329,6 +333,7 @@ exports[`CopyButton renders correctly variant small 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-16ljkze-StyledButton e1go4oa30"
       type="button"
     >
@@ -398,6 +403,7 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="custom-class cache-16ljkze-StyledButton e1go4oa30"
       type="button"
     >
@@ -467,6 +473,7 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-16ljkze-StyledButton e1go4oa30"
       type="button"
     >
@@ -536,6 +543,7 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-16ljkze-StyledButton e1go4oa30"
       type="button"
     >
@@ -605,6 +613,7 @@ exports[`CopyButton renders correctly with no border 1`] = `
     tabindex="0"
   >
     <button
+      aria-label="Copy"
       class="cache-1gy37wj-StyledButton e1go4oa30"
       type="button"
     >

--- a/packages/ui/src/components/CopyButton/index.tsx
+++ b/packages/ui/src/components/CopyButton/index.tsx
@@ -79,6 +79,7 @@ export const CopyButton = ({
         noBorder={noBorder}
         className={className}
         data-testid={dataTestId}
+        aria-label="Copy"
       >
         <Icon name={isCopied ? 'check' : 'copy-content'} size={16} />
       </StyledButton>

--- a/packages/ui/src/components/EmptyState/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/EmptyState/__stories__/index.stories.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@scaleway/ui'
 import type { ComponentMeta, Story } from '@storybook/react'
 import type { ComponentProps } from 'react'
 import { EmptyState } from '..'
+import { Button } from '../../Button'
 import kapsuleLogo from '../illustrations/kapsule.webp'
 import errorImg from '../illustrations/product-error.svg'
 

--- a/packages/ui/src/components/NumberInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/NumberInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,30 @@
 
 exports[`NumberInput should click on center button 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -118,58 +141,86 @@ exports[`NumberInput should click on center button 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="10"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":ri:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="10"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should click on min button 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -285,58 +336,86 @@ exports[`NumberInput should click on min button 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="8"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":rl:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="8"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should click on plus button with a step value 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -452,58 +531,86 @@ exports[`NumberInput should click on plus button with a step value 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="30"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":ro:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="30"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should click on plus button with a step value and an in-between value set 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -619,58 +726,86 @@ exports[`NumberInput should click on plus button with a step value and an in-bet
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="30"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r17:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="30"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should focus input and modify value 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -786,58 +921,86 @@ exports[`NumberInput should focus input and modify value 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="10"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":rr:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="10"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should focus input and modify value onMaxCrossed 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -976,59 +1139,87 @@ exports[`NumberInput should focus input and modify value onMaxCrossed 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 45px;"
-        type="number"
-        value="100"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r11:"
+          name="numberinput"
+          style="width: 45px;"
+          type="number"
+          value="100"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
+      >
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should focus input and modify value onMinCrossed 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1167,59 +1358,87 @@ exports[`NumberInput should focus input and modify value onMinCrossed 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="10"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":ru:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="10"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should increase and decrease input with arrow up and down 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1358,59 +1577,87 @@ exports[`NumberInput should increase and decrease input with arrow up and down 1
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 45px;"
-        type="number"
-        value="30"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r14:"
+          name="numberinput"
+          style="width: 45px;"
+          type="number"
+          value="30"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
+      >
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should not changed controlled value on click min button 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1526,58 +1773,86 @@ exports[`NumberInput should not changed controlled value on click min button 1`]
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="10"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r1d:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="10"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should renders correctly 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1724,64 +1999,92 @@ exports[`NumberInput should renders correctly 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="0"
-      />
-      <span
-        class="cache-1qlmcqr-StyledText eiawj1g1"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        unit
-      </span>
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r0:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="0"
         />
-      </svg>
-    </button>
+        <span
+          class="cache-1qlmcqr-StyledText eiawj1g1"
+        >
+          unit
+        </span>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should renders correctly disabled 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1905,66 +2208,94 @@ exports[`NumberInput should renders correctly disabled 1`] = `
 }
 
 <div
-    aria-disabled="true"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="true"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
         disabled=""
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="0"
-      />
-      <span
-        class="cache-1uero4z-StyledText eiawj1g1"
+        type="button"
       >
-        unit
-      </span>
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          disabled=""
+          id=":r3:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="0"
         />
-      </svg>
-    </button>
+        <span
+          class="cache-1uero4z-StyledText eiawj1g1"
+        >
+          unit
+        </span>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
+      >
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should renders correctly max value 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2111,64 +2442,92 @@ exports[`NumberInput should renders correctly max value 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="0"
-      />
-      <span
-        class="cache-1qlmcqr-StyledText eiawj1g1"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        unit
-      </span>
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r9:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="0"
         />
-      </svg>
-    </button>
+        <span
+          class="cache-1qlmcqr-StyledText eiawj1g1"
+        >
+          unit
+        </span>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should renders correctly min value 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2315,64 +2674,92 @@ exports[`NumberInput should renders correctly min value 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="0"
-      />
-      <span
-        class="cache-1qlmcqr-StyledText eiawj1g1"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        unit
-      </span>
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r6:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="0"
         />
-      </svg>
-    </button>
+        <span
+          class="cache-1qlmcqr-StyledText eiawj1g1"
+        >
+          unit
+        </span>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should renders large size 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2511,59 +2898,87 @@ exports[`NumberInput should renders large size 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="0"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":rc:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="0"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should renders small size 1`] = `
 <DocumentFragment>
-  .cache-1o444ku-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-1o444ku-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2702,59 +3117,87 @@ exports[`NumberInput should renders small size 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-1o444ku-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1tuarzc-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-10fgw5z-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-1o444ku-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 25px;"
-        type="number"
-        value="0"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-3wctzm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-1tuarzc-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-10fgw5z-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":rf:"
+          name="numberinput"
+          style="width: 25px;"
+          type="number"
+          value="0"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-3wctzm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should use maxValue instead of defaultValue if default value is higher than maxValue 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2893,59 +3336,87 @@ exports[`NumberInput should use maxValue instead of defaultValue if default valu
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 45px;"
-        type="number"
-        value="100"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r1m:"
+          name="numberinput"
+          style="width: 45px;"
+          type="number"
+          value="100"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
+      >
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should use minValue instead of defaultValue if default value is lower than minValue 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3084,59 +3555,87 @@ exports[`NumberInput should use minValue instead of defaultValue if default valu
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-asskgt-StyledSelectButton eiawj1g4"
-      disabled=""
-      type="button"
-    >
-      <svg
-        class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="20"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-asskgt-StyledSelectButton eiawj1g4"
+        disabled=""
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-1g7yqhm-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r1j:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="20"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;
 
 exports[`NumberInput should use the defaultValue 1`] = `
 <DocumentFragment>
-  .cache-101r5xn-StyledContainer {
+  .cache-7hpczr-Stack {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 8px;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
+.cache-101r5xn-StyledContainer {
   background-color: #ffffff;
   display: -webkit-box;
   display: -webkit-flex;
@@ -3252,51 +3751,56 @@ exports[`NumberInput should use the defaultValue 1`] = `
 }
 
 <div
-    aria-disabled="false"
-    class="cache-101r5xn-StyledContainer eiawj1g0"
+    class="cache-7hpczr-Stack e1sgck4o0"
   >
-    <button
-      aria-label="Minus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M19,13H5V11H19V13Z"
-        />
-      </svg>
-    </button>
     <div
-      aria-live="assertive"
-      class="cache-3i90o1-StyledCenterBox eiawj1g3"
-      role="status"
+      aria-disabled="false"
+      class="cache-101r5xn-StyledContainer eiawj1g0"
     >
-      <input
-        aria-label="Input"
-        class="cache-kk0u3u-StyledInput eiawj1g2"
-        name="numberinput"
-        style="width: 35px;"
-        type="number"
-        value="10"
-      />
-    </div>
-    <button
-      aria-label="Plus"
-      class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
-      type="button"
-    >
-      <svg
-        class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
-        viewBox="0 0 24 24"
+      <button
+        aria-label="Minus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
       >
-        <path
-          d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H5V11H19V13Z"
+          />
+        </svg>
+      </button>
+      <div
+        aria-live="assertive"
+        class="cache-3i90o1-StyledCenterBox eiawj1g3"
+        role="status"
+      >
+        <input
+          aria-label="Number Input"
+          class="cache-kk0u3u-StyledInput eiawj1g2"
+          id=":r1g:"
+          name="numberinput"
+          style="width: 35px;"
+          type="number"
+          value="10"
         />
-      </svg>
-    </button>
+      </div>
+      <button
+        aria-label="Plus"
+        class="cache-1h5w6a8-StyledSelectButton eiawj1g4"
+        type="button"
+      >
+        <svg
+          class="cache-19qo8zl-StyledIcon-sizeStyles etwatq50"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/packages/ui/src/components/NumberInput/__tests__/index.test.tsx
+++ b/packages/ui/src/components/NumberInput/__tests__/index.test.tsx
@@ -47,7 +47,7 @@ describe('NumberInput', () => {
       <NumberInput minValue={0} step={1} maxValue={100} defaultValue={10} />,
       {
         transform: async () => {
-          const inputButton = screen.getByLabelText('Input')
+          const inputButton = screen.getByLabelText('Number Input')
           const input = screen.getByRole<HTMLInputElement>('spinbutton')
 
           await userEvent.click(inputButton)
@@ -101,7 +101,7 @@ describe('NumberInput', () => {
       <NumberInput minValue={0} step={10} maxValue={100} defaultValue={10} />,
       {
         transform: async () => {
-          const buttonContainer = screen.getByLabelText('Input')
+          const buttonContainer = screen.getByLabelText('Number Input')
           const input = screen.getByRole<HTMLInputElement>('spinbutton')
 
           await userEvent.click(buttonContainer)

--- a/packages/ui/src/components/NumberInput/index.tsx
+++ b/packages/ui/src/components/NumberInput/index.tsx
@@ -8,9 +8,11 @@ import type {
   MutableRefObject,
   ReactNode,
 } from 'react'
-import { useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import parseIntOr from '../../helpers/numbers'
 import { Icon } from '../Icon'
+import { Stack } from '../Stack'
+import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
 
 const bounded = (value: number, min: number, max: number) =>
@@ -163,6 +165,10 @@ type NumberInputProps = {
   disabledTooltip?: string
   className?: string
   'data-testid'?: string
+  label?: string
+  'aria-label'?: string
+  'aria-describedby'?: string
+  id?: string
 } & Omit<
   InputHTMLAttributes<HTMLInputElement>,
   'size' | 'onChange' | 'value' | 'defaultValue'
@@ -185,10 +191,16 @@ export const NumberInput = ({
   value,
   disabledTooltip,
   className,
+  label,
+  id,
+  'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
   'data-testid': dataTestId,
 }: NumberInputProps) => {
   const inputRef =
     useRef<HTMLInputElement>() as MutableRefObject<HTMLInputElement>
+
+  const uniqueId = useId()
 
   // local state used if component is not controlled (no value prop provided)
   const [inputValue, setInputValue] = useState(() => {
@@ -290,75 +302,84 @@ export const NumberInput = ({
   const isPlusDisabled = (maxValue && plusRoundedValue > maxValue) || disabled
 
   return (
-    <StyledContainer
-      aria-disabled={disabled}
-      size={size}
-      className={className}
-      data-testid={dataTestId}
-    >
-      <Tooltip text={isMinusDisabled && disabledTooltip}>
-        <StyledSelectButton
-          onClick={offsetFn(-1)}
-          disabled={isMinusDisabled}
-          aria-label="Minus"
-          type="button"
-        >
-          <Icon
-            name="minus"
-            size={iconSizes[size]}
-            color="primary"
-            disabled={isMinusDisabled}
-          />
-        </StyledSelectButton>
-      </Tooltip>
-
-      <StyledCenterBox
+    <Stack gap={1}>
+      {label ? (
+        <Text variant="bodyStrong" as="label" htmlFor={id || uniqueId}>
+          {label}
+        </Text>
+      ) : null}
+      <StyledContainer
+        aria-disabled={disabled}
         size={size}
-        onClick={() => {
-          if (inputRef?.current) {
-            inputRef.current.focus()
-          }
-        }}
-        aria-live="assertive"
-        role="status"
+        className={className}
+        data-testid={dataTestId}
       >
-        <StyledInput
-          disabled={disabled}
-          name={name}
-          onBlur={handleOnBlur}
-          onChange={handleChange}
-          onFocus={handleOnFocus}
-          onKeyDown={onKeyDown}
-          ref={inputRef}
-          style={{
-            width: currentValue.toString().length * 10 + 15,
-          }}
-          value={currentValue.toString()} // A dom element can only have string attributes.
-          aria-label="Input"
-          type="number"
-        />
-        {typeof text === 'string' ? (
-          <StyledText disabled={disabled}>{text}</StyledText>
-        ) : (
-          text
-        )}
-      </StyledCenterBox>
+        <Tooltip text={isMinusDisabled && disabledTooltip}>
+          <StyledSelectButton
+            onClick={offsetFn(-1)}
+            disabled={isMinusDisabled}
+            aria-label="Minus"
+            type="button"
+          >
+            <Icon
+              name="minus"
+              size={iconSizes[size]}
+              color="primary"
+              disabled={isMinusDisabled}
+            />
+          </StyledSelectButton>
+        </Tooltip>
 
-      <Tooltip text={isPlusDisabled && disabledTooltip}>
-        <StyledSelectButton
-          onClick={offsetFn(1)}
-          disabled={isPlusDisabled}
-          aria-label="Plus"
-          type="button"
+        <StyledCenterBox
+          size={size}
+          onClick={() => {
+            if (inputRef?.current) {
+              inputRef.current.focus()
+            }
+          }}
+          aria-live="assertive"
+          role="status"
         >
-          <Icon
-            name="plus"
-            size={iconSizes[size]}
-            color="primary"
-            disabled={isPlusDisabled}
+          <StyledInput
+            disabled={disabled}
+            name={name}
+            onBlur={handleOnBlur}
+            onChange={handleChange}
+            onFocus={handleOnFocus}
+            onKeyDown={onKeyDown}
+            ref={inputRef}
+            style={{
+              width: currentValue.toString().length * 10 + 15,
+            }}
+            value={currentValue.toString()} // A dom element can only have string attributes.
+            type="number"
+            id={id || uniqueId}
+            aria-label={!label && !ariaLabel ? 'Number Input' : ariaLabel}
+            aria-describedby={ariaDescribedBy}
           />
-        </StyledSelectButton>
-      </Tooltip>
-    </StyledContainer>
+          {typeof text === 'string' ? (
+            <StyledText disabled={disabled}>{text}</StyledText>
+          ) : (
+            text
+          )}
+        </StyledCenterBox>
+
+        <Tooltip text={isPlusDisabled && disabledTooltip}>
+          <StyledSelectButton
+            onClick={offsetFn(1)}
+            disabled={isPlusDisabled}
+            aria-label="Plus"
+            type="button"
+          >
+            <Icon
+              name="plus"
+              size={iconSizes[size]}
+              color="primary"
+              disabled={isPlusDisabled}
+            />
+          </StyledSelectButton>
+        </Tooltip>
+      </StyledContainer>
+    </Stack>
   )
 }

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`Snippet renders correctly 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -409,6 +410,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -427,6 +429,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
+          aria-label="Show more"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -705,6 +708,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -723,6 +727,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
+          aria-label="Show more"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -1002,6 +1007,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -1020,6 +1026,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
+          aria-label="Show more"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -1193,6 +1200,7 @@ exports[`Snippet renders correctly with copiedText 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -1362,6 +1370,7 @@ exports[`Snippet renders correctly with copyText 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -1621,6 +1630,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -1639,6 +1649,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
+          aria-label="Show more"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -1902,6 +1913,7 @@ exports[`Snippet renders correctly with showText 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -1920,6 +1932,7 @@ exports[`Snippet renders correctly with showText 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
+          aria-label="Show more"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -2108,6 +2121,7 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -2293,6 +2307,7 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -2552,6 +2567,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
           tabindex="0"
         >
           <button
+            aria-label="Copy"
             class="cache-1nnm9m7-StyledButton e1go4oa30"
             type="button"
           >
@@ -2570,6 +2586,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
         class="cache-1ucxira-ShowMoreContainer eryi49r3"
       >
         <button
+          aria-label="Show more"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -429,7 +429,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
-          aria-label="Show more"
+          aria-expanded="false"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -727,7 +727,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
-          aria-label="Show more"
+          aria-expanded="false"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -1026,7 +1026,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
-          aria-label="Show more"
+          aria-expanded="false"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -1649,7 +1649,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
-          aria-label="Show more"
+          aria-expanded="false"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -1932,7 +1932,7 @@ exports[`Snippet renders correctly with showText 1`] = `
         class="cache-1qk694q-ShowMoreContainer eryi49r3"
       >
         <button
-          aria-label="Show more"
+          aria-expanded="false"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >
@@ -2586,7 +2586,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
         class="cache-1ucxira-ShowMoreContainer eryi49r3"
       >
         <button
-          aria-label="Show more"
+          aria-expanded="true"
           class="cache-eg7v1i-StyledButton eryi49r2"
           type="button"
         >

--- a/packages/ui/src/components/Snippet/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Snippet/__tests__/index.test.tsx
@@ -64,7 +64,7 @@ describe('Snippet', () => {
   it('should click on extend button to display full content on ', () =>
     shouldMatchEmotionSnapshot(<Snippet>{TEST_VALUE_MULTILINE}</Snippet>, {
       transform: async () => {
-        await userEvent.click(screen.getByRole('button', { name: 'Show' }))
+        await userEvent.click(screen.getByLabelText('Show more'))
       },
     }))
 })

--- a/packages/ui/src/components/Snippet/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Snippet/__tests__/index.test.tsx
@@ -64,7 +64,7 @@ describe('Snippet', () => {
   it('should click on extend button to display full content on ', () =>
     shouldMatchEmotionSnapshot(<Snippet>{TEST_VALUE_MULTILINE}</Snippet>, {
       transform: async () => {
-        await userEvent.click(screen.getByLabelText('Show more'))
+        await userEvent.click(screen.getByRole('button', { name: 'Show' }))
       },
     }))
 })

--- a/packages/ui/src/components/Snippet/index.tsx
+++ b/packages/ui/src/components/Snippet/index.tsx
@@ -220,12 +220,15 @@ export const Snippet = ({
             copiedText={copiedText}
             noBorder
             variant="neutral"
-            aria-label="Copy code snippet"
           />
         </ButtonContainer>
         {hasShowMoreButton ? (
           <ShowMoreContainer showMore={showMore}>
-            <StyledButton type="button" onClick={() => setShowMore(!showMore)}>
+            <StyledButton
+              type="button"
+              onClick={() => setShowMore(!showMore)}
+              aria-label="Show more"
+            >
               <AlignCenterText as="span" variant="bodySmallStrong">
                 {showMore ? hideText : showText}
                 &nbsp;

--- a/packages/ui/src/components/Snippet/index.tsx
+++ b/packages/ui/src/components/Snippet/index.tsx
@@ -227,7 +227,7 @@ export const Snippet = ({
             <StyledButton
               type="button"
               onClick={() => setShowMore(!showMore)}
-              aria-label="Show more"
+              aria-expanded={showMore}
             >
               <AlignCenterText as="span" variant="bodySmallStrong">
                 {showMore ? hideText : showText}

--- a/packages/ui/src/components/Snippet/index.tsx
+++ b/packages/ui/src/components/Snippet/index.tsx
@@ -220,6 +220,7 @@ export const Snippet = ({
             copiedText={copiedText}
             noBorder
             variant="neutral"
+            aria-label="Copy code snippet"
           />
         </ButtonContainer>
         {hasShowMoreButton ? (

--- a/packages/ui/src/components/Toggle/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/Template.stories.tsx
@@ -2,5 +2,5 @@ import type { ComponentStory } from '@storybook/react'
 import { Toggle } from '..'
 
 export const Template: ComponentStory<typeof Toggle> = args => (
-  <Toggle {...args} />
+  <Toggle label="Option 1" {...args} />
 )

--- a/packages/ui/src/components/Toggle/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Toggle/__tests__/__snapshots__/index.test.tsx.snap
@@ -122,9 +122,8 @@ exports[`Toggle renders correctly 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":r0:"
         name="test"
         type="checkbox"
       />
@@ -255,9 +254,8 @@ exports[`Toggle renders correctly label 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":rc:"
         name="test"
         type="checkbox"
       />
@@ -389,10 +387,9 @@ exports[`Toggle renders correctly when checked 1`] = `
     >
       <input
         aria-checked="true"
-        aria-label="test"
         checked=""
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":r2:"
         name="test"
         type="checkbox"
       />
@@ -523,10 +520,9 @@ exports[`Toggle renders correctly when disabled 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
         disabled=""
-        id="test"
+        id=":r4:"
         name="test"
         type="checkbox"
       />
@@ -666,9 +662,8 @@ exports[`Toggle renders correctly when required with label 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":r6:"
         name="test"
         type="checkbox"
       />
@@ -830,9 +825,8 @@ exports[`Toggle renders correctly when required with label left 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":r8:"
         name="test"
         type="checkbox"
       />
@@ -963,9 +957,8 @@ exports[`Toggle renders correctly with complex label 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":ri:"
         name="test"
         type="checkbox"
       />
@@ -1099,9 +1092,8 @@ exports[`Toggle renders correctly with custom labels on right 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":rg:"
         name="test"
         type="checkbox"
       />
@@ -1234,9 +1226,8 @@ exports[`Toggle renders correctly with labels on left 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":re:"
         name="test"
         type="checkbox"
       />
@@ -1367,9 +1358,8 @@ exports[`Toggle renders correctly with non default size 1`] = `
     >
       <input
         aria-checked="false"
-        aria-label="test"
         class="cache-1myp2ct-StyledCheckbox e6hn8de1"
-        id="test"
+        id=":ra:"
         name="test"
         type="checkbox"
       />

--- a/packages/ui/src/components/Toggle/index.tsx
+++ b/packages/ui/src/components/Toggle/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import type { ChangeEvent, ChangeEventHandler, ReactNode, Ref } from 'react'
-import { forwardRef, useCallback, useEffect, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useId, useState } from 'react'
 import { Icon } from '../Icon'
 import { Tooltip } from '../Tooltip'
 
@@ -157,6 +157,7 @@ export const Toggle = forwardRef(
     ref: Ref<HTMLInputElement>,
   ) => {
     const [state, setState] = useState(checked)
+    const uniqueId = useId()
 
     const onLocalChange = useCallback(
       (event: ChangeEvent<HTMLInputElement>) => {
@@ -191,8 +192,7 @@ export const Toggle = forwardRef(
             data-disabled={disabled}
           >
             <StyledCheckbox
-              id={id || name}
-              aria-label={name}
+              id={id || uniqueId}
               checked={state}
               aria-checked={state}
               disabled={disabled}

--- a/packages/ui/src/components/VerificationCode/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/Template.stories.tsx
@@ -3,4 +3,4 @@ import { VerificationCode } from '..'
 
 export const Template: ComponentStory<typeof VerificationCode> = ({
   ...props
-}) => <VerificationCode inputId="verification-code-input" {...props} />
+}) => <VerificationCode {...props} />

--- a/packages/ui/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/VerificationCode/__tests__/__snapshots__/index.tsx.snap
@@ -49,9 +49,10 @@ exports[`VerificationCode renders correctly with default values 1`] = `
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r0:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -59,9 +60,10 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r0:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -69,9 +71,10 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r0:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -79,9 +82,10 @@ exports[`VerificationCode renders correctly with default values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r0:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -140,9 +144,10 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r1:-0"
       pattern="[0-9]*"
       placeholder="0"
       type="tel"
@@ -150,9 +155,10 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r1:-1"
       pattern="[0-9]*"
       placeholder="0"
       type="tel"
@@ -160,9 +166,10 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r1:-2"
       pattern="[0-9]*"
       placeholder="3"
       type="tel"
@@ -170,9 +177,10 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r1:-3"
       pattern="[0-9]*"
       placeholder="7"
       type="tel"
@@ -180,9 +188,10 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 4"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="4"
-      id="verification-code-4"
+      id=":r1:-4"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -190,9 +199,10 @@ exports[`VerificationCode renders correctly with initial value and placeholder a
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 5"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="5"
-      id="verification-code-5"
+      id=":r1:-5"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -251,9 +261,10 @@ exports[`VerificationCode should handle and replace non number with "" when type
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r4:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -261,9 +272,10 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r4:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -271,9 +283,10 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r4:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -281,9 +294,10 @@ exports[`VerificationCode should handle and replace non number with "" when type
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r4:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -342,9 +356,10 @@ exports[`VerificationCode should handle error 1`] = `
 <div>
     <input
       aria-invalid="true"
+      aria-label="Verification code 0"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r9:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -352,9 +367,10 @@ exports[`VerificationCode should handle error 1`] = `
     />
     <input
       aria-invalid="true"
+      aria-label="Verification code 1"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r9:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -362,9 +378,10 @@ exports[`VerificationCode should handle error 1`] = `
     />
     <input
       aria-invalid="true"
+      aria-label="Verification code 2"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r9:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -372,9 +389,10 @@ exports[`VerificationCode should handle error 1`] = `
     />
     <input
       aria-invalid="true"
+      aria-label="Verification code 3"
       class="cache-3q3dda-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r9:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -433,9 +451,10 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r2:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -443,9 +462,10 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r2:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -453,9 +473,10 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r2:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -463,9 +484,10 @@ exports[`VerificationCode should handle keyDown and special key cases and focus/
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r2:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -524,54 +546,60 @@ exports[`VerificationCode should handle paste when type is not number 1`] = `
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r7:-0"
       placeholder=""
       type="text"
       value="1"
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r7:-1"
       placeholder=""
       type="text"
       value="h"
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r7:-2"
       placeholder=""
       type="text"
       value="2"
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r7:-3"
       placeholder=""
       type="text"
       value="3"
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 4"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="4"
-      id="verification-code-4"
+      id=":r7:-4"
       placeholder=""
       type="text"
       value="a"
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 5"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="5"
-      id="verification-code-5"
+      id=":r7:-5"
       placeholder=""
       type="text"
       value="*"
@@ -629,9 +657,10 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r3:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -639,9 +668,10 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r3:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -649,9 +679,10 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r3:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -659,9 +690,10 @@ exports[`VerificationCode should handle paste with no overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r3:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -720,9 +752,10 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r5:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -730,9 +763,10 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r5:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -740,9 +774,10 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r5:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -750,9 +785,10 @@ exports[`VerificationCode should handle paste with overflowing values 1`] = `
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r5:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -811,9 +847,10 @@ exports[`VerificationCode should handle paste with overflowing values at differe
 <div>
     <input
       aria-invalid="false"
+      aria-label="Verification code 0"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="0"
-      id="verification-code-0"
+      id=":r6:-0"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -821,9 +858,10 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 1"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="1"
-      id="verification-code-1"
+      id=":r6:-1"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -831,9 +869,10 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 2"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="2"
-      id="verification-code-2"
+      id=":r6:-2"
       pattern="[0-9]*"
       placeholder=""
       type="tel"
@@ -841,9 +880,10 @@ exports[`VerificationCode should handle paste with overflowing values at differe
     />
     <input
       aria-invalid="false"
+      aria-label="Verification code 3"
       class="cache-uxqmnp-StyledInput-VerificationCode e1odpyad0"
       data-testid="3"
-      id="verification-code-3"
+      id=":r6:-3"
       pattern="[0-9]*"
       placeholder=""
       type="tel"

--- a/packages/ui/src/components/VerificationCode/index.tsx
+++ b/packages/ui/src/components/VerificationCode/index.tsx
@@ -5,7 +5,7 @@ import type {
   FocusEventHandler,
   KeyboardEventHandler,
 } from 'react'
-import { createRef, useState } from 'react'
+import { createRef, useId, useState } from 'react'
 
 const StyledInput = styled.input`
   background: ${({ theme }) => theme.colors.neutral.backgroundWeak};
@@ -79,6 +79,7 @@ type VerificationCodeProps = {
    */
   type?: 'text' | 'number'
   'data-testid'?: string
+  'aria-label'?: string
 }
 
 const DEFAULT_ON_FUNCTION = () => {}
@@ -89,7 +90,7 @@ export const VerificationCode = ({
   error = false,
   fields = 4,
   initialValue = '',
-  inputId = 'verification-code',
+  inputId,
   inputStyle = '',
   onChange = DEFAULT_ON_FUNCTION,
   onComplete = DEFAULT_ON_FUNCTION,
@@ -97,7 +98,9 @@ export const VerificationCode = ({
   required = false,
   type = 'number',
   'data-testid': dataTestId,
+  'aria-label': ariaLabel = 'Verification code',
 }: VerificationCodeProps): JSX.Element => {
+  const uniqueId = useId()
   const valuesArray = Object.assign(
     new Array(fields).fill(''),
     initialValue.substring(0, fields).split(''),
@@ -233,10 +236,10 @@ export const VerificationCode = ({
           type={type === 'number' ? 'tel' : type}
           pattern={type === 'number' ? '[0-9]*' : undefined}
           // eslint-disable-next-line react/no-array-index-key
-          key={`${inputId}-${index}`}
+          key={index}
           data-testid={index}
           value={value}
-          id={inputId ? `${inputId}-${index}` : undefined}
+          id={`${inputId || uniqueId}-${index}`}
           ref={inputRefs[index]}
           onChange={inputOnChange(index)}
           onKeyDown={inputOnKeyDown(index)}
@@ -245,6 +248,7 @@ export const VerificationCode = ({
           disabled={disabled}
           required={required}
           placeholder={placeholder?.[index] ?? ''}
+          aria-label={`${ariaLabel} ${index}`}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

- Add unique `id` into `<Toggle />` component
- Add `aria-label` into `<Snippet />` component on copy button
- Add unique `id` into `<VerificationCode />` component
- Add `label`, `aria-label` and `aria-labelledby` into `<NumberInput />` component
- Enable a11y testing on:  Tooltip, VerificationCode, DatInput, NumberInput, Toggle, Snippet, SwitchButton
