### PR TITLE
feat(icons): add export to IconName props

### DIFF
--- a/.changeset/fresh-toes-jam.md
+++ b/.changeset/fresh-toes-jam.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/icons": minor
+---
+
+add export to IconName type

--- a/packages/icons/src/components/index.ts
+++ b/packages/icons/src/components/index.ts
@@ -1,3 +1,4 @@
+export type { IconName } from './Icon'
 export { Icon } from './Icon'
 export { CategoryIcon } from './CategoryIcon'
 export { ProductIcon } from './ProductIcon'


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarise concisely:

We need to get the IconName easily for wrapping purpose, extract this props from the component props is quite complex due to forwardRef, having it directly extracted would be really useful

#### The following changes where made:

(Describe what you did)

1. Add missing export type in package ultraviolet/icon

