### PR TITLE
fix(Tag): overflow and width

### DIFF
--- a/.changeset/major-stars-crash.md
+++ b/.changeset/major-stars-crash.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Tag`: add a max width to ensure correct overflow

--- a/packages/ui/src/components/Popup/styles.css.ts
+++ b/packages/ui/src/components/Popup/styles.css.ts
@@ -2,6 +2,7 @@ import { theme } from '@ultraviolet/themes'
 import { keyframes, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 
+import { tagStyle } from '../Tag/styles.css'
 import { tagListStyle } from '../TagList/styles.css'
 
 import { DEFAULT_ARROW_WIDTH } from './helpers'
@@ -117,6 +118,10 @@ const childrenContainer = recipe({
     selectors: {
       [`${tagListStyle.ellipsisChild} > &`]: {
         minWidth: 0,
+      },
+      [`&:has(${tagStyle.text})`]: {
+        minWidth: 0,
+        width: '100%',
       },
     },
   },

--- a/packages/ui/src/components/Tag/styles.css.ts
+++ b/packages/ui/src/components/Tag/styles.css.ts
@@ -23,6 +23,7 @@ const container = recipe({
     padding: `0 ${theme.space[1]}`,
     whiteSpace: 'nowrap',
     width: 'fit-content',
+    maxWidth: '100%',
   },
   variants: {
     copiable: {


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?
`Tag`: add a max width to ensure correct overflow

Before:
<img width="331" height="143" alt="Capture d’écran 2026-04-08 à 14 38 13" src="https://github.com/user-attachments/assets/875add72-f324-4d32-9600-1e5b4424bc34" />

After: 
<img width="331" height="143" alt="Capture d’écran 2026-04-08 à 14 38 04" src="https://github.com/user-attachments/assets/14e9f1b2-261a-46e5-9e6c-c5dcf620807f" />
