### PR TITLE
fix(illustrations): to export components in rollup config

### DIFF
--- a/.changeset/warm-mugs-protect.md
+++ b/.changeset/warm-mugs-protect.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/illustrations": patch
+---
+
+Fix export all components in build

--- a/packages/illustrations/rollup.config.mjs
+++ b/packages/illustrations/rollup.config.mjs
@@ -33,6 +33,7 @@ const input = [
   'src/products/index.ts',
   './src/various/*/index.ts',
   'src/various/index.ts',
+  'src/index.ts',
 ]
 
 export default [


### PR DESCRIPTION
## Summary

We forgot to export components in illustration so DynamicIllustration cannot be used.
