### PR TITLE
fix: stack and row initial values on dynamic variables

### DIFF
--- a/.changeset/sour-pants-write.md
+++ b/.changeset/sour-pants-write.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Stack />` and `<Row />` variables to provide default values

--- a/packages/ui/src/components/Row/variables.css.ts
+++ b/packages/ui/src/components/Row/variables.css.ts
@@ -5,22 +5,70 @@ export const templateColumn: Record<
   keyof typeof theme.breakpoints,
   ReturnType<typeof createVar>
 > = {
-  large: createVar(),
-  xlarge: createVar(),
-  medium: createVar(),
-  small: createVar(),
-  xsmall: createVar(),
-  xxsmall: createVar(),
+  large: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: 'none',
+  }),
+  xlarge: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: 'none',
+  }),
+  medium: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: 'none',
+  }),
+  small: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: 'none',
+  }),
+  xsmall: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: 'none',
+  }),
+  xxsmall: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: 'none',
+  }),
 }
 
 export const paddings: Record<
   keyof typeof theme.breakpoints,
   ReturnType<typeof createVar>
 > = {
-  large: createVar(),
-  xlarge: createVar(),
-  medium: createVar(),
-  small: createVar(),
-  xsmall: createVar(),
-  xxsmall: createVar(),
+  large: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: '0',
+  }),
+  xlarge: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: '0',
+  }),
+  medium: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: '0',
+  }),
+  small: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: '0',
+  }),
+  xsmall: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: '0',
+  }),
+  xxsmall: createVar({
+    syntax: '*',
+    inherits: false,
+    initialValue: '0',
+  }),
 }

--- a/packages/ui/src/components/Stack/variables.css.ts
+++ b/packages/ui/src/components/Stack/variables.css.ts
@@ -1,6 +1,22 @@
 import { createVar } from '@vanilla-extract/css'
 
-export const widthVar = createVar()
-export const maxWidthVar = createVar()
-export const minWidthVar = createVar()
-export const flexVar = createVar()
+export const widthVar = createVar({
+  syntax: '*',
+  inherits: false,
+  initialValue: 'auto',
+})
+export const maxWidthVar = createVar({
+  syntax: '*',
+  inherits: false,
+  initialValue: 'none',
+})
+export const minWidthVar = createVar({
+  syntax: '*',
+  inherits: false,
+  initialValue: 'none',
+})
+export const flexVar = createVar({
+  syntax: '*',
+  inherits: false,
+  initialValue: '0 1 auto',
+})


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Nested stack inherit from dynamic variables of the parent. In order to solve that we add an initial value.
