### PR TITLE
refactor(Carousel): remove styled on carousel items and use flexbox

### DIFF
--- a/.changeset/strong-taxis-kick.md
+++ b/.changeset/strong-taxis-kick.md
@@ -1,0 +1,8 @@
+---
+'@ultraviolet/ui': minor
+---
+
+Refactor `<Carousel />`:
+- Remove border and other styles applied on `<Carousel.Item />` when hovering it.
+- Add new prop `width` to `<Carousel.Item />` to set the width of the item. Default is `240px`.
+- Use flexbox for structure instead of block elements.

--- a/packages/ui/src/components/Carousel/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/Carousel/__stories__/Template.stories.tsx
@@ -1,13 +1,64 @@
+import styled from '@emotion/styled'
 import type { StoryFn } from '@storybook/react'
 import { Carousel } from '..'
 
+const Content = styled.div`
+  background-color: ${({ theme }) => theme.colors.info.background};
+  width: 100%;
+  padding: ${({ theme }) => theme.space['3']};
+  color: ${({ theme }) => theme.colors.info.text};
+  text-align: center;
+`
+
 export const Template: StoryFn<typeof Carousel> = props => (
   <Carousel {...props}>
-    <Carousel.Item>Item 1</Carousel.Item>
-    <Carousel.Item>Item 2</Carousel.Item>
-    <Carousel.Item>Item 3</Carousel.Item>
-    <Carousel.Item>Item 4</Carousel.Item>
-    <Carousel.Item>Item 5</Carousel.Item>
-    <Carousel.Item>Item 6</Carousel.Item>
+    <Carousel.Item>
+      <Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam
+      </Content>
+    </Carousel.Item>
+    <Carousel.Item>
+      <Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </Content>
+    </Carousel.Item>
+    <Carousel.Item>
+      <Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </Content>
+    </Carousel.Item>
+    <Carousel.Item>
+      <Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur.
+      </Content>
+    </Carousel.Item>
+    <Carousel.Item>
+      <Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur.
+      </Content>
+    </Carousel.Item>
+    <Carousel.Item>
+      <Content>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur.
+      </Content>
+    </Carousel.Item>
   </Carousel>
 )

--- a/packages/ui/src/components/Carousel/__tests__/__snapshots__/index.tsx.snap
+++ b/packages/ui/src/components/Carousel/__tests__/__snapshots__/index.tsx.snap
@@ -22,41 +22,37 @@ exports[`Carousel renders correctly with default props 1`] = `
   z-index: auto;
 }
 
-.cache-i20cm0-StyledScrollableWrapper {
+.cache-1v1i1kq-StyledScrollableWrapper {
   overflow-x: scroll;
   overflow-y: hidden;
   white-space: nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   padding: 16px 100px;
+  gap: 16px;
 }
 
-.cache-i20cm0-StyledScrollableWrapper>*:not(:last-child) {
-  margin-right: 16px;
-}
-
-.cache-ycjjoa-StyledBorderWrapper {
-  display: inline-block;
-  border-radius: 4px;
-  border: 1px solid #e9eaeb;
-  height: 261px;
-  width: 248px;
+.cache-11t1kmz-StyledBorderWrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  width: 240px;
   max-width: 240px;
   overflow-wrap: break-word;
   white-space: normal;
+  height: auto;
   cursor: -webkit-grab;
   cursor: grab;
-}
-
-.cache-ycjjoa-StyledBorderWrapper:hover,
-.cache-ycjjoa-StyledBorderWrapper:active,
-.cache-ycjjoa-StyledBorderWrapper:focus {
-  border: 1px solid #521094;
-  -webkit-transition: box-shadow 0.2s ease;
-  transition: box-shadow 0.2s ease;
-  box-shadow: 0px 0px 0px 3px #5e127e40;
-}
-
-.cache-ycjjoa-StyledBorderWrapper img {
-  border-radius: 4px 4px 0 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .cache-1r4agil-StyledAfterScroll {
@@ -84,41 +80,41 @@ exports[`Carousel renders correctly with default props 1`] = `
       data-testid="scrollbar-before"
     />
     <div
-      class="cache-i20cm0-StyledScrollableWrapper e1id70w02"
+      class="cache-1v1i1kq-StyledScrollableWrapper e1id70w02"
       data-testid="scrollbar-wrapper"
     >
       <div
-        class="cache-ycjjoa-StyledBorderWrapper e1id70w00"
+        class="cache-11t1kmz-StyledBorderWrapper e1id70w00"
         draggable="true"
       >
         Item 1
       </div>
       <div
-        class="cache-ycjjoa-StyledBorderWrapper e1id70w00"
+        class="cache-11t1kmz-StyledBorderWrapper e1id70w00"
         draggable="true"
       >
         Item 2
       </div>
       <div
-        class="cache-ycjjoa-StyledBorderWrapper e1id70w00"
+        class="cache-11t1kmz-StyledBorderWrapper e1id70w00"
         draggable="true"
       >
         Item 3
       </div>
       <div
-        class="cache-ycjjoa-StyledBorderWrapper e1id70w00"
+        class="cache-11t1kmz-StyledBorderWrapper e1id70w00"
         draggable="true"
       >
         Item 4
       </div>
       <div
-        class="cache-ycjjoa-StyledBorderWrapper e1id70w00"
+        class="cache-11t1kmz-StyledBorderWrapper e1id70w00"
         draggable="true"
       >
         Item 5
       </div>
       <div
-        class="cache-ycjjoa-StyledBorderWrapper e1id70w00"
+        class="cache-11t1kmz-StyledBorderWrapper e1id70w00"
         draggable="true"
       >
         Item 6

--- a/packages/ui/src/components/Carousel/index.tsx
+++ b/packages/ui/src/components/Carousel/index.tsx
@@ -26,11 +26,9 @@ const StyledScrollableWrapper = styled.div`
   overflow-x: scroll;
   overflow-y: hidden;
   white-space: nowrap;
+  display: flex;
   padding: ${({ theme }) => theme.space['2']} 100px;
-
-  > *:not(:last-child) {
-    margin-right: ${({ theme }) => theme.space['2']};
-  }
+  gap: ${({ theme }) => theme.space['2']};
 `
 
 const StyledAfterScroll = styled.span`
@@ -49,36 +47,31 @@ const StyledAfterScroll = styled.span`
   );
 `
 
-const StyledBorderWrapper = styled.div`
-  display: inline-block;
-  border-radius: ${({ theme }) => theme.radii.default};
-  border: 1px solid ${({ theme }) => theme.colors.neutral.borderWeak};
-  height: 261px;
-  width: 248px;
-  max-width: 240px;
+const StyledBorderWrapper = styled('div', {
+  shouldForwardProp: prop => !['width'].includes(prop),
+})<{ width: string }>`
+  display: flex;
+  align-items: stretch;
+  width: ${({ width }) => width};
+  max-width: ${({ width }) => width};
   overflow-wrap: break-word;
   white-space: normal;
+  height: auto;
   cursor: grab;
-
-  &:hover,
-  &:active,
-  &:focus {
-    border: 1px solid ${({ theme }) => theme.colors.primary.border};
-    transition: box-shadow 0.2s ease;
-    box-shadow: ${({ theme }) => theme.shadows.focusPrimary};
-  }
-
-  img {
-    border-radius: ${({ theme }) => theme.radii.default}
-      ${({ theme }) => theme.radii.default} 0 0;
-  }
+  flex-shrink: 0;
 `
 
 type CarouselItemProps = {
   children: ReactNode
+  width?: string
 }
-export const CarouselItem = ({ children }: CarouselItemProps): JSX.Element => (
-  <StyledBorderWrapper draggable="true">{children}</StyledBorderWrapper>
+export const CarouselItem = ({
+  children,
+  width = '240px',
+}: CarouselItemProps): JSX.Element => (
+  <StyledBorderWrapper width={width} draggable="true">
+    {children}
+  </StyledBorderWrapper>
 )
 
 type CarouselProps = {


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### What is expected?

Carousel is applying style inside of `<Carousel.Item />` with some border and hover effect, we shouldn't do that. Carousel should only provide the structure and not the style.

Refactor `<Carousel />`:
- Remove border and other styles applied on `<Carousel.Item />` when hovering it.
- Add new prop `width` to `<Carousel.Item />` to set the width of the item. Default is `240px`.
- Use flexbox for structure instead of block elements.

## Relevant logs and/or screenshots

<img width="1084" alt="Screenshot 2023-10-12 at 17 45 12" src="https://github.com/scaleway/ultraviolet/assets/15812968/2e4cabcf-a0c8-4dfb-9b47-c4270bd2e70e">

