### PR TITLE
docs: update text and link documentation

### DIFF
--- a/packages/ui/src/components/Link/__stories__/OneLine.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/OneLine.stories.tsx
@@ -1,20 +1,29 @@
+import styled from '@emotion/styled'
 import type { ComponentStory } from '@storybook/react'
 import { Link } from '../index'
+
+const Container = styled.div`
+  margin-bottom: ${({ theme }) => theme.space['2']};
+  margin-top: ${({ theme }) => theme.space['1']};
+  width: 200px;
+  background: ${({ theme }) => theme.colors.info.background};
+  padding: ${({ theme }) => theme.space['1']};
+`
 
 export const OneLine: ComponentStory<typeof Link> = () => (
   <>
     <strong>Without ellipsis</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 200 }}>
+    <Container>
       <Link href="https://scaleway.com">
         This link is quite long and is displayed on two lines.
       </Link>
-    </div>
+    </Container>
     <strong>With ellipsis (a tooltip is displayed on hover)</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 200 }}>
+    <Container>
       <Link href="https://scaleway.com" oneLine>
         This link is quite long and is cut in order to avoid two lines.
       </Link>
-    </div>
+    </Container>
   </>
 )
 

--- a/packages/ui/src/components/Link/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/index.stories.tsx
@@ -7,7 +7,7 @@ export default {
     docs: {
       description: {
         component:
-          'An Expandable is a container that can hide or show its content',
+          'Link is a component used to navigate between pages or to external websites.',
       },
     },
   },

--- a/packages/ui/src/components/Text/__stories__/Dir.stories.tsx
+++ b/packages/ui/src/components/Text/__stories__/Dir.stories.tsx
@@ -1,40 +1,40 @@
 import type { ComponentStory } from '@storybook/react'
+import { Stack } from '../../Stack'
 import { Text } from '../index'
 
 export const Dir: ComponentStory<typeof Text> = () => (
-  <>
-    <strong>ltr</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 500 }}>
-      <Text as="div" variant="body" oneLine dir="ltr">
+  <Stack gap={2}>
+    <div>
+      <strong>ltr</strong>
+      <Text as="div" variant="body" dir="ltr">
         This text is quite long. Lorem ipsum dolor sit amet, consectetur
         adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua.
       </Text>
     </div>
-    <strong>rtl</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 500 }}>
-      <Text as="div" variant="body" oneLine dir="rtl">
+    <div>
+      <strong>rtl</strong>
+      <Text as="div" variant="body" dir="rtl">
         This text is quite long. Lorem ipsum dolor sit amet, consectetur
         adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua.
       </Text>
     </div>
-    <strong>auto</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 500 }}>
-      <Text as="div" variant="body" oneLine dir="auto">
+    <div>
+      <strong>auto</strong>
+      <Text as="div" variant="body" dir="auto">
         This text is quite long. Lorem ipsum dolor sit amet, consectetur
         adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua.
       </Text>
     </div>
-  </>
+  </Stack>
 )
 
 Dir.parameters = {
   docs: {
     description: {
-      story:
-        '`dir` prop will change the direction of the `...` when using `oneLine`',
+      story: '`dir` prop will change the direction of the text',
     },
   },
 }

--- a/packages/ui/src/components/Text/__stories__/OneLine.stories.tsx
+++ b/packages/ui/src/components/Text/__stories__/OneLine.stories.tsx
@@ -1,24 +1,33 @@
+import styled from '@emotion/styled'
 import type { ComponentStory } from '@storybook/react'
 import { Text } from '../index'
+
+const Container = styled.div`
+  margin-bottom: ${({ theme }) => theme.space['2']};
+  margin-top: ${({ theme }) => theme.space['1']};
+  width: 200px;
+  background: ${({ theme }) => theme.colors.info.background};
+  padding: ${({ theme }) => theme.space['1']};
+`
 
 export const OneLine: ComponentStory<typeof Text> = () => (
   <>
     <strong>Without ellipsis</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 500 }}>
+    <Container>
       <Text as="div" variant="body">
         This text is quite long. Lorem ipsum dolor sit amet, consectetur
         adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua.
       </Text>
-    </div>
+    </Container>
     <strong>With ellipsis (a tooltip is displayed on hover)</strong>
-    <div style={{ marginBottom: 16, marginTop: 8, width: 500 }}>
+    <Container>
       <Text as="div" variant="body" oneLine>
         This text is quite long. Lorem ipsum dolor sit amet, consectetur
         adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
         magna aliqua.
       </Text>
-    </div>
+    </Container>
   </>
 )
 


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarise concisely:

#### What is expected?

Fix documentation of Link and Text.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| link  |  <img width="1022" alt="Screenshot 2023-05-30 at 17 00 22" src="https://github.com/scaleway/scaleway-ui/assets/15812968/151adc2e-072a-4730-bae7-3c76b3396099"> | <img width="1016" alt="Screenshot 2023-05-30 at 17 00 27" src="https://github.com/scaleway/scaleway-ui/assets/15812968/238c880c-9c79-4452-8c3f-0235da652414"> |
| text  | <img width="1025" alt="Screenshot 2023-05-30 at 17 01 18" src="https://github.com/scaleway/scaleway-ui/assets/15812968/2e51171a-9d71-4b99-a04f-8b9a7616d6be"> | <img width="1027" alt="Screenshot 2023-05-30 at 17 01 29" src="https://github.com/scaleway/scaleway-ui/assets/15812968/2fb80ac6-f0f6-46a0-b435-bd3fb5813fd7"> |
