### PR TITLE
fix(SelectInput): to display footer when there are values and hide on empty state

### DIFF
--- a/.changeset/easy-words-crash.md
+++ b/.changeset/easy-words-crash.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<SelectInput />` to display footer when there are values and hide on empty state

--- a/packages/ui/src/components/SelectInput/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInput/Dropdown.tsx
@@ -814,7 +814,7 @@ export const Dropdown = ({
   }, [displayedOptions, numberOfOptions])
 
   const computedFooter = useMemo(() => {
-    if (footer && !emptyState) {
+    if (footer && !isEmpty) {
       if (typeof footer === 'function') {
         return (
           <PopupFooter>{footer(() => setIsDropdownVisible(false))}</PopupFooter>
@@ -825,7 +825,7 @@ export const Dropdown = ({
     }
 
     return null
-  }, [emptyState, footer, setIsDropdownVisible])
+  }, [isEmpty, footer, setIsDropdownVisible])
 
   return (
     <StyledPopup


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Fix `<SelectInput />` to display footer when there are values and hide on empty state
