### PR TITLE
feat: remove deprecated Modal, RadioGroup, Separator and Text

### DIFF
--- a/.changeset/sixty-moons-sit.md
+++ b/.changeset/sixty-moons-sit.md
@@ -1,0 +1,19 @@
+---
+"@ultraviolet/ui": major
+---
+
+
+**BREAKING CHANGES**
+
+Deprecated props removed:
+- `Modal`: 
+    - prop "customDialogBackdropStyles" removed -> use "backdropClassName" instead to style the backdrop
+    - prop "customDialogStyles" removed -> use "customDialogStyles" instead to style the dialog
+    - prop "width" removed -> use "size" instead (same possible values)
+    - prop "opened" removed -> use "open" instead
+    - prop "onOpen" removed -> use "show" instead (ModalState)
+    - prop "onClose" removed -> use "close" instead (ModalState)
+    - prop "hide" removed -> use "close" instead (ModalState)
+- `RadioGroup.Radio`: prop "name" removed, it is automatically passed from the parent `RadioGroup`
+- `Separator`: prop "color" removed -> use "sentiment" instead
+- `Text`: prop "color" removed -> use "sentiment" instead

--- a/examples/next/src/components/Card.tsx
+++ b/examples/next/src/components/Card.tsx
@@ -24,7 +24,7 @@ const Card = ({ title, description, icon, className }: CardProps) => (
       <Image src={icon} alt="icon" width={64} height={64} />
     </div>
     <div>
-      <Text as="h3" variant="headingSmall" color="primary">
+      <Text as="h3" variant="headingSmall" sentiment="primary">
         {title}
       </Text>
       {typeof description === 'string' ? (

--- a/examples/next/src/pages/advanced/Introduction.tsx
+++ b/examples/next/src/pages/advanced/Introduction.tsx
@@ -24,10 +24,10 @@ const Introduction = () => (
         <GithubAndDocumentationButtons />
       </Breakpoint>
       <Stack>
-        <Text as="h1" variant="headingLarge" color="primary">
+        <Text as="h1" variant="headingLarge" sentiment="primary">
           Scaleway <b>UI</b>
         </Text>
-        <Text as="h2" variant="heading" color="primary" prominence="weak">
+        <Text as="h2" variant="heading" sentiment="primary" prominence="weak">
           Open Source <br />
           Component Library
         </Text>

--- a/packages/form/src/components/RadioGroupField/__tests__/index.test.tsx
+++ b/packages/form/src/components/RadioGroupField/__tests__/index.test.tsx
@@ -12,8 +12,8 @@ describe('RadioField', () => {
         name="radio"
         legend="Label"
       >
-        <RadioGroupField.Radio name="value-1" value="value-1" label="Radio 1" />
-        <RadioGroupField.Radio name="value-2" value="value-2" label="Radio 2" />
+        <RadioGroupField.Radio value="value-1" label="Radio 1" />
+        <RadioGroupField.Radio value="value-2" label="Radio 2" />
       </RadioGroupField>,
     )
     const [firstInput, secondInput] = screen.getAllByRole('radio', {
@@ -37,8 +37,8 @@ describe('RadioField', () => {
         onChange={onChange}
         legend="RadioGroupField events"
       >
-        <RadioGroupField.Radio name="value-1" value="value-1" label="Radio 1" />
-        <RadioGroupField.Radio name="value-2" value="value-2" label="Radio 2" />
+        <RadioGroupField.Radio value="value-1" label="Radio 1" />
+        <RadioGroupField.Radio value="value-2" label="Radio 2" />
       </RadioGroupField>,
     )
     const input = screen.getAllByRole('radio', { hidden: true })[0]

--- a/packages/plus/src/components/EstimateCost/Components/Item.tsx
+++ b/packages/plus/src/components/EstimateCost/Components/Item.tsx
@@ -417,7 +417,7 @@ export const Item = memo(
                   </StyledDiv>
                 ) : null}
                 {subLabel && !isOverlay ? (
-                  <StyledText as="p" variant="body" color="primary" italic>
+                  <StyledText as="p" variant="body" sentiment="primary" italic>
                     {subLabel}
                   </StyledText>
                 ) : null}
@@ -469,7 +469,7 @@ export const Item = memo(
                       ? 'weak'
                       : 'default'
                   }
-                  color={
+                  sentiment={
                     computedItemPrice === 0 && computedMaxItemPrice === 0
                       ? 'neutral'
                       : 'primary'

--- a/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
+++ b/packages/plus/src/components/EstimateCost/EstimateCostContent.tsx
@@ -431,7 +431,7 @@ export const EstimateCostContent = ({
                     <StyledText
                       as="h3"
                       variant="heading"
-                      color="primary"
+                      sentiment="primary"
                       isBeta={isBeta}
                     >
                       <LineThrough

--- a/packages/plus/src/components/Navigation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/Navigation/__tests__/__snapshots__/index.test.tsx.snap
@@ -1758,7 +1758,6 @@ exports[`Navigation > click on expand / collapse button 1`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-41 emotion-42 emotion-43"
-              color="neutral"
               role="separator"
             />
             <div
@@ -2836,7 +2835,6 @@ exports[`Navigation > click on expand / collapse button 2`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-22 emotion-23 emotion-24"
-              color="neutral"
               role="separator"
             />
             <div
@@ -4747,7 +4745,6 @@ exports[`Navigation > pin and unpin an item 1`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-41 emotion-42 emotion-43"
-              color="neutral"
               role="separator"
             />
             <div
@@ -6714,7 +6711,6 @@ exports[`Navigation > pin and unpin an item 2`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-41 emotion-42 emotion-43"
-              color="neutral"
               role="separator"
             />
             <div
@@ -8922,7 +8918,6 @@ exports[`Navigation > pin and unpin an item 3`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-64 emotion-65 emotion-66"
-              color="neutral"
               role="separator"
             />
             <div
@@ -10075,7 +10070,6 @@ exports[`Navigation > render with basic content 1`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-41 emotion-42 emotion-43"
-              color="neutral"
               role="separator"
             />
             <div
@@ -11002,7 +10996,6 @@ exports[`Navigation > render without pinnedFeature 1`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-12 emotion-13 emotion-14"
-              color="neutral"
               role="separator"
             />
             <div
@@ -12942,7 +12935,6 @@ exports[`Navigation > resize manually the navigation using slider 1`] = `
             <hr
               aria-orientation="horizontal"
               class="emotion-41 emotion-42 emotion-43"
-              color="neutral"
               role="separator"
             />
             <div

--- a/packages/plus/src/components/Plans/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/plus/src/components/Plans/__tests__/__snapshots__/index.test.tsx.snap
@@ -635,7 +635,6 @@ exports[`Plans > should work with default props 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                       <p
@@ -646,7 +645,6 @@ exports[`Plans > should work with default props 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                     </div>
@@ -2126,7 +2124,6 @@ exports[`Plans > should work with group 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                       <p
@@ -2137,7 +2134,6 @@ exports[`Plans > should work with group 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                     </div>
@@ -3065,7 +3061,6 @@ exports[`Plans > should work with hideFeatureText 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-35 emotion-36"
-                        color="neutral"
                         role="separator"
                       />
                       <p
@@ -3076,7 +3071,6 @@ exports[`Plans > should work with hideFeatureText 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-35 emotion-36"
-                        color="neutral"
                         role="separator"
                       />
                     </div>
@@ -3997,7 +3991,6 @@ exports[`Plans > should work with hideLabels 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                       <p
@@ -4008,7 +4001,6 @@ exports[`Plans > should work with hideLabels 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                     </div>
@@ -4931,7 +4923,6 @@ exports[`Plans > should work with value 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                       <p
@@ -4942,7 +4933,6 @@ exports[`Plans > should work with value 1`] = `
                       <hr
                         aria-orientation="horizontal"
                         class="emotion-37 emotion-38"
-                        color="neutral"
                         role="separator"
                       />
                     </div>

--- a/packages/ui/src/__stories__/Tools/ThemeGenerator/ThemeResult/Demo.tsx
+++ b/packages/ui/src/__stories__/Tools/ThemeGenerator/ThemeResult/Demo.tsx
@@ -222,21 +222,9 @@ export const Demo = () => {
                     setRadioState(event.target.value)
                   }
                 >
-                  <RadioGroup.Radio
-                    value="option-1"
-                    name="option-1"
-                    label="Version 1.3.0"
-                  />
-                  <RadioGroup.Radio
-                    value="option-2"
-                    name="option-2"
-                    label="Version 1.2.0"
-                  />
-                  <RadioGroup.Radio
-                    value="option-3"
-                    name="option-3"
-                    label="Version 1.1.0"
-                  />
+                  <RadioGroup.Radio value="option-1" label="Version 1.3.0" />
+                  <RadioGroup.Radio value="option-2" label="Version 1.2.0" />
+                  <RadioGroup.Radio value="option-3" label="Version 1.1.0" />
                 </RadioGroup>
               </Stack>
             </Card>

--- a/packages/ui/src/components/Drawer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Drawer/__tests__/__snapshots__/index.test.tsx.snap
@@ -934,7 +934,6 @@ exports[`Drawer > renders with disclosure and onClose 1`] = `
           <hr
             aria-orientation="horizontal"
             class="emotion-10 emotion-11"
-            color="neutral"
             role="separator"
           />
           <div

--- a/packages/ui/src/components/LineChart/CustomLegend.tsx
+++ b/packages/ui/src/components/LineChart/CustomLegend.tsx
@@ -55,7 +55,7 @@ const StyledText = styled(Text)`
 `
 
 const Cell = ({ value, variant }: CellProps) => (
-  <StyledText variant={variant} color="neutral" as="span">
+  <StyledText variant={variant} sentiment="neutral" as="span">
     {value as string | number}
   </StyledText>
 )

--- a/packages/ui/src/components/Modal/ModalContent.tsx
+++ b/packages/ui/src/components/Modal/ModalContent.tsx
@@ -17,7 +17,6 @@ const StyledContainer = styled.div`
 type ModalContentProps = ComponentProps<typeof Modal> & {
   visible: boolean
   open: boolean
-  opened: boolean
   placement: ModalPlacement
   finalSize: ModalSize
   finalId: string
@@ -31,7 +30,6 @@ type ModalContentProps = ComponentProps<typeof Modal> & {
 export const ModalContent = ({
   visible,
   open,
-  opened,
   placement,
   finalSize,
   ariaLabel,
@@ -42,8 +40,6 @@ export const ModalContent = ({
   className,
   backdropClassName,
   dataTestId,
-  customDialogStyles,
-  customDialogBackdropStyles,
   isClosable,
   children,
   handleOpen,
@@ -51,9 +47,9 @@ export const ModalContent = ({
   finalId,
   image,
 }: ModalContentProps) =>
-  visible || open || opened ? (
+  visible || open ? (
     <Dialog
-      open={visible || open || opened}
+      open={visible || open}
       placement={placement}
       size={finalSize}
       ariaLabel={ariaLabel}
@@ -65,19 +61,14 @@ export const ModalContent = ({
       backdropClassName={backdropClassName}
       data-testid={dataTestId}
       id={finalId}
-      dialogCss={customDialogStyles}
-      backdropCss={customDialogBackdropStyles}
       image={image}
     >
       <>
         {typeof children === 'function'
           ? children({
               visible,
-              onClose: handleClose,
-              onOpen: handleOpen,
               toggle: handleToggle,
               modalId: finalId,
-              hide: handleClose,
               close: handleClose,
               show: handleOpen,
             })

--- a/packages/ui/src/components/Modal/__stories__/Carousel.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/Carousel.stories.tsx
@@ -22,7 +22,7 @@ export const Carousel: StoryFn = props => {
   return (
     <Modal
       image={IMAGES_STEP[step]}
-      size="medium"
+      size="xsmall"
       disclosure={
         <Button onClick={() => setStep(0)}>Open Carousel Modal</Button>
       }
@@ -67,7 +67,7 @@ export const Carousel: StoryFn = props => {
 Carousel.parameters = {
   docs: {
     description: {
-      story: 'Add an image at the top of the modal.',
+      story: 'It is possible to create a carousel',
     },
   },
 }

--- a/packages/ui/src/components/Modal/__stories__/Size.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/Size.stories.tsx
@@ -5,14 +5,14 @@ import { MODAL_WIDTH } from '../constants'
 
 export const Size: StoryFn = props => (
   <>
-    {Object.keys(MODAL_WIDTH).map(width => (
-      <div style={{ display: 'inline-block', padding: 16 }} key={width}>
+    {Object.keys(MODAL_WIDTH).map(size => (
+      <div style={{ display: 'inline-block', padding: 16 }} key={size}>
         <Modal
           {...props}
-          size={width as keyof typeof MODAL_WIDTH}
-          disclosure={<Button>{width}</Button>}
+          size={size as keyof typeof MODAL_WIDTH}
+          disclosure={<Button>{size}</Button>}
         >
-          <div style={{ padding: 32 }}>Content of the {width} modal</div>
+          <div style={{ padding: 32 }}>Content of the {size} modal</div>
         </Modal>
       </div>
     ))}
@@ -21,6 +21,6 @@ export const Size: StoryFn = props => (
 
 Size.parameters = {
   docs: {
-    description: { story: 'Here is a list of all the width values we support' },
+    description: { story: 'Here is a list of all the size values we support' },
   },
 }

--- a/packages/ui/src/components/Modal/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Modal/__tests__/__snapshots__/index.test.tsx.snap
@@ -8,31 +8,7 @@ exports[`Modal > renders open custom size 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Modal > renders open custom size and width (size take predecence) 1`] = `
-<DocumentFragment>
-  <div
-    data-testid="testing"
-  />
-</DocumentFragment>
-`;
-
-exports[`Modal > renders open custom width 1`] = `
-<DocumentFragment>
-  <div
-    data-testid="testing"
-  />
-</DocumentFragment>
-`;
-
 exports[`Modal > renders with custom classNames 1`] = `
-<DocumentFragment>
-  <div
-    data-testid="testing"
-  />
-</DocumentFragment>
-`;
-
-exports[`Modal > renders with customStyle 1`] = `
 <DocumentFragment>
   <div
     data-testid="testing"
@@ -118,22 +94,6 @@ exports[`Modal > renders with disclosure and onClose 1`] = `
     </button>
   </div>
   @keyframes animation-0 {
-  0% {
-    -webkit-transform: translateY(+100%);
-    -moz-transform: translateY(+100%);
-    -ms-transform: translateY(+100%);
-    transform: translateY(+100%);
-  }
-
-  100% {
-    -webkit-transform: translateY(0%);
-    -moz-transform: translateY(0%);
-    -ms-transform: translateY(0%);
-    transform: translateY(0%);
-  }
-}
-
-@keyframes animation-0 {
   0% {
     -webkit-transform: translateY(+100%);
     -moz-transform: translateY(+100%);

--- a/packages/ui/src/components/Modal/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Modal/__tests__/index.test.tsx
@@ -73,34 +73,9 @@ describe('Modal', () => {
       </Modal>,
     ))
 
-  test(`renders open custom width`, () =>
-    shouldMatchEmotionSnapshotWithPortal(
-      <Modal open width="medium">
-        <div>test</div>
-      </Modal>,
-    ))
-
   test(`renders open custom size`, () =>
     shouldMatchEmotionSnapshotWithPortal(
       <Modal open size="medium">
-        <div>test</div>
-      </Modal>,
-    ))
-
-  test(`renders open custom size and width (size take predecence)`, () =>
-    shouldMatchEmotionSnapshotWithPortal(
-      <Modal open size="medium" width="large">
-        <div>test</div>
-      </Modal>,
-    ))
-
-  test(`renders with customStyle`, () =>
-    shouldMatchEmotionSnapshotWithPortal(
-      <Modal
-        open
-        customDialogBackdropStyles={customDialogBackdropStyles}
-        customDialogStyles={customDialogStyles}
-      >
         <div>test</div>
       </Modal>,
     ))
@@ -228,27 +203,6 @@ describe('Modal', () => {
       </Modal>,
     )
     const modalButton = screen.getByRole('button')
-    await userEvent.click(modalButton)
-    expect(mockOnClick).toBeCalledTimes(1)
-  })
-
-  test(`should call 'hide' prop from render props`, async () => {
-    renderWithTheme(
-      <Modal ariaLabel="modal-test" id="modal-test" open>
-        {({ hide }) => (
-          <button
-            type="button"
-            onClick={() => {
-              mockOnClick()
-              hide()
-            }}
-          >
-            Close
-          </button>
-        )}
-      </Modal>,
-    )
-    const modalButton = screen.getByRole('button', { name: 'Close' })
     await userEvent.click(modalButton)
     expect(mockOnClick).toBeCalledTimes(1)
   })

--- a/packages/ui/src/components/Modal/components/Dialog.tsx
+++ b/packages/ui/src/components/Modal/components/Dialog.tsx
@@ -79,7 +79,8 @@ export const StyledDialog = styled('dialog', {
   border: 0;
   padding: ${({ theme }) => theme.space['3']};
   width: ${MODAL_WIDTH.medium}rem;
-  box-shadow: ${({ theme }) => `${theme.shadows.overlay[0]}, ${theme.shadows.overlay[1]}`};
+  box-shadow: ${({ theme }) =>
+    `${theme.shadows.overlay[0]}, ${theme.shadows.overlay[1]}`};
   
 
 
@@ -137,8 +138,6 @@ export const Dialog = ({
   preventBodyScroll,
   hideOnEsc,
   backdropClassName,
-  dialogCss,
-  backdropCss,
   image,
 }: DialogProps) => {
   const [isVisible, setIsVisible] = useState(false)
@@ -309,7 +308,6 @@ export const Dialog = ({
       data-open
       onClick={handleClose}
       className={backdropClassName}
-      css={backdropCss}
       data-testid={dataTestId ? `${dataTestId}-backdrop` : undefined}
       onFocus={stopFocus}
       data-animation={animation}
@@ -317,7 +315,6 @@ export const Dialog = ({
       id="backdrop-modal"
     >
       <StyledDialog
-        css={dialogCss}
         onKeyUp={handleKeyUp}
         onKeyDown={handleFocusTrap}
         className={className}

--- a/packages/ui/src/components/Modal/components/Disclosure.tsx
+++ b/packages/ui/src/components/Modal/components/Disclosure.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type { PropsWithRef } from 'react'
 import { cloneElement, isValidElement, useEffect, useMemo } from 'react'
 import type { DisclosureProps } from '../types'
 
@@ -26,11 +25,8 @@ export const Disclosure = ({
     if (typeof disclosure === 'function') {
       return disclosure({
         visible,
-        onClose: handleClose,
         toggle,
-        onOpen: handleOpen,
         modalId: id,
-        hide: handleClose,
         close: handleClose,
         show: handleOpen,
       })
@@ -47,5 +43,5 @@ export const Disclosure = ({
     ref,
     'aria-controls': id,
     'aria-haspopup': 'dialog',
-  } as unknown as PropsWithRef<typeof disclosure>)
+  } as unknown as typeof disclosure)
 }

--- a/packages/ui/src/components/Modal/index.tsx
+++ b/packages/ui/src/components/Modal/index.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { ReactElement, ReactNode } from 'react'
-import type React from 'react'
 import { useCallback, useContext, useId, useRef, useState } from 'react'
 import { ModalContent } from './ModalContent'
 import { ModalContext, ModalProvider } from './ModalProvider'
@@ -19,28 +18,12 @@ export type ModalProps = {
   onClose?: () => void
   onBeforeClose?: () => Promise<void> | void
   open?: boolean
-  /**
-   * @deprecated You should use open prop instead
-   */
-  opened?: boolean
   placement?: ModalPlacement
   size?: ModalSize
-  /**
-   * @deprecated You should use size prop instead
-   */
-  width?: ModalSize
   children: ReactNode | ((args: ModalState) => ReactNode)
   className?: string
   'data-testid'?: string
   backdropClassName?: string
-  /**
-   * @deprecated You should use backdropClassName instead
-   */
-  customDialogBackdropStyles?: React.JSX.IntrinsicAttributes['css']
-  /**
-   * @deprecated You should use className instead
-   */
-  customDialogStyles?: React.JSX.IntrinsicAttributes['css']
   /**
    * Add an image a the top of the modal.
    */
@@ -61,16 +44,12 @@ export const Modal = ({
   onClose,
   onBeforeClose,
   open = false,
-  opened = false,
   placement = 'center',
   preventBodyScroll = true,
-  size,
+  size = 'small',
   className,
   'data-testid': dataTestId,
   backdropClassName,
-  width = 'small',
-  customDialogStyles,
-  customDialogBackdropStyles,
   image,
 }: ModalProps) => {
   // Used for disclosure usage only
@@ -101,7 +80,6 @@ export const Modal = ({
   }, [])
 
   const finalId = id ?? controlId
-  const finalSize = size ?? width
 
   // using context we can check if the modal is being used inside another modal
   // the first modal to render will create the context, and the others will use it.
@@ -124,10 +102,9 @@ export const Modal = ({
         <ModalProvider>
           <ModalContent
             open={open}
-            opened={opened}
             visible={visible}
             placement={placement}
-            finalSize={finalSize}
+            finalSize={size}
             ariaLabel={ariaLabel}
             hideOnClickOutside={hideOnClickOutside}
             hideOnEsc={hideOnEsc}
@@ -136,8 +113,6 @@ export const Modal = ({
             className={className}
             backdropClassName={backdropClassName}
             dataTestId={dataTestId}
-            customDialogStyles={customDialogStyles}
-            customDialogBackdropStyles={customDialogBackdropStyles}
             isClosable={isClosable}
             handleOpen={handleOpen}
             handleToggle={handleToggle}
@@ -150,10 +125,9 @@ export const Modal = ({
       ) : (
         <ModalContent
           open={open}
-          opened={opened}
           visible={visible}
           placement={placement}
-          finalSize={finalSize}
+          finalSize={size}
           ariaLabel={ariaLabel}
           hideOnClickOutside={hideOnClickOutside}
           hideOnEsc={hideOnEsc}
@@ -162,8 +136,6 @@ export const Modal = ({
           className={className}
           backdropClassName={backdropClassName}
           dataTestId={dataTestId}
-          customDialogStyles={customDialogStyles}
-          customDialogBackdropStyles={customDialogBackdropStyles}
           isClosable={isClosable}
           handleOpen={handleOpen}
           handleToggle={handleToggle}

--- a/packages/ui/src/components/Modal/types.ts
+++ b/packages/ui/src/components/Modal/types.ts
@@ -1,5 +1,4 @@
 import type { ReactElement, ReactNode, RefObject } from 'react'
-import type React from 'react'
 
 export type ModalSize = 'large' | 'medium' | 'small' | 'xsmall' | 'xxsmall'
 
@@ -15,21 +14,9 @@ export type ModalPlacement =
   | 'left'
 
 export type ModalState = {
-  /**
-   * @deprecated use show
-   */
-  onOpen: () => void
-  /**
-   * @deprecated use close
-   */
-  onClose: () => void
   toggle: () => void
   visible: boolean
   modalId: string
-  /**
-   * @deprecated use close
-   */
-  hide: () => void
   close: () => void
   show: () => void
 }
@@ -58,7 +45,5 @@ export type DialogProps = {
   onClose: () => void
   'data-testid'?: string
   children: ReactNode
-  backdropCss: React.JSX.IntrinsicAttributes['css']
-  dialogCss: React.JSX.IntrinsicAttributes['css']
   image?: string
 }

--- a/packages/ui/src/components/RadioGroup/__tests__/index.test.tsx
+++ b/packages/ui/src/components/RadioGroup/__tests__/index.test.tsx
@@ -12,8 +12,8 @@ describe('RadioGroup', () => {
         name="radio"
         legend="Label"
       >
-        <RadioGroup.Radio name="value-1" value="value-1" label="Radio 1" />
-        <RadioGroup.Radio name="value-2" value="value-2" label="Radio 2" />
+        <RadioGroup.Radio value="value-1" label="Radio 1" />
+        <RadioGroup.Radio value="value-2" label="Radio 2" />
       </RadioGroup>,
     ))
 
@@ -26,8 +26,8 @@ describe('RadioGroup', () => {
         legend="Label"
         direction="row"
       >
-        <RadioGroup.Radio name="value-1" value="value-1" label="Radio 1" />
-        <RadioGroup.Radio name="value-2" value="value-2" label="Radio 2" />
+        <RadioGroup.Radio value="value-1" label="Radio 1" />
+        <RadioGroup.Radio value="value-2" label="Radio 2" />
       </RadioGroup>,
     ))
 
@@ -40,8 +40,8 @@ describe('RadioGroup', () => {
         legend="Label"
         helper="Helper content"
       >
-        <RadioGroup.Radio name="value-1" value="value-1" label="Radio 1" />
-        <RadioGroup.Radio name="value-2" value="value-2" label="Radio 2" />
+        <RadioGroup.Radio value="value-1" label="Radio 1" />
+        <RadioGroup.Radio value="value-2" label="Radio 2" />
       </RadioGroup>,
     ))
 
@@ -54,16 +54,14 @@ describe('RadioGroup', () => {
         legend="Label"
         error="Eror content"
       >
-        <RadioGroup.Radio name="value-1" value="value-1" label="Radio 1" />
-        <RadioGroup.Radio name="value-2" value="value-2" label="Radio 2" />
+        <RadioGroup.Radio value="value-1" label="Radio 1" />
+        <RadioGroup.Radio value="value-2" label="Radio 2" />
       </RadioGroup>,
     ))
 
   test('throws if RadioGroup.Radio used without RadioGroup', () => {
     expect(() =>
-      render(
-        <RadioGroup.Radio name="value-1" value="value-1" label="Radio 1" />,
-      ),
+      render(<RadioGroup.Radio value="value-1" label="Radio 1" />),
     ).toThrow('RadioGroup.Radio can only be used inside a RadioGroup')
   })
 })

--- a/packages/ui/src/components/RadioGroup/index.tsx
+++ b/packages/ui/src/components/RadioGroup/index.tsx
@@ -27,20 +27,13 @@ const RadioGroupContext = createContext<RadioGroupContextType | undefined>(
 
 type RadioGroupRadioProps = Omit<
   ComponentProps<typeof Radio>,
-  'onChange' | 'checked' | 'required'
-> & {
-  /**
-   * @deprecated you don't need to use `name` anymore, the name will be passed from the parent `RadioGroup`.
-   */
-  name?: string
-}
-
+  'onChange' | 'checked' | 'required' | 'name'
+>
 const RadioGroupRadio = ({
   onFocus,
   onBlur,
   disabled,
   error,
-  name,
   value,
   label,
   helper,
@@ -66,7 +59,7 @@ const RadioGroupRadio = ({
       onBlur={onBlur}
       disabled={disabled}
       error={error || errorContext}
-      name={groupName ?? name}
+      name={groupName}
       value={value}
       label={label}
       helper={helper}

--- a/packages/ui/src/components/Separator/__stories__/Color.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/Color.stories.tsx
@@ -1,7 +1,0 @@
-import { Template } from './Template.stories'
-
-export const Color = Template.bind({})
-
-Color.args = {
-  color: 'primary',
-}

--- a/packages/ui/src/components/Separator/__stories__/Sentiment.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/Sentiment.stories.tsx
@@ -1,0 +1,7 @@
+import { Template } from './Template.stories'
+
+export const Sentiment = Template.bind({})
+
+Sentiment.args = {
+  sentiment: 'primary',
+}

--- a/packages/ui/src/components/Separator/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/index.stories.tsx
@@ -9,5 +9,5 @@ export default {
 export { Playground } from './Playground.stories'
 export { Thickness } from './Thickness.stories'
 export { Direction } from './Direction.stories'
-export { Color } from './Color.stories'
+export { Sentiment } from './Sentiment.stories'
 export { Icon } from './Icon.stories'

--- a/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Separator/__tests__/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`Separator > renders correctly horizontally 1`] = `
     <hr
       aria-orientation="horizontal"
       class="emotion-0 emotion-1"
-      color="neutral"
       role="separator"
     />
   </div>
@@ -45,59 +44,6 @@ exports[`Separator > renders correctly vertically 1`] = `
     <hr
       aria-orientation="vertical"
       class="emotion-0 emotion-1"
-      color="neutral"
-      role="separator"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Separator > renders correctly with custom color 1`] = `
-<DocumentFragment>
-  .emotion-0 {
-  margin: 0;
-  border: 0;
-  width: auto;
-  height: 1px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  background-color: #e9eaeb;
-}
-
-<div
-    data-testid="testing"
-  >
-    <hr
-      aria-orientation="horizontal"
-      class="emotion-0 emotion-1"
-      color="primary"
-      role="separator"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`Separator > renders correctly with custom color 2`] = `
-<DocumentFragment>
-  .emotion-0 {
-  margin: 0;
-  border: 0;
-  width: auto;
-  height: 1px;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  background-color: #8c40ef;
-}
-
-<div
-    data-testid="testing"
-  >
-    <hr
-      aria-orientation="horizontal"
-      class="emotion-0 emotion-1"
-      color="neutral"
       role="separator"
     />
   </div>
@@ -162,7 +108,6 @@ exports[`Separator > renders correctly with custom icon 1`] = `
     >
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
       <svg
         class="emotion-4 emotion-5"
@@ -179,7 +124,6 @@ exports[`Separator > renders correctly with custom icon 1`] = `
       </svg>
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
     </div>
   </div>
@@ -244,7 +188,6 @@ exports[`Separator > renders correctly with custom icon horizontally 1`] = `
     >
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
       <svg
         class="emotion-4 emotion-5"
@@ -261,7 +204,6 @@ exports[`Separator > renders correctly with custom icon horizontally 1`] = `
       </svg>
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
     </div>
   </div>
@@ -326,7 +268,6 @@ exports[`Separator > renders correctly with custom icon vertically 1`] = `
     >
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
       <svg
         class="emotion-4 emotion-5"
@@ -343,9 +284,33 @@ exports[`Separator > renders correctly with custom icon vertically 1`] = `
       </svg>
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
     </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Separator > renders correctly with custom sentiment 1`] = `
+<DocumentFragment>
+  .emotion-0 {
+  margin: 0;
+  border: 0;
+  width: auto;
+  height: 1px;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  background-color: #8c40ef;
+}
+
+<div
+    data-testid="testing"
+  >
+    <hr
+      aria-orientation="horizontal"
+      class="emotion-0 emotion-1"
+      role="separator"
+    />
   </div>
 </DocumentFragment>
 `;
@@ -408,7 +373,6 @@ exports[`Separator > renders correctly with custom sentiment and icon 1`] = `
     >
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
       <svg
         class="emotion-4 emotion-5"
@@ -425,7 +389,6 @@ exports[`Separator > renders correctly with custom sentiment and icon 1`] = `
       </svg>
       <hr
         class="emotion-2 emotion-3"
-        color="neutral"
       />
     </div>
   </div>
@@ -451,7 +414,6 @@ exports[`Separator > renders correctly with custom thickness 1`] = `
     <hr
       aria-orientation="horizontal"
       class="emotion-0 emotion-1"
-      color="neutral"
       role="separator"
     />
   </div>
@@ -477,7 +439,6 @@ exports[`Separator > renders correctly with default props 1`] = `
     <hr
       aria-orientation="horizontal"
       class="emotion-0 emotion-1"
-      color="neutral"
       role="separator"
     />
   </div>

--- a/packages/ui/src/components/Separator/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Separator/__tests__/index.test.tsx
@@ -13,10 +13,7 @@ describe('Separator', () => {
   test(`renders correctly horizontally`, () =>
     shouldMatchEmotionSnapshot(<Separator direction="horizontal" />))
 
-  test(`renders correctly with custom color`, () =>
-    shouldMatchEmotionSnapshot(<Separator color="primary" />))
-
-  test(`renders correctly with custom color`, () =>
+  test(`renders correctly with custom sentiment`, () =>
     shouldMatchEmotionSnapshot(<Separator sentiment="primary" />))
 
   test(`renders correctly with custom icon`, () =>

--- a/packages/ui/src/components/Separator/index.tsx
+++ b/packages/ui/src/components/Separator/index.tsx
@@ -12,8 +12,7 @@ type StyledIconProps = {
 }
 
 const StyledIconWrapper = styled('div', {
-  shouldForwardProp: prop =>
-    !['direction', 'color', 'sentiment'].includes(prop),
+  shouldForwardProp: prop => !['direction', 'sentiment'].includes(prop),
 })<StyledIconProps>`
   display: flex;
   flex-direction: ${({ direction }) =>
@@ -51,10 +50,6 @@ const StyledHr = styled('hr', {
 type SeparatorProps = {
   direction?: Direction
   thickness?: number
-  /**
-   * @deprecated Use `sentiment` instead
-   */
-  color?: Color
   sentiment?: Color
   className?: string
   'data-testid'?: string
@@ -67,7 +62,6 @@ type SeparatorProps = {
 export const Separator = ({
   direction = 'horizontal',
   thickness = 1,
-  color = 'neutral',
   sentiment = 'neutral',
   className,
   'data-testid': dataTestId,
@@ -81,12 +75,10 @@ export const Separator = ({
       className={className}
       data-testid={dataTestId}
       sentiment={sentiment}
-      color={color}
     >
       <StyledHr
         direction={direction}
         thickness={thickness}
-        color={color}
         sentiment={sentiment}
         hasIcon
       />
@@ -94,7 +86,6 @@ export const Separator = ({
       <StyledHr
         direction={direction}
         thickness={thickness}
-        color={color}
         sentiment={sentiment}
         hasIcon
       />
@@ -105,7 +96,6 @@ export const Separator = ({
       aria-orientation={direction}
       direction={direction}
       thickness={thickness}
-      color={color}
       sentiment={sentiment}
       className={className}
       data-testid={dataTestId}

--- a/packages/ui/src/components/Table/HeaderCell.tsx
+++ b/packages/ui/src/components/Table/HeaderCell.tsx
@@ -127,7 +127,7 @@ export const HeaderCell = ({
       <StyledText
         as="div"
         variant="bodySmall"
-        color={order !== undefined ? 'primary' : 'neutral'}
+        sentiment={order !== undefined ? 'primary' : 'neutral'}
       >
         {children}
         {info ? (

--- a/packages/ui/src/components/Text/__stories__/Prominence.stories.tsx
+++ b/packages/ui/src/components/Text/__stories__/Prominence.stories.tsx
@@ -3,7 +3,7 @@ import { Template } from './Template.stories'
 export const Prominence = Template.bind({})
 Prominence.args = {
   children: 'This is a colored text with prominence',
-  color: 'danger',
+  sentiment: 'danger',
   prominence: 'weak',
   variant: 'body',
 }

--- a/packages/ui/src/components/Text/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Text/__stories__/Sentiments.stories.tsx
@@ -32,8 +32,7 @@ export const Sentiments: StoryFn<ComponentProps<typeof Text>> = args => (
 Sentiments.parameters = {
   docs: {
     description: {
-      story:
-        'Set a sentiment using `sentiment` property. (`color` prop is deprecated but still works and has the same effect)',
+      story: 'Set a sentiment using `sentiment` property.',
     },
   },
 }

--- a/packages/ui/src/components/Text/index.tsx
+++ b/packages/ui/src/components/Text/index.tsx
@@ -6,7 +6,7 @@ import type { CSSProperties, ElementType, ReactNode } from 'react'
 import { useRef } from 'react'
 import recursivelyGetChildrenString from '../../helpers/recursivelyGetChildrenString'
 import { useIsOverflowing } from '../../hooks/useIsOverflowing'
-import type { Color, ExtendedColor } from '../../theme'
+import type { ExtendedColor } from '../../theme'
 import { typography } from '../../theme'
 import capitalize from '../../utils/capitalize'
 import { Tooltip } from '../Tooltip'
@@ -73,7 +73,15 @@ const generateStyles = ({
       : undefined
 
   return `
-    ${sentiment ? `color: ${!isSentimentMonochrome ? textColor : theme.colors.other.monochrome[sentiment].text};` : ''}
+    ${
+      sentiment
+        ? `color: ${
+            !isSentimentMonochrome
+              ? textColor
+              : theme.colors.other.monochrome[sentiment].text
+          };`
+        : ''
+    }
 
     font-size: ${theme.typography[variant].fontSize};
     font-family: ${theme.typography[variant].fontFamily};
@@ -103,10 +111,6 @@ type TextProps = {
   children: ReactNode
   placement?: PlacementProps
   variant: TextVariant
-  /**
-   * @deprecated use `sentiment` property instead
-   */
-  color?: Color
   sentiment?: ExtendedColor
   prominence?: ProminenceProps
   as: ElementType
@@ -159,7 +163,6 @@ export const Text = ({
   variant,
   children,
   as,
-  color,
   sentiment,
   oneLine = false,
   placement,
@@ -176,7 +179,6 @@ export const Text = ({
   'data-testid': dataTestId,
   'aria-hidden': ariaHidden,
 }: TextProps) => {
-  const computedSentiment = sentiment ?? color
   const elementRef = useRef(null)
   const isOverflowing = useIsOverflowing(elementRef)
 
@@ -189,7 +191,7 @@ export const Text = ({
         as={as}
         placement={placement}
         prominence={prominence}
-        sentiment={computedSentiment}
+        sentiment={sentiment}
         variant={variant}
         oneLine={oneLine}
         className={className}


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarise concisely:

#### The following changes where made:
**BREAKING CHANGES**

Deprecated props removed:
- `Modal`: 
    - prop "customDialogBackdropStyles" removed -> use "backdropClassName" instead to style the backdrop
    - prop "customDialogStyles" removed -> use "customDialogStyles" instead to style the dialog
    - prop "width" removed -> use "size" instead (same possible values)
    - prop "opened" removed -> use "open" instead
    - prop "onOpen" removed -> use "show" instead (ModalState)
    - prop "onClose" removed -> use "close" instead (ModalState)
    - prop "hide" removed -> use "close" instead (ModalState)
- `RadioGroup.Radio`: prop "name" removed, it is automatically passed from the parent `RadioGroup`
- `Separator`: prop "color" removed -> use "sentiment" instead
- `Text`: prop "color" removed -> use "sentiment" instead