### PR TITLE
fix(Expandable): overflow visible when open

### DIFF
--- a/packages/ui/src/components/Expandable/index.tsx
+++ b/packages/ui/src/components/Expandable/index.tsx
@@ -62,6 +62,7 @@ export const Expandable = ({
       transitionTimer.current = setTimeout(() => {
         if (ref.current) {
           ref.current.style.maxHeight = 'initial'
+          ref.current.style.overflow = 'visible'
         }
       }, ANIMATION_DURATION)
     } else {
@@ -72,6 +73,7 @@ export const Expandable = ({
         transitionTimer.current = setTimeout(() => {
           if (ref.current) {
             ref.current.style.maxHeight = `${minHeight}px`
+            ref.current.style.overflow = 'hidden'
           }
         }, 0)
       }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The overflow of expandable component remained hidden when the state was open.
