### PR TITLE
feat(Form): decorrelate label from field name

### DIFF
--- a/.changeset/wise-eels-crash.md
+++ b/.changeset/wise-eels-crash.md
@@ -1,0 +1,26 @@
+---
+"@ultraviolet/form": minor
+---
+
+Form element can have a `errorLabel` (string)  to use as a custom value to display (instead of the label) when an error is displayed (empty required element, min/max value not respected, etc.).
+
+For instance, this component: 
+```js
+<NumberInputField label="Choose number of elements" errorLabel="Amount" value={20} max={10} />
+```
+Used with this error:
+```js
+import type { FormErrors } from '@ultraviolet/form'
+import { NumberInputField } from '@ultraviolet/form'
+
+const errors: FormErrors = {
+   ...
+   isInteger: ...
+   max: ({ max, label }) => `${label} must be less than ${max}$`,
+   min: ...
+   ...
+}
+```
+The displayed `max` error message is `Amount must be less than 10` instead of `Choose number of elements must be less than 10`.
+
+It allows custom error labels with a fallback on the `label` if `errorLabel` is not defined — this can be useful when creating a default `useError`.

--- a/packages/form/src/components/CheckboxField/__tests__/index.test.tsx
+++ b/packages/form/src/components/CheckboxField/__tests__/index.test.tsx
@@ -87,7 +87,7 @@ describe('checkboxField', () => {
         methods={result.current}
         onSubmit={() => {}}
       >
-        <CheckboxField name="test" required>
+        <CheckboxField name="test" required errorLabel="errorLabel">
           Checkbox field error
         </CheckboxField>
         <div>Focus</div>

--- a/packages/form/src/components/CheckboxField/index.tsx
+++ b/packages/form/src/components/CheckboxField/index.tsx
@@ -32,6 +32,7 @@ export const CheckboxField = <
   onBlur,
   shouldUnregister = false,
   validate,
+  errorLabel,
   'aria-label': ariaLabel,
   ...props
 }: CheckboxFieldProps<TFieldValues, TFieldName>) => {
@@ -56,7 +57,10 @@ export const CheckboxField = <
       required={required}
       checked={!!field.value}
       disabled={field.disabled}
-      error={getError({ label: label ?? ariaLabel ?? name }, error)}
+      error={getError(
+        { label: errorLabel ?? label ?? ariaLabel ?? name },
+        error,
+      )}
       name={field.name}
       onBlur={event => {
         field.onBlur()

--- a/packages/form/src/components/CheckboxGroupField/index.tsx
+++ b/packages/form/src/components/CheckboxGroupField/index.tsx
@@ -43,6 +43,7 @@ const CheckboxGroupFieldComponent = <
   shouldUnregister = false,
   validate,
   legend = '',
+  errorLabel,
   ...props
 }: CheckboxGroupFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -96,7 +97,7 @@ const CheckboxGroupFieldComponent = <
   return (
     <CheckboxGroup
       {...props}
-      error={getError({ label: legend }, error) ?? customError}
+      error={getError({ label: errorLabel ?? legend }, error) ?? customError}
       legend={legend}
       name={name}
       onChange={event => {

--- a/packages/form/src/components/DateInputField/index.tsx
+++ b/packages/form/src/components/DateInputField/index.tsx
@@ -44,6 +44,7 @@ export const DateInputField = <
   selectsRange,
   showMonthYearPicker,
   shouldUnregister = false,
+  errorLabel,
   ...props
 }: DateInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -72,7 +73,7 @@ export const DateInputField = <
           ? (field.value as [Date | null, Date | null])[1]
           : undefined
       }
-      error={getError({ label, maxDate, minDate }, error)}
+      error={getError({ label: errorLabel ?? label, maxDate, minDate }, error)}
       format={
         format ??
         (value => {

--- a/packages/form/src/components/FileInputField/index.tsx
+++ b/packages/form/src/components/FileInputField/index.tsx
@@ -40,6 +40,7 @@ const FileInputFieldBase = <
   title,
   bottom,
   children,
+  errorLabel,
   ...props
 }: FileInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -60,7 +61,7 @@ const FileInputFieldBase = <
     return (
       <FileInput
         {...props}
-        error={getError({ label }, error)}
+        error={getError({ label: errorLabel ?? label }, error)}
         label={label}
         onChangeFiles={files => {
           field.onChange(files)

--- a/packages/form/src/components/NumberInputField/index.tsx
+++ b/packages/form/src/components/NumberInputField/index.tsx
@@ -32,6 +32,7 @@ export const NumberInputField = <
   required,
   shouldUnregister = false,
   validate,
+  errorLabel,
   ...props
 }: NumberInputProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -58,7 +59,12 @@ export const NumberInputField = <
       {...props}
       aria-label={ariaLabel}
       error={getError(
-        { isInteger: step, label: label ?? ariaLabel ?? name, max, min },
+        {
+          isInteger: step,
+          label: errorLabel ?? label ?? ariaLabel ?? name,
+          max,
+          min,
+        },
         error,
       )}
       label={label}

--- a/packages/form/src/components/RadioField/__tests__/index.test.tsx
+++ b/packages/form/src/components/RadioField/__tests__/index.test.tsx
@@ -59,6 +59,7 @@ describe('radioField', () => {
         onChange={onChange}
         onFocus={onFocus}
         value="events"
+        errorLabel="errorLabel"
       />,
     )
     const input = screen.getByRole('radio', { hidden: true })

--- a/packages/form/src/components/RadioField/index.tsx
+++ b/packages/form/src/components/RadioField/index.tsx
@@ -31,6 +31,7 @@ export const RadioField = <
   value,
   shouldUnregister = false,
   validate,
+  errorLabel,
   'aria-label': ariaLabel,
   ...props
 }: RadioFieldProps<TFieldValues, TFieldName>) => {
@@ -48,7 +49,10 @@ export const RadioField = <
     shouldUnregister,
   })
 
-  const errorLabel = useMemo(() => {
+  const computedErrorLabel = useMemo(() => {
+    if (errorLabel) {
+      return errorLabel
+    }
     if (label && typeof label === 'string') {
       return label
     }
@@ -58,14 +62,14 @@ export const RadioField = <
     }
 
     return name
-  }, [label, name, ariaLabel])
+  }, [label, name, ariaLabel, errorLabel])
 
   return (
     <Radio
       {...props}
       checked={field.value === value}
       disabled={disabled}
-      error={getError({ label: errorLabel }, error)}
+      error={getError({ label: computedErrorLabel }, error)}
       name={field.name}
       onBlur={event => {
         field.onBlur()

--- a/packages/form/src/components/RadioGroupField/index.tsx
+++ b/packages/form/src/components/RadioGroupField/index.tsx
@@ -29,6 +29,7 @@ const RadioGroupFieldComponent = <
   shouldUnregister = false,
   validate,
   legend = '',
+  errorLabel,
   ...props
 }: RadioGroupFieldProps<TFieldValues, TFieldName>): JSX.Element => {
   const { getError } = useErrors()
@@ -48,7 +49,7 @@ const RadioGroupFieldComponent = <
   return (
     <RadioGroup
       {...props}
-      error={getError({ label: legend }, error) ?? customError}
+      error={getError({ label: errorLabel ?? legend }, error) ?? customError}
       legend={legend}
       name={field.name}
       onChange={event => {

--- a/packages/form/src/components/SelectInputField/index.tsx
+++ b/packages/form/src/components/SelectInputField/index.tsx
@@ -30,6 +30,7 @@ export const SelectInputField = <
   validate,
   onChange,
   multiselect,
+  errorLabel,
   ...props
 }: SelectInputFieldProps<TFieldValues, TFieldName>) => {
   const {
@@ -60,7 +61,10 @@ export const SelectInputField = <
   return (
     <SelectInput
       aria-label={ariaLabel}
-      error={getError({ label: label ?? ariaLabel ?? name }, error)}
+      error={getError(
+        { label: errorLabel ?? label ?? ariaLabel ?? name },
+        error,
+      )}
       label={label}
       multiselect={multiselect}
       name={field.name}

--- a/packages/form/src/components/SelectableCardGroupField/SelectableCardGroupField.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/SelectableCardGroupField.tsx
@@ -31,6 +31,7 @@ const SelectableCardGroupFieldComponent = <
   type = 'radio',
   shouldUnregister = false,
   validate,
+  errorLabel,
   ...props
 }: SelectableCardGroupFieldProps<TFieldValues, TFieldName>): JSX.Element => {
   const { getError } = useErrors()
@@ -51,7 +52,7 @@ const SelectableCardGroupFieldComponent = <
     <SelectableCardGroup
       {...props}
       columns={columns}
-      error={getError({ label: legend }, error) ?? customError}
+      error={getError({ label: errorLabel ?? legend }, error) ?? customError}
       legend={legend}
       name={name}
       onChange={event => {

--- a/packages/form/src/components/SelectableCardOptionGroupField/index.tsx
+++ b/packages/form/src/components/SelectableCardOptionGroupField/index.tsx
@@ -48,6 +48,7 @@ const SelectableCardOptionGroupFieldComponent: <
   error: customError,
   shouldUnregister = false,
   validate,
+  errorLabel,
   ...props
 }: SelectableCardOptionGroupFieldProps<
   TFieldValues,
@@ -75,7 +76,7 @@ const SelectableCardOptionGroupFieldComponent: <
 
   return (
     <SelectableCardOptionGroup
-      error={getError({ label: legend }, error) ?? customError}
+      error={getError({ label: errorLabel ?? legend }, error) ?? customError}
       legend={legend}
       name={name}
       onChange={event => {

--- a/packages/form/src/components/SliderField/index.tsx
+++ b/packages/form/src/components/SliderField/index.tsx
@@ -35,6 +35,7 @@ export const SliderField = <
   value,
   defaultValue,
   options,
+  errorLabel,
   'aria-label': ariaLabel,
   ...props
 }: SliderFieldProps<TFieldValues, TFieldName>) => {
@@ -79,7 +80,10 @@ export const SliderField = <
   return (
     <Slider
       aria-label={ariaLabel}
-      error={getError({ label: label ?? ariaLabel ?? name, max, min }, error)}
+      error={getError(
+        { label: errorLabel ?? label ?? ariaLabel ?? name, max, min },
+        error,
+      )}
       label={label}
       max={max}
       min={min}

--- a/packages/form/src/components/TagInputField/index.tsx
+++ b/packages/form/src/components/TagInputField/index.tsx
@@ -30,6 +30,7 @@ export const TagInputField = <
   shouldUnregister = false,
   label,
   validate,
+  errorLabel,
   'aria-label': ariaLabel,
   ...props
 }: TagInputFieldProps<TFieldValues, TFieldName>) => {
@@ -60,7 +61,7 @@ export const TagInputField = <
       {...props}
       aria-label={ariaLabel}
       error={getError(
-        { label: label ?? ariaLabel ?? name, regex: regexes },
+        { label: errorLabel ?? label ?? ariaLabel ?? name, regex: regexes },
         error,
       )}
       label={label}

--- a/packages/form/src/components/TextAreaField/index.tsx
+++ b/packages/form/src/components/TextAreaField/index.tsx
@@ -41,6 +41,7 @@ export const TextAreaField = <
   regex: regexes,
   submitOnEnter,
   validate,
+  errorLabel,
   'aria-label': ariaLabel,
   ...props
 }: TextAreaFieldProps<TFieldValues, TFieldName>) => {
@@ -89,7 +90,7 @@ export const TextAreaField = <
       {...props}
       error={getError(
         {
-          label: label ?? ariaLabel ?? name,
+          label: errorLabel ?? label ?? ariaLabel ?? name,
           maxLength,
           minLength,
           regex: regexes,

--- a/packages/form/src/components/TextInputField/index.tsx
+++ b/packages/form/src/components/TextInputField/index.tsx
@@ -40,6 +40,7 @@ export const TextInputField = <
   shouldUnregister,
   validate,
   control,
+  errorLabel,
   ...props
 }: TextInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -72,7 +73,7 @@ export const TextInputField = <
       aria-label={ariaLabel}
       error={getError(
         {
-          label: label ?? ariaLabel ?? name,
+          label: errorLabel ?? label ?? ariaLabel ?? name,
           maxLength,
           minLength,
           regex: regexes,

--- a/packages/form/src/components/TimeInputField/index.tsx
+++ b/packages/form/src/components/TimeInputField/index.tsx
@@ -34,6 +34,7 @@ export const TimeInputField = <
   'aria-label': ariaLabel,
   shouldUnregister,
   control,
+  errorLabel,
   ...props
 }: TimeInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -55,7 +56,7 @@ export const TimeInputField = <
       {...props}
       error={getError(
         {
-          label: label ?? ariaLabel ?? name,
+          label: errorLabel ?? label ?? ariaLabel ?? name,
           value: field.value,
         },
         error,

--- a/packages/form/src/components/ToggleField/index.tsx
+++ b/packages/form/src/components/ToggleField/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Toggle } from '@ultraviolet/ui'
+import { useMemo } from 'react'
 import { useController } from 'react-hook-form'
 
 import { useErrors } from '../../providers'
@@ -33,6 +34,7 @@ export const ToggleField = <
   format,
   shouldUnregister = false,
   validate,
+  errorLabel,
   'aria-label': ariaLabel,
   ...props
 }: ToggleFieldProps<TFieldValues, TFieldName>) => {
@@ -58,14 +60,23 @@ export const ToggleField = <
     return field.value as boolean
   }
 
+  const computedErrorLabel = useMemo(() => {
+    if (errorLabel) {
+      return errorLabel
+    }
+
+    if (typeof label === 'string') {
+      return label
+    }
+
+    return ariaLabel ?? name
+  }, [errorLabel, name, ariaLabel, label])
+
   return (
     <Toggle
       {...props}
       checked={transformedValue()}
-      error={getError(
-        { label: typeof label === 'string' ? label : (ariaLabel ?? name) },
-        error,
-      )}
+      error={getError({ label: computedErrorLabel }, error)}
       label={label}
       name={field.name}
       onBlur={event => {

--- a/packages/form/src/components/ToggleGroupField/index.tsx
+++ b/packages/form/src/components/ToggleGroupField/index.tsx
@@ -27,6 +27,7 @@ const ToggleGroupFieldComponent = <
   required = false,
   shouldUnregister = false,
   validate,
+  errorLabel,
   ...props
 }: ToggleGroupFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -50,7 +51,7 @@ const ToggleGroupFieldComponent = <
   return (
     <ToggleGroup
       {...props}
-      error={customError ?? getError({ label: legend }, error)}
+      error={customError ?? getError({ label: errorLabel ?? legend }, error)}
       legend={legend}
       name={field.name}
       onChange={event => {

--- a/packages/form/src/components/UnitInputField/index.tsx
+++ b/packages/form/src/components/UnitInputField/index.tsx
@@ -32,6 +32,7 @@ export const UnitInputField = <
   validate,
   control,
   optionName,
+  errorLabel,
   ...props
 }: UnitInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
@@ -59,7 +60,7 @@ export const UnitInputField = <
   return (
     <UnitInput
       {...props}
-      error={getError({ label }, valueFieldState.error)}
+      error={getError({ label: errorLabel ?? label }, valueFieldState.error)}
       label={label}
       max={max}
       min={min}

--- a/packages/form/src/components/VerificationCodeField/index.tsx
+++ b/packages/form/src/components/VerificationCodeField/index.tsx
@@ -26,6 +26,7 @@ export const VerificationCodeField = <
   onChange,
   required,
   validate,
+  errorLabel,
   ...props
 }: VerificationCodeFieldProps<TFieldValues, TName>) => {
   const { getError } = useErrors()
@@ -53,7 +54,10 @@ export const VerificationCodeField = <
   return (
     <VerificationCode
       {...props}
-      error={getError({ label: label ?? 'verification-code-field' }, error)}
+      error={getError(
+        { label: errorLabel ?? label ?? 'verification-code-field' },
+        error,
+      )}
       fields={fields}
       inputId={inputId}
       label={label}

--- a/packages/form/src/compositions/OfferListField/index.tsx
+++ b/packages/form/src/compositions/OfferListField/index.tsx
@@ -42,6 +42,7 @@ const OfferListField = <
   label,
   required,
   value,
+  errorLabel,
   onChange,
   shouldUnregister,
 }: OfferListFieldProps<TFieldValues, TName>) => {
@@ -81,7 +82,7 @@ const OfferListField = <
         <Text as="p" prominence="default" sentiment="danger" variant="caption">
           {getError(
             {
-              label: label ?? name,
+              label: errorLabel ?? label ?? name,
               value: field.value,
             },
             error,

--- a/packages/form/src/compositions/OptionSelectorField/index.tsx
+++ b/packages/form/src/compositions/OptionSelectorField/index.tsx
@@ -27,6 +27,7 @@ export const OptionSelectorField = <
   control,
   validate,
   onChange,
+  errorLabel,
   ...props
 }: OptionSelectorFieldProps<TFieldValues, TFieldName>) => {
   const {
@@ -56,7 +57,10 @@ export const OptionSelectorField = <
   return (
     <OptionSelector
       aria-label={ariaLabel}
-      error={getError({ label: label ?? ariaLabel ?? name }, error)}
+      error={getError(
+        { label: errorLabel ?? label ?? ariaLabel ?? name },
+        error,
+      )}
       name={field.name}
       onChange={val => {
         field.onChange({ first: val.first, second: val.second })

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -60,6 +60,7 @@ export type BaseFieldProps<
     TFieldName
   >['shouldUnregister']
   control?: Control<TFieldValues>
+  errorLabel?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

Form element can have a `errorLabel` (string)  to use as a custom value to display (instead of the label) when an error is displayed (empty required element, min/max value not respected, etc.).

For instance, this component: 
```js
<NumberInputField label="Choose number of elements" errorLabel="Amount" value={20} max={10} />
```
Used with this error:
```js
import type { FormErrors } from '@ultraviolet/form'
import { NumberInputField } from '@ultraviolet/form'

const errors: FormErrors = {
   ...
   isInteger: ...
   max: ({ max, label }) => `${label} must be less than ${max}$`,
   min: ...
   ...
}
```
The displayed `max` error message is `Amount must be less than 10` instead of `Choose number of elements must be less than 10`.

It allows custom error labels with a fallback on the `label` if `errorLabel` is not defined — this can be useful when creating a default `useError`.