### PR TITLE
fix(Text): oneLine overflow

### DIFF
--- a/.changeset/common-moose-live.md
+++ b/.changeset/common-moose-live.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Text`: add `min-width` to the popup container when `oneLine` is enable to ensure the ellipsis works properly

--- a/.changeset/common-moose-live.md
+++ b/.changeset/common-moose-live.md
@@ -2,4 +2,4 @@
 "@ultraviolet/ui": patch
 ---
 
-`Text`: add `min-width` to the popup container when `oneLine` is enable to ensure the ellipsis works properly
+`Text`: add `min-width` to the popup container when `oneLine` is enabled to ensure the ellipsis works properly

--- a/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`tagInputField > should render correctly with regex 1`] = `
                 class="uv_d6zknp0 uv_d6zknp5"
               >
                 <span
-                  class="uv_d6zknp1c uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a"
+                  class="uv_d6zknp1c uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a uv_m4c9ow3e"
                 >
                   4
                 </span>
@@ -180,7 +180,7 @@ exports[`tagInputField > should works with defaultValues 1`] = `
                 class="uv_d6zknp0 uv_d6zknp5"
               >
                 <span
-                  class="uv_d6zknp1c uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a"
+                  class="uv_d6zknp1c uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a uv_m4c9ow3e"
                 >
                   First
                 </span>

--- a/packages/ui/src/components/FileInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/FileInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`fileInput > renders correctly onChange 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         cat.png
                       </p>
@@ -286,7 +286,7 @@ exports[`fileInput > renders correctly onChange 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m style__m4c9ow3e"
                       >
                         error_example.png
                       </p>
@@ -356,7 +356,7 @@ exports[`fileInput > renders correctly onChange 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         doc.pdf
                       </p>
@@ -422,7 +422,7 @@ exports[`fileInput > renders correctly onChange 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         video.mp4
                       </p>
@@ -504,7 +504,7 @@ exports[`fileInput > renders correctly onChange 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         loading_example.pdf
                       </p>
@@ -590,7 +590,7 @@ exports[`fileInput > renders correctly ondrop, ondrag 1`] = `
                     class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                   >
                     <p
-                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                     >
                       cat.png
                     </p>
@@ -655,7 +655,7 @@ exports[`fileInput > renders correctly ondrop, ondrag 1`] = `
                     class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                   >
                     <p
-                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m"
+                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m style__m4c9ow3e"
                     >
                       error_example.png
                     </p>
@@ -735,7 +735,7 @@ exports[`fileInput > renders correctly ondrop, ondrag 1`] = `
                     class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                   >
                     <p
-                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                     >
                       sound.mp3
                     </p>
@@ -800,7 +800,7 @@ exports[`fileInput > renders correctly ondrop, ondrag 1`] = `
                     class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                   >
                     <p
-                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                     >
                       doc.pdf
                     </p>
@@ -866,7 +866,7 @@ exports[`fileInput > renders correctly ondrop, ondrag 1`] = `
                     class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                   >
                     <p
-                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                     >
                       video.mp4
                     </p>
@@ -948,7 +948,7 @@ exports[`fileInput > renders correctly ondrop, ondrag 1`] = `
                     class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                   >
                     <p
-                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                      class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                     >
                       loading_example.pdf
                     </p>
@@ -1122,7 +1122,7 @@ exports[`fileInput > renders correctly with FileInput.Button 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         cat.png
                       </p>
@@ -1187,7 +1187,7 @@ exports[`fileInput > renders correctly with FileInput.Button 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m style__m4c9ow3e"
                       >
                         error_example.png
                       </p>
@@ -1267,7 +1267,7 @@ exports[`fileInput > renders correctly with FileInput.Button 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         sound.mp3
                       </p>
@@ -1332,7 +1332,7 @@ exports[`fileInput > renders correctly with FileInput.Button 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         doc.pdf
                       </p>
@@ -1398,7 +1398,7 @@ exports[`fileInput > renders correctly with FileInput.Button 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         video.mp4
                       </p>
@@ -1480,7 +1480,7 @@ exports[`fileInput > renders correctly with FileInput.Button 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         loading_example.pdf
                       </p>
@@ -1767,7 +1767,7 @@ exports[`fileInput > renders correctly with multiple and list 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         cat.png
                       </p>
@@ -1832,7 +1832,7 @@ exports[`fileInput > renders correctly with multiple and list 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m style__m4c9ow3e"
                       >
                         error_example.png
                       </p>
@@ -1912,7 +1912,7 @@ exports[`fileInput > renders correctly with multiple and list 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         sound.mp3
                       </p>
@@ -1977,7 +1977,7 @@ exports[`fileInput > renders correctly with multiple and list 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         doc.pdf
                       </p>
@@ -2043,7 +2043,7 @@ exports[`fileInput > renders correctly with multiple and list 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         video.mp4
                       </p>
@@ -2125,7 +2125,7 @@ exports[`fileInput > renders correctly with multiple and list 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         loading_example.pdf
                       </p>
@@ -2248,7 +2248,7 @@ exports[`fileInput > should handle adding a file when selecting via the hidden f
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         upload.png
                       </p>
@@ -2414,7 +2414,7 @@ exports[`fileInput > should work correctly with listLimit 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         cat.png
                       </p>
@@ -2479,7 +2479,7 @@ exports[`fileInput > should work correctly with listLimit 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m style__m4c9ow3e"
                       >
                         error_example.png
                       </p>
@@ -2559,7 +2559,7 @@ exports[`fileInput > should work correctly with listLimit 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         sound.mp3
                       </p>
@@ -2624,7 +2624,7 @@ exports[`fileInput > should work correctly with listLimit 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         doc.pdf
                       </p>
@@ -2690,7 +2690,7 @@ exports[`fileInput > should work correctly with listLimit 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         video.mp4
                       </p>
@@ -2772,7 +2772,7 @@ exports[`fileInput > should work correctly with listLimit 1`] = `
                       class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                     >
                       <p
-                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                       >
                         loading_example.pdf
                       </p>
@@ -2883,7 +2883,7 @@ exports[`fileInput > should work with function children and title 1`] = `
                         class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                       >
                         <p
-                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                         >
                           cat.png
                         </p>
@@ -2948,7 +2948,7 @@ exports[`fileInput > should work with function children and title 1`] = `
                         class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                       >
                         <p
-                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m"
+                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_danger__m4c9ow9 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_48__m4c9ow2m style__m4c9ow3e"
                         >
                           error_example.png
                         </p>
@@ -3028,7 +3028,7 @@ exports[`fileInput > should work with function children and title 1`] = `
                         class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                       >
                         <p
-                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                         >
                           sound.mp3
                         </p>
@@ -3093,7 +3093,7 @@ exports[`fileInput > should work with function children and title 1`] = `
                         class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                       >
                         <p
-                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                         >
                           doc.pdf
                         </p>
@@ -3159,7 +3159,7 @@ exports[`fileInput > should work with function children and title 1`] = `
                         class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                       >
                         <p
-                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                         >
                           video.mp4
                         </p>
@@ -3241,7 +3241,7 @@ exports[`fileInput > should work with function children and title 1`] = `
                         class="styles__12cubgsr styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
                       >
                         <p
-                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                          class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
                         >
                           loading_example.pdf
                         </p>

--- a/packages/ui/src/components/Popup/styles.css.ts
+++ b/packages/ui/src/components/Popup/styles.css.ts
@@ -4,6 +4,7 @@ import { recipe } from '@vanilla-extract/recipes'
 
 import { tagStyle } from '../Tag/styles.css'
 import { tagListStyle } from '../TagList/styles.css'
+import { textStyle } from '../Text/style.css'
 
 import { DEFAULT_ARROW_WIDTH } from './helpers'
 import {
@@ -122,6 +123,9 @@ const childrenContainer = recipe({
       [`&:has(${tagStyle.text})`]: {
         minWidth: 0,
         width: '100%',
+      },
+      [`&:has(.${textStyle.oneLine})`]: {
+        minWidth: 0,
       },
     },
   },

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -939,7 +939,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                 style="--r8qe41: auto; --r8qe40: 1024px;"
               >
                 <span
-                  class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                  class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                 >
                   Pluto
                 </span>
@@ -2595,7 +2595,7 @@ exports[`selectInput > renders correctly unclosable tags when readonly 1`] = `
                 style="--r8qe41: auto; --r8qe40: 1024px;"
               >
                 <span
-                  class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                  class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                 >
                   Venus
                 </span>

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`tag > renders correctly 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -27,7 +27,7 @@ exports[`tag > renders correctly colored 1`] = `
       class="styles__d6zknp0 styles_sentiment_primary__d6zknp6"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -45,7 +45,7 @@ exports[`tag > renders correctly disabled 1`] = `
       class="styles__d6zknp0 styles_disabled_true__d6zknp2 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_23__d6zknp10"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -63,7 +63,7 @@ exports[`tag > renders correctly neutral 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -81,7 +81,7 @@ exports[`tag > renders correctly with code variant 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_code__m4c9owv style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_code__m4c9owv style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -106,7 +106,7 @@ exports[`tag > renders correctly with copiable 1`] = `
         type="button"
       >
         <span
-          class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+          class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
         >
           test
         </span>
@@ -132,7 +132,7 @@ exports[`tag > renders correctly with copiable and copy button 1`] = `
         type="button"
       >
         <span
-          class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+          class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
         >
           test
         </span>
@@ -171,7 +171,7 @@ exports[`tag > renders correctly with icon 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         <svg
           class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
@@ -204,7 +204,7 @@ exports[`tag > renders correctly with isLoading 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -254,7 +254,7 @@ exports[`tag > renders correctly with key-value variant 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5 styles_isKey_true__d6zknpa styles_isKeyValue_true__d6zknpc styles_undefined_compound_9__d6zknpm styles_undefined_compound_16__d6zknpt"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         key
       </span>
@@ -263,7 +263,7 @@ exports[`tag > renders correctly with key-value variant 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5 styles_isValue_true__d6zknpb styles_isKeyValue_true__d6zknpc styles_undefined_compound_16__d6zknpt"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         value
       </span>
@@ -281,7 +281,7 @@ exports[`tag > renders correctly with onClose 1`] = `
       class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>

--- a/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -296,7 +296,7 @@ exports[`tagInput > should renders correctly with some tags 1`] = `
               class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 hello
               </span>
@@ -325,7 +325,7 @@ exports[`tagInput > should renders correctly with some tags 1`] = `
               class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 world
               </span>
@@ -390,7 +390,7 @@ exports[`tagInput > should renders correctly with some tags objects 1`] = `
               class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 hello
               </span>
@@ -419,7 +419,7 @@ exports[`tagInput > should renders correctly with some tags objects 1`] = `
               class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 world
               </span>

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -30,7 +30,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -40,7 +40,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             provider
           </span>
@@ -50,7 +50,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             database
           </span>
@@ -68,7 +68,7 @@ exports[`tagList > hide items after maxLength 1`] = `
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -78,7 +78,7 @@ exports[`tagList > hide items after maxLength 1`] = `
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -88,7 +88,7 @@ exports[`tagList > hide items after maxLength 1`] = `
             data-testid="provider"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               provider
             </span>
@@ -98,7 +98,7 @@ exports[`tagList > hide items after maxLength 1`] = `
             data-testid="database"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               database
             </span>
@@ -144,7 +144,7 @@ exports[`tagList > renders correctly 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -162,7 +162,7 @@ exports[`tagList > renders correctly 1`] = `
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -208,7 +208,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             very
           </span>
@@ -218,7 +218,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
@@ -228,7 +228,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
@@ -238,7 +238,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
@@ -248,7 +248,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
@@ -266,7 +266,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
             data-testid="very"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               very
             </span>
@@ -276,7 +276,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
@@ -286,7 +286,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
@@ -296,7 +296,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
@@ -306,7 +306,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
@@ -359,7 +359,7 @@ exports[`tagList > renders correctly and add ellipsis to the first tag as it too
             data-testid="scaleway is the best cloud provider ever invented"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway is the best cloud provider ever invented
             </span>
@@ -412,7 +412,7 @@ exports[`tagList > renders correctly and ignore custom threshold as it does not 
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -422,7 +422,7 @@ exports[`tagList > renders correctly and ignore custom threshold as it does not 
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -468,7 +468,7 @@ exports[`tagList > renders correctly when maxLength is smaller than first tag 1`
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -486,7 +486,7 @@ exports[`tagList > renders correctly when maxLength is smaller than first tag 1`
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -525,7 +525,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -543,7 +543,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -569,7 +569,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 scaleway
               </span>
@@ -587,7 +587,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 cloud
               </span>
@@ -620,7 +620,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -630,7 +630,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -648,7 +648,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -658,7 +658,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -690,7 +690,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -700,7 +700,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -718,7 +718,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -728,7 +728,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -774,7 +774,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -792,7 +792,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -845,7 +845,7 @@ exports[`tagList > renders correctly with icons 1`] = `
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -863,7 +863,7 @@ exports[`tagList > renders correctly with icons 1`] = `
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -889,7 +889,7 @@ exports[`tagList > renders correctly with icons 1`] = `
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 scaleway
               </span>
@@ -907,7 +907,7 @@ exports[`tagList > renders correctly with icons 1`] = `
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 cloud
               </span>
@@ -940,7 +940,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -950,7 +950,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -968,7 +968,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -978,7 +978,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -1052,7 +1052,7 @@ exports[`tagList > renders correctly with placement 1`] = `
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -1070,7 +1070,7 @@ exports[`tagList > renders correctly with placement 1`] = `
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>

--- a/packages/ui/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Text/__tests__/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`text > renders correctly with dir 1`] = `
       style="margin-bottom: 16px; margin-top: 8px; width: 500px;"
     >
       <div
-        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
+        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
         dir="rtl"
       >
         This text is quite long. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -66,7 +66,7 @@ exports[`text > renders correctly with tooltip 1`] = `
       style="margin-bottom: 16px; margin-top: 8px; width: 500px;"
     >
       <div
-        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
+        class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         This text is quite long. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
       </div>

--- a/packages/ui/src/components/Text/index.tsx
+++ b/packages/ui/src/components/Text/index.tsx
@@ -87,6 +87,7 @@ export const Text = ({
             underline,
             variant,
           }),
+          oneLine ? textStyle.oneLine : '',
         )}
         data-testid={dataTestId}
         dir={dir}

--- a/packages/ui/src/components/Text/style.css.ts
+++ b/packages/ui/src/components/Text/style.css.ts
@@ -1,5 +1,6 @@
 import { isColorMonochrome, textVariants, theme } from '@ultraviolet/themes'
 import { capitalize, filterByProperty } from '@ultraviolet/utils'
+import { style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 
 import { PROMINENCES } from './constants'
@@ -207,6 +208,7 @@ const text = recipe({
   },
 })
 
+const oneLine = style({})
 export type TextVariants = NonNullable<RecipeVariants<typeof text>>
 
-export const textStyle = { text }
+export const textStyle = { text, oneLine }

--- a/packages/ui/src/compositions/ContentCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/ContentCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`contentCardGroup > renders correctly with a children 1`] = `
           >
             <div>
               <h3
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
               />
             </div>
             <div>
@@ -76,13 +76,13 @@ exports[`contentCardGroup > renders correctly with description 1`] = `
           >
             <div>
               <h3
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
               >
                 title
               </h3>
             </div>
             <p
-              class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+              class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
             >
               description
             </p>
@@ -135,12 +135,12 @@ exports[`contentCardGroup > renders correctly with different title and subtitle 
           >
             <div>
               <h2
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35 style__m4c9ow3e"
               >
                 subtitle
               </h2>
               <h1
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
               >
                 title
               </h1>
@@ -197,7 +197,7 @@ exports[`contentCardGroup > renders correctly with link target _parent 1`] = `
           >
             <div>
               <h3
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
               >
                 title
               </h3>
@@ -327,7 +327,7 @@ exports[`contentCardGroup > renders correctly with required title & hread 1`] = 
           >
             <div>
               <h3
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
               >
                 title
               </h3>
@@ -381,12 +381,12 @@ exports[`contentCardGroup > renders correctly with subtitle 1`] = `
           >
             <div>
               <h5
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35 style__m4c9ow3e"
               >
                 subtitle
               </h5>
               <h3
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
               >
                 title
               </h3>

--- a/packages/ui/src/compositions/Conversation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/Conversation/__tests__/__snapshots__/index.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`conversation > should work with Default 1`] = `
               class="styles__18j62h6c styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Hello
               </span>
@@ -64,7 +64,7 @@ exports[`conversation > should work with Default 1`] = `
               class="styles__18j62h6c styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Hello
               </span>

--- a/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
+++ b/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Regular.test.tsx.snap
@@ -1623,7 +1623,7 @@ exports[`estimateCost - Regular Item > render basic props with overlay 1`] = `
                   >
                     <div>
                       <p
-                        class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a"
+                        class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                         style="--_1oy0ow40: 200px;"
                       >
                         This is a regular Item
@@ -1883,7 +1883,7 @@ exports[`estimateCost - Regular Item > render basic props with overlay 1`] = `
                         style="display: inline-flex;"
                       >
                         <p
-                          class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a"
+                          class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                           style="--_1oy0ow40: 350px;"
                         >
                           This is a regular Item
@@ -2040,7 +2040,7 @@ exports[`estimateCost - Regular Item > render basic props with overlay beta 1`] 
                   >
                     <div>
                       <p
-                        class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a"
+                        class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                         style="--_1oy0ow40: 200px;"
                       >
                         This is a regular Item 1
@@ -2276,7 +2276,7 @@ exports[`estimateCost - Regular Item > render basic props with overlay beta 1`] 
                         style="display: inline-flex;"
                       >
                         <p
-                          class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a"
+                          class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                           style="--_1oy0ow40: 350px;"
                         >
                           This is a regular Item 1
@@ -3036,7 +3036,7 @@ exports[`estimateCost - Regular Item > render basic with ellipsis 1`] = `
                   >
                     <div>
                       <p
-                        class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a"
+                        class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                         style="--_1oy0ow40: 200px;"
                       >
                         This is a regular Item
@@ -3254,7 +3254,7 @@ exports[`estimateCost - Regular Item > render basic with ellipsis 1`] = `
                         style="display: inline-flex;"
                       >
                         <p
-                          class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a"
+                          class="components__1oy0ow41 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                           style="--_1oy0ow40: 350px;"
                         >
                           This is a regular Item

--- a/packages/ui/src/compositions/InfoTable/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/InfoTable/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -37,7 +37,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -52,7 +52,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -72,7 +72,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell with more text
           </dd>
@@ -87,7 +87,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -107,7 +107,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -127,7 +127,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell
           </dd>
@@ -142,14 +142,14 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 styles__1s4jots6 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 styles__1s4jots6 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             <div
               class="styles__x6hyh50 styles_alignItems_center_xxsmall__x6hyh5d styles_gap_0.5rem_xxsmall__x6hyh52j"
               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
             >
               <p
-                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 a content
               </p>
@@ -199,7 +199,7 @@ exports[`infoTable > should work with CellWithCopybutton 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -232,7 +232,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -247,7 +247,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -262,7 +262,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -282,7 +282,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell with more text
           </dd>
@@ -297,7 +297,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -317,7 +317,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -337,7 +337,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell
           </dd>
@@ -352,7 +352,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -367,7 +367,7 @@ exports[`infoTable > should work with default props 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -400,7 +400,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -415,7 +415,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -430,7 +430,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -450,7 +450,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell with more text
           </dd>
@@ -465,7 +465,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -485,7 +485,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -520,7 +520,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -535,7 +535,7 @@ exports[`infoTable > should work with multiLine 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -568,7 +568,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -583,7 +583,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -598,7 +598,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -618,7 +618,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell with more text
           </dd>
@@ -633,7 +633,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -653,7 +653,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -673,7 +673,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell cell
           </dd>
@@ -688,7 +688,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>
@@ -703,7 +703,7 @@ exports[`infoTable > should work with width 1`] = `
             title
           </dt>
           <dd
-            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+            class="styles__1s4jots5 style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32 style__m4c9ow3e"
           >
             cell
           </dd>


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

#### What is expected?
`Text`: add `min-width` to the popup container when `oneLine` is enable to ensure the ellipsis works properly

Before:
<img width="494" height="155" alt="Capture d’écran 2026-04-07 à 10 31 52" src="https://github.com/user-attachments/assets/16a14c89-d461-46b5-8da3-cc457031460e" />

After : 
<img width="494" height="155" alt="Capture d’écran 2026-04-07 à 10 50 46" src="https://github.com/user-attachments/assets/fff7b7df-4b5f-4e23-816e-7598ae491a4f" />
