### PR TITLE
fix(SelectableCardGroupField): value 

### DIFF
--- a/.changeset/angry-adults-boil.md
+++ b/.changeset/angry-adults-boil.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`<SelectableCardGroupField />`: prop "value" should not be mandatory

--- a/packages/form/src/components/SelectableCardGroupField/index.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/index.tsx
@@ -11,7 +11,10 @@ type SelectableCardGroupFieldProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues>,
 > = BaseFieldProps<TFieldValues, TFieldName> &
-  Omit<ComponentProps<typeof SelectableCardGroup>, 'name' | 'onChange'>
+  Omit<
+    ComponentProps<typeof SelectableCardGroup>,
+    'name' | 'onChange' | 'value'
+  >
 
 export const SelectableCardGroupField = <
   TFieldValues extends FieldValues,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:
prop "value" should not be mandatory in `SelectableCardGroupField`