### PR TITLE
fix(Tooltip): rollback alignement

### DIFF
--- a/.changeset/chatty-countries-draw.md
+++ b/.changeset/chatty-countries-draw.md
@@ -1,0 +1,5 @@
+---
+'@scaleway/ui': patch
+---
+
+Fix Tooltip to remove `width: fit-content`

--- a/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Button/__tests__/__snapshots__/index.tsx.snap
@@ -263,11 +263,8 @@ exports[`Button render small 1`] = `
 
 exports[`Button render with a tooltip 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1s99gb8-StyledFilledButton {
@@ -326,7 +323,7 @@ exports[`Button render with a tooltip 1`] = `
 
 <div
     aria-describedby=":r1f:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button

--- a/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/CopyButton/__tests__/__snapshots__/index.tsx.snap
@@ -2,11 +2,8 @@
 
 exports[`CopyButton renders correctly 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-16ljkze-StyledButton {
@@ -52,7 +49,7 @@ exports[`CopyButton renders correctly 1`] = `
 
 <div
     aria-describedby=":r0:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -75,11 +72,8 @@ exports[`CopyButton renders correctly 1`] = `
 
 exports[`CopyButton renders correctly sentiment large 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-r06x4m-StyledButton {
@@ -125,7 +119,7 @@ exports[`CopyButton renders correctly sentiment large 1`] = `
 
 <div
     aria-describedby=":r2:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -148,11 +142,8 @@ exports[`CopyButton renders correctly sentiment large 1`] = `
 
 exports[`CopyButton renders correctly sentiment neutral 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-xsw6vc-StyledButton {
@@ -198,7 +189,7 @@ exports[`CopyButton renders correctly sentiment neutral 1`] = `
 
 <div
     aria-describedby=":r4:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -221,11 +212,8 @@ exports[`CopyButton renders correctly sentiment neutral 1`] = `
 
 exports[`CopyButton renders correctly sentiment primary 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-16ljkze-StyledButton {
@@ -271,7 +259,7 @@ exports[`CopyButton renders correctly sentiment primary 1`] = `
 
 <div
     aria-describedby=":r3:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -294,11 +282,8 @@ exports[`CopyButton renders correctly sentiment primary 1`] = `
 
 exports[`CopyButton renders correctly sentiment small 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-16ljkze-StyledButton {
@@ -344,7 +329,7 @@ exports[`CopyButton renders correctly sentiment small 1`] = `
 
 <div
     aria-describedby=":r1:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -367,11 +352,8 @@ exports[`CopyButton renders correctly sentiment small 1`] = `
 
 exports[`CopyButton renders correctly with custom class name 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-16ljkze-StyledButton {
@@ -417,7 +399,7 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 
 <div
     aria-describedby=":r8:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -440,11 +422,8 @@ exports[`CopyButton renders correctly with custom class name 1`] = `
 
 exports[`CopyButton renders correctly with custom copied text 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-16ljkze-StyledButton {
@@ -490,7 +469,7 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 
 <div
     aria-describedby=":r7:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -513,11 +492,8 @@ exports[`CopyButton renders correctly with custom copied text 1`] = `
 
 exports[`CopyButton renders correctly with custom copy text 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-16ljkze-StyledButton {
@@ -563,7 +539,7 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 
 <div
     aria-describedby=":r6:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button
@@ -586,11 +562,8 @@ exports[`CopyButton renders correctly with custom copy text 1`] = `
 
 exports[`CopyButton renders correctly with no border 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1gy37wj-StyledButton {
@@ -636,7 +609,7 @@ exports[`CopyButton renders correctly with no border 1`] = `
 
 <div
     aria-describedby=":r5:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button

--- a/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/List/__tests__/__snapshots__/index.test.tsx.snap
@@ -3505,11 +3505,8 @@ exports[`List Should render correctly with info 1`] = `
   color: #4f0599;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-dwb18c-StyledIcon-sizeStyles {
@@ -3612,7 +3609,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 1
         <div
           aria-describedby=":r38:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <svg
@@ -3632,7 +3629,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 2
         <div
           aria-describedby=":r39:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <svg
@@ -3652,7 +3649,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 3
         <div
           aria-describedby=":r3a:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <svg
@@ -3672,7 +3669,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 4
         <div
           aria-describedby=":r3b:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <svg
@@ -3692,7 +3689,7 @@ exports[`List Should render correctly with info 1`] = `
         Column 5
         <div
           aria-describedby=":r3c:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <svg

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -45,11 +45,8 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
   overflow-y: auto;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-exvtnx-ListItem {
@@ -252,7 +249,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -292,7 +289,7 @@ exports[`PieChart renders correctly when legend is focused 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -380,11 +377,8 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
   overflow-y: auto;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-exvtnx-ListItem {
@@ -587,7 +581,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -627,7 +621,7 @@ exports[`PieChart renders correctly when legend is hovered 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -904,11 +898,8 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
   overflow-y: auto;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1klfns5-ListItem {
@@ -1071,7 +1062,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -1111,7 +1102,7 @@ exports[`PieChart renders correctly with detailed legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -1185,11 +1176,8 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
   overflow-y: auto;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1klfns5-ListItem {
@@ -1359,7 +1347,7 @@ exports[`PieChart renders correctly with detailed legend and discount 1`] = `
     >
       <div
         aria-describedby="chart-legend-discount"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -1550,11 +1538,8 @@ exports[`PieChart renders correctly with legend 1`] = `
   overflow-y: auto;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1klfns5-ListItem {
@@ -1845,7 +1830,7 @@ exports[`PieChart renders correctly with legend 1`] = `
     >
       <div
         aria-describedby="chart-legend-compute"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -1885,7 +1870,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-gpu"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -1925,7 +1910,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-functions"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -1965,7 +1950,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-containers"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -2005,7 +1990,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-s3"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -2045,7 +2030,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-dns"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -2085,7 +2070,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-appleSilicon"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -2125,7 +2110,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-baremetal"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -2165,7 +2150,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-database"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li
@@ -2205,7 +2190,7 @@ exports[`PieChart renders correctly with legend 1`] = `
       </div>
       <div
         aria-describedby="chart-legend-lb"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <li

--- a/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Popover/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,16 +2,13 @@
 
 exports[`Tooltip should render correctly with component in content prop 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r5:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     Children
@@ -21,16 +18,13 @@ exports[`Tooltip should render correctly with component in content prop 1`] = `
 
 exports[`Tooltip should render correctly with placement should renders tooltip with placement bottom 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":rk:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -44,16 +38,13 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 exports[`Tooltip should render correctly with placement should renders tooltip with placement left 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":rc:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -67,16 +58,13 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 exports[`Tooltip should render correctly with placement should renders tooltip with placement right 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":rg:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -90,16 +78,13 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 exports[`Tooltip should render correctly with placement should renders tooltip with placement top 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r8:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -113,16 +98,13 @@ exports[`Tooltip should render correctly with placement should renders tooltip w
 
 exports[`Tooltip should render correctly with required props 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r0:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     Children
@@ -132,16 +114,13 @@ exports[`Tooltip should render correctly with required props 1`] = `
 
 exports[`Tooltip should render correctly with required props and visible 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r1:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     Children
@@ -151,16 +130,13 @@ exports[`Tooltip should render correctly with required props and visible 1`] = `
 
 exports[`Tooltip should render correctly with sentiment should renders tooltip with placement neutral 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":ro:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -174,16 +150,13 @@ exports[`Tooltip should render correctly with sentiment should renders tooltip w
 
 exports[`Tooltip should render correctly with sentiment should renders tooltip with placement primary 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":rs:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -197,16 +170,13 @@ exports[`Tooltip should render correctly with sentiment should renders tooltip w
 
 exports[`Tooltip should render correctly with sizes should renders tooltip with placement large 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r18:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -220,16 +190,13 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 
 exports[`Tooltip should render correctly with sizes should renders tooltip with placement medium 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r14:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p
@@ -243,16 +210,13 @@ exports[`Tooltip should render correctly with sizes should renders tooltip with 
 
 exports[`Tooltip should render correctly with sizes should renders tooltip with placement small 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r10:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <p

--- a/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCard/__tests__/__snapshots__/index.test.tsx.snap
@@ -1170,11 +1170,8 @@ exports[`SelectableCard renders correctly with checkbox type and isError prop 1`
 
 exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-dgvm93-Container {
@@ -1406,7 +1403,7 @@ exports[`SelectableCard renders correctly with checkbox type and tooltip prop 1`
 
 <div
     aria-describedby=":rn:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <div
@@ -2774,11 +2771,8 @@ exports[`SelectableCard renders correctly with radio type and isError prop 1`] =
 
 exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-dgvm93-Container {
@@ -2982,7 +2976,7 @@ exports[`SelectableCard renders correctly with radio type and tooltip prop 1`] =
 
 <div
     aria-describedby=":rl:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <div

--- a/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Snippet/__tests__/__snapshots__/index.test.tsx.snap
@@ -81,11 +81,8 @@ exports[`Snippet renders correctly 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -149,7 +146,7 @@ exports[`Snippet renders correctly 1`] = `
       >
         <div
           aria-describedby=":r1:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -261,11 +258,8 @@ exports[`Snippet renders correctly in multiline  1`] = `
   border: 2px solid transparent;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -412,7 +406,7 @@ exports[`Snippet renders correctly in multiline  1`] = `
       >
         <div
           aria-describedby=":r3:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -562,11 +556,8 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
   border: 2px solid transparent;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -713,7 +704,7 @@ exports[`Snippet renders correctly in multiline with prefix command 1`] = `
       >
         <div
           aria-describedby=":r9:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -864,11 +855,8 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
   border: 2px solid transparent;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1015,7 +1003,7 @@ exports[`Snippet renders correctly in multiline with prefix lines number 1`] = `
       >
         <div
           aria-describedby=":r6:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -1143,11 +1131,8 @@ exports[`Snippet renders correctly with copiedText 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1211,7 +1196,7 @@ exports[`Snippet renders correctly with copiedText 1`] = `
       >
         <div
           aria-describedby=":ri:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -1316,11 +1301,8 @@ exports[`Snippet renders correctly with copyText 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1384,7 +1366,7 @@ exports[`Snippet renders correctly with copyText 1`] = `
       >
         <div
           aria-describedby=":rg:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -1496,11 +1478,8 @@ exports[`Snippet renders correctly with hideText 1`] = `
   border: 2px solid transparent;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1647,7 +1626,7 @@ exports[`Snippet renders correctly with hideText 1`] = `
       >
         <div
           aria-describedby=":rk:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -1782,11 +1761,8 @@ exports[`Snippet renders correctly with showText 1`] = `
   border: 2px solid transparent;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -1933,7 +1909,7 @@ exports[`Snippet renders correctly with showText 1`] = `
       >
         <div
           aria-describedby=":rn:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -2076,11 +2052,8 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -2144,7 +2117,7 @@ exports[`Snippet renders correctly with single line with prefix command 1`] = `
       >
         <div
           aria-describedby=":rc:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -2265,11 +2238,8 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
   box-shadow: -27px 0 19px -11px #f6f6f8;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -2333,7 +2303,7 @@ exports[`Snippet renders correctly with single line with prefix lines number 1`]
       >
         <div
           aria-describedby=":re:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -2445,11 +2415,8 @@ exports[`Snippet should click on extend button to display full content on  1`] =
   border: 2px solid transparent;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1nnm9m7-StyledButton {
@@ -2596,7 +2563,7 @@ exports[`Snippet should click on extend button to display full content on  1`] =
       >
         <div
           aria-describedby=":rq:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button

--- a/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SwitchButton/__tests__/__snapshots__/index.test.tsx.snap
@@ -826,11 +826,8 @@ exports[`SwitchButton renders correctly with right value 1`] = `
 
 exports[`SwitchButton renders with tooltip 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-f7e9vn-StyledBorderedBox {
@@ -1081,7 +1078,7 @@ exports[`SwitchButton renders with tooltip 1`] = `
 
 <div
     aria-describedby=":ra:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <div

--- a/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Table/__tests__/__snapshots__/index.test.tsx.snap
@@ -838,11 +838,8 @@ exports[`Table Should render correctly with info 1`] = `
   gap: 8px;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-dwb18c-StyledIcon-sizeStyles {
@@ -891,7 +888,7 @@ exports[`Table Should render correctly with info 1`] = `
             Name
             <div
               aria-describedby=":r2l:"
-              class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+              class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
               tabindex="0"
             >
               <svg

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -207,11 +207,8 @@ exports[`Tag renders correctly neutral 1`] = `
 
 exports[`Tag renders correctly with copiable 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1tfylds-Container-StyledContainer {
@@ -263,7 +260,7 @@ exports[`Tag renders correctly with copiable 1`] = `
 
 <div
     aria-describedby=":r1:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     <button

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -58,11 +58,8 @@ exports[`TagList renders correctly 1`] = `
   text-overflow: ellipsis;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-2nt0x1-TagsWrapper {
@@ -102,7 +99,7 @@ exports[`TagList renders correctly 1`] = `
       </div>
       <div
         aria-describedby=":r0:"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <span
@@ -139,11 +136,8 @@ exports[`TagList renders correctly with copiable 1`] = `
   gap: 8px;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-1tfylds-Container-StyledContainer {
@@ -202,7 +196,7 @@ exports[`TagList renders correctly with copiable 1`] = `
       >
         <div
           aria-describedby=":r4:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -218,7 +212,7 @@ exports[`TagList renders correctly with copiable 1`] = `
         </div>
         <div
           aria-describedby=":r5:"
-          class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+          class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
           tabindex="0"
         >
           <button
@@ -387,11 +381,8 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
   text-overflow: ellipsis;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-2nt0x1-TagsWrapper {
@@ -441,7 +432,7 @@ exports[`TagList renders correctly with custom threshold and extra tags 1`] = `
       </div>
       <div
         aria-describedby=":r1:"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <span
@@ -514,11 +505,8 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
   text-overflow: ellipsis;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-2nt0x1-TagsWrapper {
@@ -558,7 +546,7 @@ exports[`TagList renders correctly with custom threshold and extra tags and maxL
       </div>
       <div
         aria-describedby=":r2:"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <span
@@ -635,11 +623,8 @@ exports[`TagList renders correctly with multiline 1`] = `
   text-overflow: ellipsis;
 }
 
-.cache-fqcxly-StyledChildrenContainer {
+.cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 .cache-2nt0x1-TagsWrapper {
@@ -689,7 +674,7 @@ exports[`TagList renders correctly with multiline 1`] = `
       </div>
       <div
         aria-describedby=":r3:"
-        class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+        class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
         tabindex="0"
       >
         <span

--- a/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tooltip/__tests__/__snapshots__/index.test.tsx.snap
@@ -2,16 +2,13 @@
 
 exports[`Tooltip should render correctly 1`] = `
 <DocumentFragment>
-  .cache-fqcxly-StyledChildrenContainer {
+  .cache-yb56yg-StyledChildrenContainer {
   display: inherit;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
 }
 
 <div
     aria-describedby=":r0:"
-    class="cache-fqcxly-StyledChildrenContainer ep3agpf0"
+    class="cache-yb56yg-StyledChildrenContainer ep3agpf0"
     tabindex="0"
   >
     Hover me

--- a/packages/ui/src/components/Tooltip/index.tsx
+++ b/packages/ui/src/components/Tooltip/index.tsx
@@ -94,7 +94,6 @@ const StyledTooltip = styled.div<StyledTooltipProps>`
 
 const StyledChildrenContainer = styled.div`
   display: inherit;
-  width: fit-content;
 `
 
 type TooltipProps = {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Rollback on `width: fit-content` as it changes the width of tooltip children and that's no what we want. Tooltip should be as much neutral as possible and do no change children behavior. 