### PR TITLE
fix: expandable row registering

### DIFF
--- a/.changeset/weak-donuts-tickle.md
+++ b/.changeset/weak-donuts-tickle.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': patch
+---
+
+Avoid row expandableRow to unregister if parent component is re-render

--- a/packages/ui/src/components/ListV2/Row.tsx
+++ b/packages/ui/src/components/ListV2/Row.tsx
@@ -123,15 +123,16 @@ export const Row = forwardRef(
     const isSelectDisabled =
       isDisabled || (selectDisabled !== undefined && selectDisabled !== false)
 
+    const hasExpandable = !!expandable
     useEffect(() => {
-      if (expandable) {
+      if (hasExpandable) {
         const unregisterCallback = registerExpandableRow(id)
 
         return unregisterCallback
       }
 
       return undefined
-    }, [id, expandable, registerExpandableRow])
+    }, [id, hasExpandable, registerExpandableRow])
 
     useEffect(() => {
       if (!isSelectDisabled) {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

Even if React manages to reconciliate expandable at each render, the prop itself is consider as different for useEffect, when parent component was re-render, the prop looks different and the row was register again, bringing an unwanted collapse of the row