### PR TITLE
feat(CodeEditor): add auto completion prop

### DIFF
--- a/.changeset/tricky-zebras-marry.md
+++ b/.changeset/tricky-zebras-marry.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/plus": minor
+---
+
+New prop `autoCompletion` on `<CodeEditor />` component

--- a/packages/plus/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/plus/src/components/CodeEditor/CodeEditor.tsx
@@ -20,6 +20,7 @@ type CodeEditorProps = {
   onBlur?: () => void
   height?: string
   readOnly?: boolean
+  autoCompletion?: boolean
 }
 
 export const CodeEditor = ({
@@ -30,6 +31,7 @@ export const CodeEditor = ({
   onBlur,
   height,
   readOnly,
+  autoCompletion,
 }: CodeEditorProps) => (
   <div>
     {title ? (
@@ -49,6 +51,7 @@ export const CodeEditor = ({
       basicSetup={{
         highlightActiveLine: false,
         highlightActiveLineGutter: false,
+        autocompletion: autoCompletion,
       }}
     />
   </div>

--- a/packages/plus/src/components/CodeEditor/__stories__/AutoCompletion.stories.tsx
+++ b/packages/plus/src/components/CodeEditor/__stories__/AutoCompletion.stories.tsx
@@ -1,0 +1,14 @@
+import { Template } from './Template.stories'
+
+export const AutoCompletion = Template.bind({})
+
+AutoCompletion.args = { ...Template.args, autoCompletion: false }
+
+AutoCompletion.parameters = {
+  docs: {
+    description: {
+      story:
+        'AutoCompletion is enabled by default. You can disable it by setting `autoCompletion` to `false`.',
+    },
+  },
+}

--- a/packages/plus/src/components/CodeEditor/__stories__/index.stories.tsx
+++ b/packages/plus/src/components/CodeEditor/__stories__/index.stories.tsx
@@ -7,3 +7,4 @@ export default {
 } as Meta
 
 export { Playground } from './Playground.stories'
+export { AutoCompletion } from './AutoCompletion.stories'


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

#### What is expected?

Add prop `autoCompletion` to allow or not to have auto complete.

## Relevant logs and/or screenshots

<img width="1033" alt="Screenshot 2025-04-17 at 11 38 47" src="https://github.com/user-attachments/assets/5931344f-3062-4b7a-95af-3ba5759a179e" />
