### PR TITLE
fix(Button): remove `iconOnly` from dom

### DIFF
--- a/.changeset/ten-socks-repeat.md
+++ b/.changeset/ten-socks-repeat.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': patch
+---
+
+Removed `iconOnly` prop from DOM in `<Button />` component

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -114,7 +114,9 @@ const coreStyle = ({
 
 const StyledFilledButton = styled('button', {
   shouldForwardProp: prop =>
-    !['size', 'sentiment', 'iconPosition', 'fullWidth'].includes(prop),
+    !['size', 'sentiment', 'iconPosition', 'fullWidth', 'iconOnly'].includes(
+      prop,
+    ),
 })<StyledButtonProps>`
   ${args => coreStyle(args)}
 
@@ -153,7 +155,9 @@ const StyledFilledButton = styled('button', {
 
 const StyledOutlinedButton = styled('button', {
   shouldForwardProp: prop =>
-    !['size', 'sentiment', 'iconPosition', 'fullWidth'].includes(prop),
+    !['size', 'sentiment', 'iconPosition', 'fullWidth', 'iconOnly'].includes(
+      prop,
+    ),
 })<StyledButtonProps>`
   ${args => coreStyle(args)}
 
@@ -208,7 +212,9 @@ const StyledOutlinedButton = styled('button', {
 
 const StyledGhostButton = styled('button', {
   shouldForwardProp: prop =>
-    !['size', 'sentiment', 'iconPosition', 'fullWidth'].includes(prop),
+    !['size', 'sentiment', 'iconPosition', 'fullWidth', 'iconOnly'].includes(
+      prop,
+    ),
 })<StyledButtonProps>`
   ${args => coreStyle(args)}
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

`iconOnly` prop is added into DOM while it shouldn't as it is an internal prop of Button component used for styling.
