### PR TITLE
ci: fix tsc storybook

### DIFF
--- a/packages/ui/src/components/Radio/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/Template.stories.tsx
@@ -1,9 +1,7 @@
-import type { ComponentStory } from '@storybook/react'
+import type { StoryFn } from '@storybook/react'
 import { Radio } from '..'
 
-export const Template: ComponentStory<typeof Radio> = args => (
-  <Radio {...args} />
-)
+export const Template: StoryFn<typeof Radio> = args => <Radio {...args} />
 
 Template.args = {
   checked: false,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### The following changes where made:

`ComponentStory` is deprecated, migrate to `StoryFn`.

