### PR TITLE
chore(devDeps): remove deprecated types package of react-datepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "@testing-library/user-event": "14.5.2",
     "@types/node": "20.14.10",
     "@types/react": "18.3.3",
-    "@types/react-datepicker": "6.2.0",
     "@types/react-dom": "18.3.0",
     "@types/zxcvbn": "4.4.4",
     "@ultraviolet/themes": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,7 +76,6 @@
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
     "@types/react": "18.3.3",
-    "@types/react-datepicker": "6.2.0",
     "@types/react-dom": "18.3.0",
     "@ultraviolet/icons": "workspace:*",
     "@ultraviolet/themes": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,6 @@ importers:
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
-      '@types/react-datepicker':
-        specifier: 6.2.0
-        version: 6.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react-dom':
         specifier: 18.3.0
         version: 18.3.0
@@ -664,9 +661,6 @@ importers:
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
-      '@types/react-datepicker':
-        specifier: 6.2.0
-        version: 6.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react-dom':
         specifier: 18.3.0
         version: 18.3.0
@@ -3134,9 +3128,6 @@ packages:
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-
-  '@types/react-datepicker@6.2.0':
-    resolution: {integrity: sha512-+JtO4Fm97WLkJTH8j8/v3Ldh7JCNRwjMYjRaKh4KHH0M3jJoXtwiD3JBCsdlg3tsFIw9eQSqyAPeVDN2H2oM9Q==}
 
   '@types/react-dom@18.3.0':
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
@@ -11573,15 +11564,6 @@ snapshots:
   '@types/qs@6.9.15': {}
 
   '@types/range-parser@1.2.7': {}
-
-  '@types/react-datepicker@6.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/react': 0.26.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/react': 18.3.3
-      date-fns: 3.6.0
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@types/react-dom@18.3.0':
     dependencies:


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Removal of `@types/react-datepicker` as it is deprecated.

<img width="1229" alt="Screenshot 2024-07-16 at 10 52 21" src="https://github.com/user-attachments/assets/27f6f1c2-a066-40aa-8ba3-62dabea3306c">
