### PR TITLE
fix(SelectInputV2): footer empty state

### DIFF
--- a/.changeset/happy-ravens-move.md
+++ b/.changeset/happy-ravens-move.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`<SelectInputV2 />: hide footer when empty state

--- a/packages/ui/src/components/SelectInputV2/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInputV2/Dropdown.tsx
@@ -65,9 +65,11 @@ const NON_SEARCHABLE_KEYS = [
 const StyledPopup = styled(Popup)`
   width: 100%;
   min-width: 320px;
-  background-color: ${({ theme }) => theme.colors.other.elevation.background.raised};
+  background-color: ${({ theme }) =>
+    theme.colors.other.elevation.background.raised};
   color: ${({ theme }) => theme.colors.neutral.text};
-  box-shadow: ${({ theme }) => `${theme.shadows.raised[0]}, ${theme.shadows.raised[1]}`};
+  box-shadow: ${({ theme }) =>
+    `${theme.shadows.raised[0]}, ${theme.shadows.raised[1]}`};
   padding: ${({ theme }) => theme.space[0]};
   margin-bottom: ${({ theme }) => theme.space[10]};
 `
@@ -123,7 +125,8 @@ const DropdownItem = styled.div<{
 }>`
   text-align:left;
   border: none;
-  background-color: ${({ theme }) => theme.colors.other.elevation.background.raised};
+  background-color: ${({ theme }) =>
+    theme.colors.other.elevation.background.raised};
 
   padding: ${({ theme }) => theme.space['1.5']} ${({ theme }) =>
     theme.space['2']} ${({ theme }) => theme.space['1.5']} ${({ theme }) =>
@@ -812,7 +815,7 @@ export const Dropdown = ({
   }, [displayedOptions, numberOfOptions])
 
   const computedFooter = useMemo(() => {
-    if (footer) {
+    if (footer && !emptyState) {
       if (typeof footer === 'function') {
         return (
           <PopupFooter>{footer(() => setIsDropdownVisible(false))}</PopupFooter>
@@ -823,7 +826,7 @@ export const Dropdown = ({
     }
 
     return null
-  }, [footer, setIsDropdownVisible])
+  }, [emptyState, footer, setIsDropdownVisible])
 
   return (
     <StyledPopup

--- a/packages/ui/src/components/SelectInputV2/__stories__/DropdownAlign.stories.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/DropdownAlign.stories.tsx
@@ -7,12 +7,7 @@ export const DropdownAlign: StoryFn<typeof SelectInputV2> = args => (
   <Stack alignItems="center">
     <Stack gap={5} width="10%">
       <SelectInputV2 {...args} label="Align start (default)" />
-      <SelectInputV2
-        {...args}
-        selectAllGroup
-        label="Align center"
-        dropdownAlign="center"
-      />
+      <SelectInputV2 {...args} label="Align center" dropdownAlign="center" />
     </Stack>
   </Stack>
 )

--- a/packages/ui/src/components/SelectInputV2/__stories__/EmptyState.stories.tsx
+++ b/packages/ui/src/components/SelectInputV2/__stories__/EmptyState.stories.tsx
@@ -70,7 +70,8 @@ EmptyState.decorators = [
 EmptyState.parameters = {
   docs: {
     description: {
-      story: 'Set a custom `EmptyState` when no option is available.',
+      story:
+        'Set a custom `EmptyState` when no option is available. The footer is hidden when there is an empty state.',
     },
   },
 }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?
`SelectInputV2`: Hide footer when there is an empty state