### PR TITLE
fix(Separator): icon color

### DIFF
--- a/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -207,29 +207,6 @@ exports[`SubmitErrorAlert should display an alert when submitError is present 1`
   text-decoration: none;
 }
 
-.cache-pjzp28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: 16px;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: normal;
-  -webkit-box-align: normal;
-  -ms-flex-align: normal;
-  align-items: normal;
-  -webkit-box-pack: normal;
-  -ms-flex-pack: normal;
-  -webkit-justify-content: normal;
-  justify-content: normal;
-  -webkit-box-flex-wrap: nowrap;
-  -webkit-flex-wrap: nowrap;
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap;
-}
-
 <form
     novalidate=""
   >
@@ -271,9 +248,6 @@ exports[`SubmitErrorAlert should display an alert when submitError is present 1`
             </p>
           </div>
         </div>
-        <div
-          class="cache-pjzp28 e1sgck4o0"
-        />
       </div>
     </div>
     ,

--- a/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/form/src/components/SubmitErrorAlert/__tests__/__snapshots__/index.spec.tsx.snap
@@ -207,6 +207,29 @@ exports[`SubmitErrorAlert should display an alert when submitError is present 1`
   text-decoration: none;
 }
 
+.cache-pjzp28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: normal;
+  -webkit-box-align: normal;
+  -ms-flex-align: normal;
+  align-items: normal;
+  -webkit-box-pack: normal;
+  -ms-flex-pack: normal;
+  -webkit-justify-content: normal;
+  justify-content: normal;
+  -webkit-box-flex-wrap: nowrap;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+}
+
 <form
     novalidate=""
   >
@@ -248,6 +271,9 @@ exports[`SubmitErrorAlert should display an alert when submitError is present 1`
             </p>
           </div>
         </div>
+        <div
+          class="cache-pjzp28 e1sgck4o0"
+        />
       </div>
     </div>
     ,

--- a/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
@@ -63,6 +63,70 @@ exports[`Separator renders correctly with custom color 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Separator renders correctly with custom color and icon 1`] = `
+<DocumentFragment>
+  .cache-1gpqkcp-StyledIconWrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.cache-885ddd-StyledHr {
+  margin: 0;
+  border: 0;
+  width: auto;
+  height: 1px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  background-color: #390171;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.cache-nwqmla-StyledIcon-sizeStyles-StyledIcon {
+  vertical-align: middle;
+  fill: #390171;
+  height: 24px;
+  width: 24px;
+  min-width: 24px;
+  min-height: 24px;
+  fill: #390171;
+}
+
+<div
+    aria-orientation="horizontal"
+    class="cache-1gpqkcp-StyledIconWrapper eoti1h22"
+    role="separator"
+  >
+    <hr
+      class="cache-885ddd-StyledHr eoti1h20"
+    />
+    <svg
+      class="eoti1h21 cache-nwqmla-StyledIcon-sizeStyles-StyledIcon etwatq50"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M1,12L5,16V13H17.17C17.58,14.17 18.69,15 20,15A3,3 0 0,0 23,12A3,3 0 0,0 20,9C18.69,9 17.58,9.83 17.17,11H5V8L1,12Z"
+        style="transform: rotate(-90deg); transform-origin: 50% 50%;"
+      />
+    </svg>
+    <hr
+      class="cache-885ddd-StyledHr eoti1h20"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Separator renders correctly with custom icon 1`] = `
 <DocumentFragment>
   .cache-1gpqkcp-StyledIconWrapper {

--- a/packages/ui/src/components/Separator/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Separator/__tests__/index.test.tsx
@@ -16,6 +16,11 @@ describe('Separator', () => {
 
   test(`renders correctly with custom icon`, () =>
     shouldMatchEmotionSnapshot(<Separator icon="ray-top-arrow" />))
+
+  test(`renders correctly with custom color and icon`, () =>
+    shouldMatchEmotionSnapshot(
+      <Separator color="primary" icon="ray-top-arrow" />,
+    ))
   test(`renders correctly with custom icon vertically`, () =>
     shouldMatchEmotionSnapshot(
       <Separator direction="vertical" icon="ray-top-arrow" />,

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -18,8 +18,8 @@ const StyledIconWrapper = styled('div', {
   align-items: center;
 `
 
-const StyledIcon = styled(Icon)`
-  fill: ${({ theme }) => theme.colors.neutral.border};
+const StyledIcon = styled(Icon)<{ color: Color }>`
+  fill: ${({ color, theme }) => theme.colors[color].border};
 `
 
 type HorizontalSeparatorProps = SeparatorProps & {
@@ -73,7 +73,7 @@ export const Separator = ({
         color={color}
         hasIcon
       />
-      <StyledIcon name={icon} size={24} color="neutral" />
+      <StyledIcon name={icon} size={24} color={color} />
       <StyledHr
         direction={direction}
         thickness={thickness}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Set the correct color of the icon (if one is set) on `<Separator />`

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="1141" alt="Screenshot 2023-05-03 at 09 53 07" src="https://user-images.githubusercontent.com/43268759/235859992-b5bb94c9-426b-4fd8-aba0-9744a7bca180.png"> | <img width="929" alt="Screenshot 2023-05-03 at 09 54 23" src="https://user-images.githubusercontent.com/43268759/235860206-e2973009-10a4-46d2-9052-73fe0ddf8674.png"> |
