### PR TITLE
fix(Checkbox): input size being wrong

### DIFF
--- a/.changeset/evil-boats-stare.md
+++ b/.changeset/evil-boats-stare.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Fix `<Checkbox />` input size being wrong

--- a/packages/ui/src/components/Checkbox/styles.css.ts
+++ b/packages/ui/src/components/Checkbox/styles.css.ts
@@ -35,6 +35,8 @@ export const checkboxInput = style({
   whiteSpace: 'nowrap',
   opacity: 0,
   borderWidth: 0,
+  height: theme.sizing['300'],
+  width: theme.sizing['300'],
 })
 
 export const checkboxContainer = style({


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarise concisely:

#### What is expected?

Checkbox input has wrong size

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="369" height="164" alt="Screenshot 2025-10-06 at 11 31 15" src="https://github.com/user-attachments/assets/00fdd657-d731-4c41-b60f-7f908e558eb5" /> | <img width="368" height="163" alt="Screenshot 2025-10-06 at 11 31 22" src="https://github.com/user-attachments/assets/1987642c-8126-43b6-af15-6b65ad6a9d72" /> |
