### PR TITLE
fix(BarChart): legend placement

### DIFF
--- a/.changeset/pink-months-lose.md
+++ b/.changeset/pink-months-lose.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`BarChart`: fix legend placement (firefox)

--- a/packages/ui/src/helpers/nivoTheme.ts
+++ b/packages/ui/src/helpers/nivoTheme.ts
@@ -13,6 +13,7 @@ export const getNivoTheme = (theme: ReturnType<typeof useTheme>) =>
       },
     },
     text: {
+      dominantBaseline: 'middle',
       fill: theme.colors.neutral.text,
       fontFamily: theme.typography.body.fontFamily,
       fontSize: theme.typography.bodySmall.fontSize,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

`BarChart`: fix legend placement (firefox)
(There are still some differences between mozilla and chromium, but this is mainly due to how they handle svgs)
| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| firefox  |<img width="1521" height="529" alt="Capture d’écran 2026-04-07 à 15 31 02" src="https://github.com/user-attachments/assets/6d939b11-0f0b-46de-a6c8-f757f342e5f0" /> | <img width="1521" height="529" alt="Capture d’écran 2026-04-07 à 15 30 59" src="https://github.com/user-attachments/assets/fd6603e2-a85a-4f43-ad0b-b17ff7402662" /> |
| chrome  | <img width="1521" height="557" alt="Capture d’écran 2026-04-07 à 15 32 26" src="https://github.com/user-attachments/assets/5899487e-abe5-4745-a070-4f47569eef1d" />|<img width="1521" height="557" alt="Capture d’écran 2026-04-07 à 15 32 07" src="https://github.com/user-attachments/assets/ce1e596a-f285-49cb-a803-0f3bf84d8037" /> |
