### PR TITLE
fix: verification code focus on paste

### DIFF
--- a/.changeset/nice-singers-shout.md
+++ b/.changeset/nice-singers-shout.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': patch
+---
+
+Verification code correct focus on paste

--- a/packages/ui/src/components/VerificationCode/index.tsx
+++ b/packages/ui/src/components/VerificationCode/index.tsx
@@ -224,12 +224,18 @@ export const VerificationCode = ({
         return newArray
       })
 
+      const nextIndex = Math.min(
+        currentIndex + pastedValue.length,
+        inputRefs.length - 1,
+      )
+      const next = inputRefs[nextIndex]
+      next?.current?.focus()
       triggerChange(pastedValue)
     }
 
   return (
     <div className={className} data-testid={dataTestId}>
-      {values.map((value: string, index) => (
+      {values.map((value: string, index: number) => (
         <StyledInput
           css={[inputStyle]}
           aria-invalid={error}

--- a/packages/ui/src/components/VerificationCode/index.tsx
+++ b/packages/ui/src/components/VerificationCode/index.tsx
@@ -224,8 +224,9 @@ export const VerificationCode = ({
         return newArray
       })
 
+      // we select min value between the end of inputs and valid pasted chars
       const nextIndex = Math.min(
-        currentIndex + pastedValue.length,
+        currentIndex + pastedValue.filter(item => item !== '').length,
         inputRefs.length - 1,
       )
       const next = inputRefs[nextIndex]


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Verification code correct focus on paste

#### The following changes where made:

(Describe what you did)

1. Go to verification code

2. Paste something

3. It should focus on next available input or last one

## Relevant logs and/or screenshots


https://github.com/scaleway/scaleway-ui/assets/3360430/7f381378-4dd3-4a66-a4e7-3c6cdaa3b260


