### PR TITLE
fix(Alert): show close button when on close is given

### DIFF
--- a/.changeset/nasty-seas-bake.md
+++ b/.changeset/nasty-seas-bake.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': minor
+---
+
+Fix `<Alert />` to show close button when `onClose` is given

--- a/packages/ui/src/components/Alert/index.tsx
+++ b/packages/ui/src/components/Alert/index.tsx
@@ -143,7 +143,7 @@ export const Alert = ({
           </StyledButton>
         ) : null}
       </WrapStack>
-      {isClosable ? (
+      {isClosable || onClose ? (
         <CloseButton
           variant="ghost"
           size="small"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Display close button when `onClose` property is given.
