### PR TITLE
fix(Charts): update barchart and linechart to have new data colors

### DIFF
--- a/.changeset/angry-crabs-relate.md
+++ b/.changeset/angry-crabs-relate.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': minor
+---
+
+Update BarChart and LineChart to have new data colors

--- a/packages/ui/src/components/BarChart/__stories__/PositiveNegative.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/PositiveNegative.stories.tsx
@@ -1,38 +1,46 @@
+import { useTheme } from '@emotion/react'
 import type { ComponentStory } from '@storybook/react'
 import { format } from 'date-fns'
 import { BarChart } from '..'
 import { barChartPositiveNegativeData } from './mockData'
 
-export const PositiveNegative: ComponentStory<typeof BarChart> = props => (
-  <BarChart
-    {...props}
-    height={200}
-    data={barChartPositiveNegativeData}
-    axisFormatters={{
-      bottom: value => format(new Date(value), 'dd-MM-Y'),
-      left: value => {
-        if (value === 1) return 'Active'
-        if (value === -1) return 'Inactive'
+export const PositiveNegative: ComponentStory<typeof BarChart> = props => {
+  const theme = useTheme()
 
-        return ''
-      },
-    }}
-    tooltipFunction={({ value, indexValue, color }) => ({
-      color,
-      formattedValue: value === 1 ? 'Active' : 'Inactive',
-      indexValue: format(new Date(indexValue), 'dd-MM-Y'),
-    })}
-    tickValues={{
-      left: 10,
-    }}
-    chartProps={{
-      colors: ({ value }) => (value === 1 ? 'green' : 'red'),
-      gridYValues: [-1, 0, 1],
-      maxValue: 1,
-      minValue: -1,
-    }}
-  />
-)
+  return (
+    <BarChart
+      {...props}
+      height={200}
+      data={barChartPositiveNegativeData}
+      axisFormatters={{
+        bottom: value => format(new Date(value), 'dd-MM-Y'),
+        left: value => {
+          if (value === 1) return 'Active'
+          if (value === -1) return 'Inactive'
+
+          return ''
+        },
+      }}
+      tooltipFunction={({ value, indexValue, color }) => ({
+        color,
+        formattedValue: value === 1 ? 'Active' : 'Inactive',
+        indexValue: format(new Date(indexValue), 'dd-MM-Y'),
+      })}
+      tickValues={{
+        left: 10,
+      }}
+      chartProps={{
+        colors: ({ value }) =>
+          value === 1
+            ? theme.colors.other.data.charts.success
+            : theme.colors.other.data.charts.danger,
+        gridYValues: [-1, 0, 1],
+        maxValue: 1,
+        minValue: -1,
+      }}
+    />
+  )
+}
 
 PositiveNegative.parameters = {
   docs: {

--- a/packages/ui/src/components/BarChart/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/BarChart/__tests__/__snapshots__/index.tsx.snap
@@ -335,12 +335,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(23, 282)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="118"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -349,12 +349,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(246, 165)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="235"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -363,12 +363,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(469, 0)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="400"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -377,12 +377,12 @@ exports[`BarChart renders correctly with data 1`] = `
               transform="translate(692, 235)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="165"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -730,12 +730,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(23, 282)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="118"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -744,12 +744,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(246, 165)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="235"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -758,12 +758,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(469, 0)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="400"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -772,12 +772,12 @@ exports[`BarChart renders correctly with data transformer 1`] = `
               transform="translate(692, 235)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="165"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1566,12 +1566,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(15, 0)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1580,12 +1580,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(127, 200)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1594,12 +1594,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(239, 200)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1608,12 +1608,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(351, 0)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1622,12 +1622,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(463, 200)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1636,12 +1636,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(575, 200)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1650,12 +1650,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(687, 0)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />
@@ -1664,12 +1664,12 @@ exports[`BarChart renders correctly with negative values 1`] = `
               transform="translate(799, 200)"
             >
               <rect
-                fill="#22c8a2"
+                fill="#5e47be"
                 focusable="false"
                 height="200"
                 rx="0"
                 ry="0"
-                stroke="#22c8a2"
+                stroke="#5e47be"
                 stroke-width="0"
                 width="0"
               />

--- a/packages/ui/src/components/BarChart/index.tsx
+++ b/packages/ui/src/components/BarChart/index.tsx
@@ -52,19 +52,6 @@ export const BarChart = ({
   'data-testid': dataTestId,
 }: BarChartProps) => {
   const theme = useTheme()
-  const dataset = data?.map(d => {
-    const colors = keys?.reduce<Record<string, string>>((acc, key, index) => {
-      const colorKeyName = `${key}Color`
-      acc[colorKeyName] = getLegendColor(index, theme)
-
-      return acc
-    }, {})
-
-    return {
-      ...d,
-      ...colors,
-    }
-  })
 
   const chartTheme = {
     axis: {
@@ -100,8 +87,8 @@ export const BarChart = ({
   return (
     <div style={{ height }} className={className} data-testid={dataTestId}>
       <ResponsiveBar
-        colors={({ id, data: localData }) => String(localData[`${id}Color`])}
-        data={dataset}
+        colors={getLegendColor(theme)}
+        data={data}
         margin={margin}
         axisBottom={{
           format: axisFormatters?.bottom,

--- a/packages/ui/src/components/LineChart/CustomLegend.tsx
+++ b/packages/ui/src/components/LineChart/CustomLegend.tsx
@@ -29,7 +29,7 @@ const styles = {
       margin-left: 16px;
       width: 32px;
       height: 2px;
-      background-color: ${getLegendColor(index, theme)};
+      background-color: ${getLegendColor(theme)[index]};
     `,
   row: css`
     display: flex;

--- a/packages/ui/src/components/LineChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/LineChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -603,7 +603,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -612,7 +612,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -624,7 +624,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -636,7 +636,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -648,7 +648,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -660,7 +660,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -914,11 +914,11 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
   text-decoration: none;
 }
 
-.cache-1agnpp2-legend {
+.cache-suenwm-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #22c8a2;
+  background-color: #5e47be;
 }
 
 .cache-1igd88g-StyledText-StyledText {
@@ -1038,7 +1038,7 @@ exports[`LineChart renders correctly when chart is hovered 1`] = `
                 line chart values
               </span>
               <div
-                class="cache-1agnpp2-legend"
+                class="cache-suenwm-legend"
                 data-testid="label-lineChartSerie"
               />
             </div>
@@ -1847,19 +1847,19 @@ exports[`LineChart renders correctly when data is async 1`] = `
             <path
               d="M915,272C915,272,915,270,915,270C915,270,915,29,915,29C915,29,915,301,915,301C915,301,915,336,915,336C915,336,915,96,915,96C915,96,915,212,915,212C915,212,915,409,915,409C915,409,915,287,915,287C915,287,915,284,915,284C915,284,915,275,915,275C915,275,915,272,915,272C915,272,915,72,915,72C915,72,915,226,915,226C915,226,915,200,915,200"
               fill="none"
-              stroke="#3f6ed8"
+              stroke="#3ebd8f"
               stroke-width="2"
             />
             <path
               d="M915,281C915,281,915,299,915,299C915,299,915,272,915,272C915,272,915,328,915,328C915,328,915,339,915,339C915,339,915,78,915,78C915,78,915,200,915,200C915,200,915,255,915,255C915,255,915,299,915,299"
               fill="none"
-              stroke="#a365f6"
+              stroke="#0083e6"
               stroke-width="2"
             />
             <path
               d="M915,252C915,252,915,270,915,270C915,270,915,325,915,325C915,325,915,301,915,301C915,301,915,310,915,310C915,310,915,165,915,165C915,165,915,258,915,258C915,258,915,139,915,139C915,139,915,264,915,264C915,264,915,299,915,299"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -1868,7 +1868,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 200)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1880,7 +1880,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 226)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1892,7 +1892,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 72)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1904,7 +1904,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 272)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1916,7 +1916,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 275)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1928,7 +1928,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 284)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1940,7 +1940,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 287)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1952,7 +1952,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 409)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1964,7 +1964,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 212)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1976,7 +1976,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 96)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -1988,7 +1988,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 336)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2000,7 +2000,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 301)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2012,7 +2012,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 29)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2024,7 +2024,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 270)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2036,7 +2036,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 272)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2048,7 +2048,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2060,7 +2060,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2072,7 +2072,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2084,7 +2084,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2096,7 +2096,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2108,7 +2108,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2120,7 +2120,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2132,7 +2132,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 255)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2144,7 +2144,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 200)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2156,7 +2156,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 78)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2168,7 +2168,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 339)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2180,7 +2180,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 328)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2192,7 +2192,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 272)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2204,7 +2204,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2216,7 +2216,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 281)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2228,7 +2228,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2240,7 +2240,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2252,7 +2252,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2264,7 +2264,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2276,7 +2276,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2288,7 +2288,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2300,7 +2300,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 264)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2312,7 +2312,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 139)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2324,7 +2324,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 258)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2336,7 +2336,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 165)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2348,7 +2348,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 310)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2360,7 +2360,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 301)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2372,7 +2372,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 325)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2384,7 +2384,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 270)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2396,7 +2396,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 transform="translate(915, 252)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -2650,11 +2650,11 @@ exports[`LineChart renders correctly when data is async 1`] = `
   text-decoration: none;
 }
 
-.cache-1agnpp2-legend {
+.cache-suenwm-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #22c8a2;
+  background-color: #5e47be;
 }
 
 .cache-1igd88g-StyledText-StyledText {
@@ -2677,18 +2677,18 @@ exports[`LineChart renders correctly when data is async 1`] = `
   align-self: center;
 }
 
-.cache-ja0hz5-legend {
+.cache-gv8bfd-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #a365f6;
+  background-color: #0083e6;
 }
 
-.cache-xgdiqy-legend {
+.cache-1ypaxp0-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #3f6ed8;
+  background-color: #3ebd8f;
 }
 
 <div
@@ -2787,7 +2787,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 Serie 1
               </span>
               <div
-                class="cache-1agnpp2-legend"
+                class="cache-suenwm-legend"
                 data-testid="label-lineChartMultiple1"
               />
             </div>
@@ -2875,7 +2875,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 Serie 2
               </span>
               <div
-                class="cache-ja0hz5-legend"
+                class="cache-gv8bfd-legend"
                 data-testid="label-lineChartMultiple2"
               />
             </div>
@@ -2963,7 +2963,7 @@ exports[`LineChart renders correctly when data is async 1`] = `
                 Serie 3
               </span>
               <div
-                class="cache-xgdiqy-legend"
+                class="cache-1ypaxp0-legend"
                 data-testid="label-lineChartMultiple3"
               />
             </div>
@@ -3842,11 +3842,11 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
   text-decoration: none;
 }
 
-.cache-1agnpp2-legend {
+.cache-suenwm-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #22c8a2;
+  background-color: #5e47be;
 }
 
 .cache-1igd88g-StyledText-StyledText {
@@ -3966,7 +3966,7 @@ exports[`LineChart renders correctly when legend is deselected 1`] = `
                 line chart values
               </span>
               <div
-                class="cache-1agnpp2-legend"
+                class="cache-suenwm-legend"
                 data-testid="label-lineChartSerie"
               />
             </div>
@@ -4601,7 +4601,7 @@ exports[`LineChart renders correctly with data 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -4610,7 +4610,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4622,7 +4622,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4634,7 +4634,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4646,7 +4646,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -4658,7 +4658,7 @@ exports[`LineChart renders correctly with data 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5286,7 +5286,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -5295,7 +5295,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5307,7 +5307,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5319,7 +5319,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5331,7 +5331,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5343,7 +5343,7 @@ exports[`LineChart renders correctly with data transformer 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5971,7 +5971,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -5980,7 +5980,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -5992,7 +5992,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6004,7 +6004,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6016,7 +6016,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6028,7 +6028,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -6282,11 +6282,11 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
   text-decoration: none;
 }
 
-.cache-1agnpp2-legend {
+.cache-suenwm-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #22c8a2;
+  background-color: #5e47be;
 }
 
 .cache-1igd88g-StyledText-StyledText {
@@ -6406,7 +6406,7 @@ exports[`LineChart renders correctly with detailed legend 1`] = `
                 line chart values
               </span>
               <div
-                class="cache-1agnpp2-legend"
+                class="cache-suenwm-legend"
                 data-testid="label-lineChartSerie"
               />
             </div>
@@ -7215,19 +7215,19 @@ exports[`LineChart renders correctly with multiple series 1`] = `
             <path
               d="M915,272C915,272,915,270,915,270C915,270,915,29,915,29C915,29,915,301,915,301C915,301,915,336,915,336C915,336,915,96,915,96C915,96,915,212,915,212C915,212,915,409,915,409C915,409,915,287,915,287C915,287,915,284,915,284C915,284,915,275,915,275C915,275,915,272,915,272C915,272,915,72,915,72C915,72,915,226,915,226C915,226,915,200,915,200"
               fill="none"
-              stroke="#3f6ed8"
+              stroke="#3ebd8f"
               stroke-width="2"
             />
             <path
               d="M915,281C915,281,915,299,915,299C915,299,915,272,915,272C915,272,915,328,915,328C915,328,915,339,915,339C915,339,915,78,915,78C915,78,915,200,915,200C915,200,915,255,915,255C915,255,915,299,915,299"
               fill="none"
-              stroke="#a365f6"
+              stroke="#0083e6"
               stroke-width="2"
             />
             <path
               d="M915,252C915,252,915,270,915,270C915,270,915,325,915,325C915,325,915,301,915,301C915,301,915,310,915,310C915,310,915,165,915,165C915,165,915,258,915,258C915,258,915,139,915,139C915,139,915,264,915,264C915,264,915,299,915,299"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -7236,7 +7236,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 200)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7248,7 +7248,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 226)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7260,7 +7260,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 72)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7272,7 +7272,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 272)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7284,7 +7284,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 275)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7296,7 +7296,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 284)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7308,7 +7308,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 287)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7320,7 +7320,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 409)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7332,7 +7332,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 212)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7344,7 +7344,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 96)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7356,7 +7356,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 336)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7368,7 +7368,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 301)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7380,7 +7380,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 29)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7392,7 +7392,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 270)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7404,7 +7404,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 272)"
               >
                 <circle
-                  fill="#3f6ed8"
+                  fill="#3ebd8f"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7416,7 +7416,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7428,7 +7428,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7440,7 +7440,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7452,7 +7452,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7464,7 +7464,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7476,7 +7476,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7488,7 +7488,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7500,7 +7500,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 255)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7512,7 +7512,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 200)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7524,7 +7524,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 78)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7536,7 +7536,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 339)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7548,7 +7548,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 328)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7560,7 +7560,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 272)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7572,7 +7572,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7584,7 +7584,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 281)"
               >
                 <circle
-                  fill="#a365f6"
+                  fill="#0083e6"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7596,7 +7596,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7608,7 +7608,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7620,7 +7620,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7632,7 +7632,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7644,7 +7644,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7656,7 +7656,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 299)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7668,7 +7668,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 264)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7680,7 +7680,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 139)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7692,7 +7692,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 258)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7704,7 +7704,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 165)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7716,7 +7716,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 310)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7728,7 +7728,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 301)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7740,7 +7740,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 325)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7752,7 +7752,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 270)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -7764,7 +7764,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 transform="translate(915, 252)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -8018,11 +8018,11 @@ exports[`LineChart renders correctly with multiple series 1`] = `
   text-decoration: none;
 }
 
-.cache-1agnpp2-legend {
+.cache-suenwm-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #22c8a2;
+  background-color: #5e47be;
 }
 
 .cache-1igd88g-StyledText-StyledText {
@@ -8045,18 +8045,18 @@ exports[`LineChart renders correctly with multiple series 1`] = `
   align-self: center;
 }
 
-.cache-ja0hz5-legend {
+.cache-gv8bfd-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #a365f6;
+  background-color: #0083e6;
 }
 
-.cache-xgdiqy-legend {
+.cache-1ypaxp0-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #3f6ed8;
+  background-color: #3ebd8f;
 }
 
 <div
@@ -8156,7 +8156,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 Serie 1
               </span>
               <div
-                class="cache-1agnpp2-legend"
+                class="cache-suenwm-legend"
                 data-testid="label-lineChartMultiple1"
               />
             </div>
@@ -8245,7 +8245,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 Serie 2
               </span>
               <div
-                class="cache-ja0hz5-legend"
+                class="cache-gv8bfd-legend"
                 data-testid="label-lineChartMultiple2"
               />
             </div>
@@ -8334,7 +8334,7 @@ exports[`LineChart renders correctly with multiple series 1`] = `
                 Serie 3
               </span>
               <div
-                class="cache-xgdiqy-legend"
+                class="cache-1ypaxp0-legend"
                 data-testid="label-lineChartMultiple3"
               />
             </div>
@@ -8969,7 +8969,7 @@ exports[`LineChart renders correctly with point formatter 1`] = `
             <path
               d="M183,133C244,133,305,133,366,133C427,133,488,400,549,400C610,400,671,382.3333333333333,732,347C793,311.6666666666667,854,169.33333333333331,915,27"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -8978,7 +8978,7 @@ exports[`LineChart renders correctly with point formatter 1`] = `
                 transform="translate(915, 27)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -8990,7 +8990,7 @@ exports[`LineChart renders correctly with point formatter 1`] = `
                 transform="translate(732, 347)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9002,7 +9002,7 @@ exports[`LineChart renders correctly with point formatter 1`] = `
                 transform="translate(549, 400)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9014,7 +9014,7 @@ exports[`LineChart renders correctly with point formatter 1`] = `
                 transform="translate(366, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9026,7 +9026,7 @@ exports[`LineChart renders correctly with point formatter 1`] = `
                 transform="translate(183, 133)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9712,7 +9712,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
             <path
               d="M915,322C915,322,915,346,915,346C915,346,915,309,915,309C915,309,915,388,915,388C915,388,915,404,915,404C915,404,915,33,915,33C915,33,915,206,915,206C915,206,915,285,915,285C915,285,915,346,915,346"
               fill="none"
-              stroke="#22c8a2"
+              stroke="#5e47be"
               stroke-width="2"
             />
             <g>
@@ -9721,7 +9721,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9733,7 +9733,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9745,7 +9745,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9757,7 +9757,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9769,7 +9769,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9781,7 +9781,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9793,7 +9793,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9805,7 +9805,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 285)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9817,7 +9817,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 206)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9829,7 +9829,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 33)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9841,7 +9841,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 404)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9853,7 +9853,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 388)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9865,7 +9865,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 309)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9877,7 +9877,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 346)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -9889,7 +9889,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 transform="translate(915, 322)"
               >
                 <circle
-                  fill="#22c8a2"
+                  fill="#5e47be"
                   r="5"
                   stroke="transparent"
                   stroke-width="0"
@@ -10143,11 +10143,11 @@ exports[`LineChart renders correctly with timeline data 1`] = `
   text-decoration: none;
 }
 
-.cache-1agnpp2-legend {
+.cache-suenwm-legend {
   margin-left: 16px;
   width: 32px;
   height: 2px;
-  background-color: #22c8a2;
+  background-color: #5e47be;
 }
 
 .cache-1igd88g-StyledText-StyledText {
@@ -10267,7 +10267,7 @@ exports[`LineChart renders correctly with timeline data 1`] = `
                 line chart hours values
               </span>
               <div
-                class="cache-1agnpp2-legend"
+                class="cache-suenwm-legend"
                 data-testid="label-lineChartHours"
               />
             </div>

--- a/packages/ui/src/components/LineChart/index.tsx
+++ b/packages/ui/src/components/LineChart/index.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@emotion/react'
 import type { DatumValue, Box as NivoBox, ValueFormat } from '@nivo/core'
-import type { LineSvgProps, Point, Serie } from '@nivo/line'
+import type { LineSvgProps, Serie } from '@nivo/line'
 import { ResponsiveLine } from '@nivo/line'
 import type { ScaleSpec } from '@nivo/scales'
 import type { ComponentProps } from 'react'
@@ -59,11 +59,10 @@ export const LineChart = ({
 }: LineChartProps) => {
   const theme = useTheme()
   const dataset = {
-    datasets: data?.map((d, i) => ({
+    datasets: data?.map(d => ({
       data: d.data,
       id: d.id,
       label: d?.['label'] as string,
-      serieColor: getLegendColor(i, theme),
     })),
   }
 
@@ -96,11 +95,13 @@ export const LineChart = ({
     setSelected(dataset.datasets?.map(({ id }, index) => `${id}${index}`))
   }, [dataset.datasets, selected])
 
+  const localColors = getLegendColor(theme)
+
   return (
     <>
       <div style={{ height }}>
         <ResponsiveLine
-          colors={(point: Point) => point.serieColor}
+          colors={localColors}
           data={finalData ?? []}
           margin={margin}
           xScale={xScale}

--- a/packages/ui/src/components/PieChart/index.tsx
+++ b/packages/ui/src/components/PieChart/index.tsx
@@ -4,6 +4,7 @@ import type { Box } from '@nivo/core'
 import { Pie } from '@nivo/pie'
 import type { ReactNode } from 'react'
 import { useCallback, useState } from 'react'
+import { getLegendColor } from '../../helpers/legend'
 import { Text } from '../Text'
 import Legends from './Legends'
 import type { Data } from './types'
@@ -64,7 +65,7 @@ export const PieChart = ({
   margin = DEFAULT_MARGIN,
   chartProps = DEFAULT_CHARTPROPS,
 }: PieChartProps) => {
-  const { colors } = useTheme()
+  const theme = useTheme()
   const [currentFocusIndex, setCurrentFocusIndex] = useState<string>()
   const emptyTooltip = useCallback(() => <span />, [])
   const isEmpty = !data || data.length === 0
@@ -81,19 +82,7 @@ export const PieChart = ({
     [emptyLegend],
   )
 
-  const localColors = Object.keys(colors.other.data.charts)
-    .filter(key => !['success', 'danger'].includes(key))
-    .sort((a, b) => {
-      if (Number(a.replace('data', '')) < Number(b.replace('data', ''))) {
-        return -1
-      }
-
-      return 1
-    })
-    .map(
-      key =>
-        colors.other.data.charts[key as keyof typeof colors.other.data.charts],
-    )
+  const localColors = getLegendColor(theme)
 
   const LegendDisplayer = useCallback(
     () =>
@@ -133,7 +122,7 @@ export const PieChart = ({
           defs={[
             {
               background: 'inherit',
-              color: colors.neutral.textStrong,
+              color: theme.colors.neutral.textStrong,
               id: 'lines',
               lineWidth: 2,
               rotation: 0,

--- a/packages/ui/src/helpers/legend.ts
+++ b/packages/ui/src/helpers/legend.ts
@@ -1,16 +1,19 @@
 import type { Theme } from '@emotion/react'
 
-const legendColors = (theme: Theme): string[] => [
-  theme.colors.success.backgroundStrong,
-  theme.colors.secondary.backgroundStrong,
-  theme.colors.info.backgroundStrong,
-  theme.colors.danger.backgroundStrong,
-  theme.colors.primary.backgroundStrong,
-  theme.colors.warning.backgroundStrong,
-]
+export const getLegendColor = (theme: Theme): string[] => {
+  const { colors } = theme
 
-export const getLegendColor = (index: number, theme: Theme): string => {
-  const colors = legendColors(theme)
+  return Object.keys(colors.other.data.charts)
+    .filter(key => !['success', 'danger'].includes(key))
+    .sort((a, b) => {
+      if (Number(a.replace('data', '')) < Number(b.replace('data', ''))) {
+        return -1
+      }
 
-  return colors[index] || colors[colors.length % index]
+      return 1
+    })
+    .map(
+      key =>
+        colors.other.data.charts[key as keyof typeof colors.other.data.charts],
+    )
 }


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

New data colors on `BarChart` and `LineChart`

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1025" alt="Screenshot 2023-04-27 at 18 08 45" src="https://user-images.githubusercontent.com/15812968/234924205-b6dda4b6-2d55-486a-93e1-14f8cab1f9ce.png"> | <img width="1019" alt="Screenshot 2023-04-27 at 18 08 51" src="https://user-images.githubusercontent.com/15812968/234924347-2c2c2b19-0032-4d75-ab96-ce190f007050.png"> |
| url  | <img width="1023" alt="Screenshot 2023-04-27 at 18 09 10" src="https://user-images.githubusercontent.com/15812968/234924714-ac0aad1c-0c31-4f2c-8b27-ea663ac4edee.png"> | <img width="1012" alt="Screenshot 2023-04-27 at 18 09 24" src="https://user-images.githubusercontent.com/15812968/234924793-c1d8b367-0b5d-4150-b795-9e7cb5aed019.png"> |
