### PR TITLE
feat(List.Row): allow data-dragging and custom styles

### DIFF
--- a/.changeset/proud-days-carry.md
+++ b/.changeset/proud-days-carry.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+List.Row: Allow to pass a data-dragging prop and cusotm style to Row. It allows usage of dnd-kit with List.Row

--- a/packages/ui/src/components/List/Row.tsx
+++ b/packages/ui/src/components/List/Row.tsx
@@ -1,7 +1,7 @@
 import type { Theme } from '@emotion/react'
 import { keyframes, useTheme } from '@emotion/react'
 import styled from '@emotion/styled'
-import type { ReactNode, RefObject } from 'react'
+import type { ComponentProps, ReactNode, RefObject } from 'react'
 import {
   Children,
   forwardRef,
@@ -214,6 +214,8 @@ type RowProps = {
   expandablePadding?: keyof typeof space
   highlightAnimation?: boolean
   'data-testid'?: string
+  style?: ComponentProps<'tr'>['style']
+  'data-dragging'?: boolean
 }
 
 export const Row = forwardRef<HTMLTableRowElement, RowProps>(
@@ -230,6 +232,8 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
       className,
       expandablePadding,
       'data-testid': dataTestid,
+      'data-dragging': dataDragging,
+      style,
     },
     forwardedRef,
   ) => {
@@ -329,6 +333,8 @@ export const Row = forwardRef<HTMLTableRowElement, RowProps>(
           data-testid={dataTestid}
           columns={columns}
           columnsStartAt={(selectable ? 1 : 0) + (expandButton ? 1 : 0)}
+          style={style}
+          data-dragging={dataDragging}
           highlightAnimation={highlightAnimation}
         >
           {selectable ? (


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Allow `List.Row` to be used with dnd-kit by allowing passing `style` and `data-dragging` prop

#### The following changes where made:

1. Add the new props

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
