### PR TITLE
fix(NumberInputField): min max validation

### DIFF
--- a/.changeset/wise-mayflies-try.md
+++ b/.changeset/wise-mayflies-try.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/form': patch
+---
+
+Fix min/max validation of NumberInputField

--- a/packages/form/src/components/NumberInputField/index.tsx
+++ b/packages/form/src/components/NumberInputField/index.tsx
@@ -58,6 +58,8 @@ export const NumberInputField = ({
     validate,
     value,
     defaultValue: 0,
+    max: maxValue,
+    min: minValue,
   })
 
   return (


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

The `NumberInputField` min/max was not used in the form validation.
