### PR TITLE
fix(EmptyState): avoid empty div

### DIFF
--- a/.changeset/orange-streets-live.md
+++ b/.changeset/orange-streets-live.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`EmptyState`: small refactor to avoid empty divs

--- a/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/EmptyState/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,13 +25,6 @@ exports[`emptySpace > should work with border 1`] = `
             </p>
           </div>
         </div>
-        <div
-          class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
-        >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
-        </div>
         content
       </div>
     </div>
@@ -71,13 +64,6 @@ exports[`emptySpace > should work with image 1`] = `
             </p>
           </div>
         </div>
-        <div
-          class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
-        >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
-        </div>
         content
       </div>
     </div>
@@ -114,13 +100,6 @@ exports[`emptySpace > should work with image as component 1`] = `
             </p>
           </div>
         </div>
-        <div
-          class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
-        >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
-        </div>
         content
       </div>
     </div>
@@ -156,9 +135,6 @@ exports[`emptySpace > should work with learn more 1`] = `
         <div
           class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
         >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
           <a
             class="styles__1dtqm9e0 styles_prominence_default__1dtqm9e3 styles_sentiment_info__1dtqm9e2 styles_oneLine_false__1dtqm9e8 styles_variant_bodyStrong__1dtqm9eb styles_type_standalone__1dtqm9ed styles_undefined_compound_4__1dtqm9ei styles__1dtqm9en"
             data-variant="standalone"
@@ -304,13 +280,6 @@ exports[`emptySpace > should work with size 1`] = `
             </p>
           </div>
         </div>
-        <div
-          class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
-        >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
-        </div>
         content
       </div>
     </div>
@@ -349,13 +318,6 @@ exports[`emptySpace > should work with title 1`] = `
             </p>
           </div>
         </div>
-        <div
-          class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
-        >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
-        </div>
         content
       </div>
     </div>
@@ -387,13 +349,6 @@ exports[`emptySpace > should work without parameters 1`] = `
               test
             </p>
           </div>
-        </div>
-        <div
-          class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_1rem_xxsmall__toi52u3v styles_justifyContent_center_xxsmall__toi52u61"
-        >
-          <div
-            class="styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_1rem_xxsmall__toi52u3v"
-          />
         </div>
       </div>
     </div>

--- a/packages/ui/src/components/EmptyState/index.tsx
+++ b/packages/ui/src/components/EmptyState/index.tsx
@@ -108,22 +108,26 @@ export const EmptyState = ({
           </Text>
         </Stack>
       </Stack>
-      <Stack alignItems="center" gap={2} justifyContent="center">
-        <Stack direction="row" gap={2}>
-          {secondaryButton}
-          {primaryButton}
+      {primaryButton || secondaryButton || learnMore ? (
+        <Stack alignItems="center" gap={2} justifyContent="center">
+          {primaryButton || secondaryButton ? (
+            <Stack direction="row" gap={2}>
+              {secondaryButton}
+              {primaryButton}
+            </Stack>
+          ) : null}
+          {learnMore?.text ? (
+            <Link
+              href={learnMore.link}
+              iconPosition="right"
+              size={size === 'small' ? 'small' : undefined}
+              target={learnMore.target}
+            >
+              {learnMore.text}
+            </Link>
+          ) : null}
         </Stack>
-        {learnMore?.text ? (
-          <Link
-            href={learnMore.link}
-            iconPosition="right"
-            size={size === 'small' ? 'small' : undefined}
-            target={learnMore.target}
-          >
-            {learnMore.text}
-          </Link>
-        ) : null}
-      </Stack>
+      ) : null}
       {children}
     </Stack>
   </Stack>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`EmptyState`: small refactor to avoid empty divs