### PR TITLE
fix(Modal): set tabIndex to focus dialog element first

### DIFF
--- a/.changeset/silly-tables-rush.md
+++ b/.changeset/silly-tables-rush.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': patch
+---
+
+fix(Modal): set tabIndex to focus dialog element first

--- a/packages/ui/src/components/Modal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Modal/__tests__/__snapshots__/index.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`Modal renders with customStyle 1`] = `
         data-dialog="true"
         id="id-d9i348"
         role="dialog"
-        tabindex="-1"
+        tabindex="0"
       >
         <div>
           test
@@ -342,7 +342,7 @@ exports[`Modal renders with default Props 1`] = `
         id="id-d9i348"
         role="dialog"
         style="display: none;"
-        tabindex="-1"
+        tabindex="0"
       >
         <div
           class="cache-v3mj59-StyledContainer e1x6rvve0"
@@ -530,7 +530,7 @@ exports[`Modal renders with disclosure 1`] = `
         id="modal-test"
         role="dialog"
         style="display: none;"
-        tabindex="-1"
+        tabindex="0"
       >
         <div
           class="cache-v3mj59-StyledContainer e1x6rvve0"
@@ -722,7 +722,7 @@ exports[`Modal renders with disclosure and onBeforeClose 1`] = `
         id="modal-test"
         role="dialog"
         style=""
-        tabindex="-1"
+        tabindex="0"
       >
         <div>
           modal
@@ -913,7 +913,7 @@ exports[`Modal renders with opened={true} 1`] = `
         data-dialog="true"
         id="id-d9i348"
         role="dialog"
-        tabindex="-1"
+        tabindex="0"
       >
         <div>
           test
@@ -1098,7 +1098,7 @@ exports[`Modal renders with portal node (modal=false) 1`] = `
       id="modal-test"
       role="dialog"
       style="display: none;"
-      tabindex="-1"
+      tabindex="0"
     >
       <div
         class="cache-v3mj59-StyledContainer e1x6rvve0"

--- a/packages/ui/src/components/Modal/index.tsx
+++ b/packages/ui/src/components/Modal/index.tsx
@@ -322,6 +322,7 @@ export const Modal = memo(
           <StyledDialog
             aria-label={ariaLabel}
             role="dialog"
+            tabIndex={0}
             animation={animation}
             bordered={bordered}
             height={height}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

When a Modal is open, it follows reakit Dialog focus rules (see https://reakit.io/docs/dialog/#initial-focus). But as Tooltip is now focusable, if the Tooltip is the first element in the focus queue, the Tooltip was displayed opened. To prevent this, we set the Dialog element as the first focusable element.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | 
![Capture d’écran 2023-05-12 à 11 58 52](https://github.com/scaleway/scaleway-ui/assets/2362139/9b097d8a-94d6-4a33-aff8-12d6c2344433)
 | 
![Screenshot 2023-05-12 at 14 46 34](https://github.com/scaleway/scaleway-ui/assets/2362139/9c3bbdd6-696c-4a11-a5f6-1819ead56e3d)
|
