### PR TITLE
feat: add title tag to SVG for accebility purpose

### DIFF
--- a/.changeset/chatty-cups-drive.md
+++ b/.changeset/chatty-cups-drive.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/icons": minor
+"@ultraviolet/ui": minor
+---
+
+feat: add title tag to SVG for accessibility purpose

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -217,7 +217,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
     return (
       <SystemIcon
         ref={ref}
-        id={uniqueId}
+        id={title ? uniqueId : undefined}
         sentiment={computedSentiment}
         prominence={prominence}
         size={size}

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import type { consoleLightTheme as theme } from '@ultraviolet/themes'
 import type { FunctionComponent, SVGProps } from 'react'
-import { forwardRef, useMemo } from 'react'
+import { forwardRef, useEffect, useId, useMemo } from 'react'
 import capitalize from '../../utils/capitalize'
 import { ICONS } from './Icons'
 import { SMALL_ICONS } from './SmallIcons'
@@ -125,6 +125,10 @@ type IconProps = {
   variant?: 'outlined' | 'filled'
   'data-testid'?: string
   disabled?: boolean
+  /**
+   * A title to be used by the SCG for accessibility purpose.
+   */
+  title?: string
 } & Pick<
   SVGProps<SVGSVGElement>,
   'className' | 'stroke' | 'cursor' | 'strokeWidth'
@@ -148,9 +152,12 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
       cursor,
       strokeWidth,
       disabled,
+      title,
     },
     ref,
   ) => {
+    const uniqueId = useId()
+
     const computedSentiment = sentiment ?? color
     const SystemIcon = useMemo(() => {
       if (size === 'small' || size === 16) {
@@ -183,9 +190,34 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(
       return '0 0 20 20'
     }, [name, size])
 
+    useEffect(() => {
+      if (title) {
+        const svgElement = document.getElementById(uniqueId)
+
+        if (svgElement) {
+          const titleTag = svgElement.querySelector('title')
+
+          // if a title already exist, update it
+          if (titleTag) {
+            titleTag.textContent = title
+          }
+          // insert the title
+          else {
+            const newTitleTag = document.createElementNS(
+              'http://www.w3.org/2000/svg',
+              'title',
+            )
+            svgElement.insertBefore(newTitleTag, svgElement.firstChild)
+            newTitleTag.textContent = title
+          }
+        }
+      }
+    }, [title, uniqueId])
+
     return (
       <SystemIcon
         ref={ref}
+        id={uniqueId}
         sentiment={computedSentiment}
         prominence={prominence}
         size={size}

--- a/packages/icons/src/components/Icon/index.tsx
+++ b/packages/icons/src/components/Icon/index.tsx
@@ -126,7 +126,7 @@ type IconProps = {
   'data-testid'?: string
   disabled?: boolean
   /**
-   * A title to be used by the SCG for accessibility purpose.
+   * A title to be used by the SVG for accessibility purpose.
    */
   title?: string
 } & Pick<

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -251,7 +251,6 @@ type CommonProps = {
   disabled?: boolean
   iconPosition?: 'left' | 'right'
   iconVariant?: ComponentProps<typeof Icon>['variant']
-  iconTitle?: string
   fullWidth?: boolean
   isLoading?: boolean
   'aria-label'?: string
@@ -325,7 +324,6 @@ export const Button = forwardRef<Element, FinalProps>(
       icon,
       iconPosition = 'left',
       iconVariant,
-      iconTitle,
       fullWidth = false,
       isLoading = false,
       children,
@@ -353,12 +351,7 @@ export const Button = forwardRef<Element, FinalProps>(
     const content = (
       <>
         {!isLoading && icon ? (
-          <Icon
-            name={icon}
-            size="small"
-            variant={iconVariant}
-            title={iconTitle}
-          />
+          <Icon name={icon} size="small" variant={iconVariant} />
         ) : null}
         {isLoading ? (
           <Loader

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -251,6 +251,7 @@ type CommonProps = {
   disabled?: boolean
   iconPosition?: 'left' | 'right'
   iconVariant?: ComponentProps<typeof Icon>['variant']
+  iconTitle?: string
   fullWidth?: boolean
   isLoading?: boolean
   'aria-label'?: string
@@ -324,6 +325,7 @@ export const Button = forwardRef<Element, FinalProps>(
       icon,
       iconPosition = 'left',
       iconVariant,
+      iconTitle,
       fullWidth = false,
       isLoading = false,
       children,
@@ -351,7 +353,12 @@ export const Button = forwardRef<Element, FinalProps>(
     const content = (
       <>
         {!isLoading && icon ? (
-          <Icon name={icon} size="small" variant={iconVariant} />
+          <Icon
+            name={icon}
+            size="small"
+            variant={iconVariant}
+            title={iconTitle}
+          />
         ) : null}
         {isLoading ? (
           <Loader


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

`Icon`s have now an optional title prop, than can be used to add/update a `Title` tag to be ridden by accessibility tools.

#### The following changes where made:

Added an optional prop `title` to `Icon`


