### PR TITLE
feat(ui): add aria-keyshortcut attr to link & button

### DIFF
--- a/.changeset/little-hotels-walk.md
+++ b/.changeset/little-hotels-walk.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Add `aria-keyshortcuts` attribute to Link & Button

--- a/packages/ui/src/components/Button/index.tsx
+++ b/packages/ui/src/components/Button/index.tsx
@@ -259,6 +259,7 @@ type CommonProps = {
   'aria-disabled'?: boolean
   'aria-pressed'?: boolean
   'aria-roledescription'?: string
+  'aria-keyshortcuts'?: string
   onClick?: MouseEventHandler<HTMLElement>
   tooltip?: string
   tabIndex?: ButtonHTMLAttributes<HTMLButtonElement>['tabIndex']
@@ -314,6 +315,7 @@ export const Button = forwardRef<Element, FinalProps>(
       'aria-disabled': ariaDisabled,
       'aria-pressed': ariaPressed,
       'aria-roledescription': ariaRoledescription,
+      'aria-keyshortcuts': ariaKeyshortcuts,
       href,
       download,
       target,
@@ -360,6 +362,7 @@ export const Button = forwardRef<Element, FinalProps>(
             aria-disabled={ariaDisabled ?? disabled}
             aria-expanded={ariaExpanded}
             aria-haspopup={ariaHaspopup}
+            aria-keyshortcuts={ariaKeyshortcuts}
             aria-label={ariaLabel}
             aria-pressed={ariaPressed}
             aria-roledescription={ariaRoledescription}

--- a/packages/ui/src/components/Link/index.tsx
+++ b/packages/ui/src/components/Link/index.tsx
@@ -55,6 +55,7 @@ type LinkProps = {
   onClick?: MouseEventHandler<HTMLAnchorElement>
   'aria-label'?: string
   'aria-current'?: AnchorHTMLAttributes<HTMLAnchorElement>['aria-current']
+  'aria-keyshortcuts'?: string
   oneLine?: boolean
   'data-testid'?: string
   variant?: 'inline' | 'standalone'
@@ -221,6 +222,7 @@ export const Link = forwardRef(
       onClick,
       'aria-label': ariaLabel,
       'aria-current': ariaCurrent,
+      'aria-keyshortcuts': ariaKeyshortcuts,
       oneLine = false,
       'data-testid': dataTestId,
       variant = 'standalone',
@@ -256,6 +258,7 @@ export const Link = forwardRef(
       <Tooltip text={oneLine && isTruncated ? finalStringChildren : ''}>
         <StyledLink
           aria-current={ariaCurrent}
+          aria-keyshortcuts={ariaKeyshortcuts}
           aria-label={ariaLabel}
           className={className}
           data-testid={dataTestId}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarise concisely:

Add `aria-keyshortcuts` attribute to Link & Button

#### What is expected?

It should handle values for assistive techs to inform about key shortcuts used by script to activate link or button using keyboard

> doc: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts

#### The following changes where made:

1. add `aria-keyshortcuts` type
2. add the attribute and its value on component
3. same for Link and Button

## Relevant logs and/or screenshots

| example on component Link | VoiceOver result |
| --- | --- |
| <img width="360" height="85" alt="Capture d’écran 2025-10-08 à 15 44 40" src="https://github.com/user-attachments/assets/ba0c28af-ed87-4f93-bdae-dbc950251cdd" /> | <img width="1089" height="169" alt="Capture d’écran 2025-10-06 à 11 38 08" src="https://github.com/user-attachments/assets/0321e18c-31eb-4ca2-b879-671528dc7b74" /> |




