### PR TITLE
fix(useClipboard): hook update

### DIFF
--- a/.changeset/many-badgers-repeat.md
+++ b/.changeset/many-badgers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/utils": patch
+---
+
+`useClipboard`: fix hook not reacting to prop updates. Clipboard operations now always use the latest values of `text` and `options`

--- a/packages/ui/src/components/CopyButton/__tests__/index.test.tsx
+++ b/packages/ui/src/components/CopyButton/__tests__/index.test.tsx
@@ -56,4 +56,22 @@ describe('copyButton', () => {
     expect(onCopy).toHaveBeenCalledOnce()
     expect(writeTextSpy).toHaveBeenCalledWith('test')
   })
+
+  it('should update clipboard text when value prop changes', async () => {
+    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    navigator.clipboard.writeText = writeTextSpy
+
+    const { rerender } = renderWithTheme(<CopyButton value="initial text" />)
+
+    const copyButton = screen.getByRole('button')
+    await userEvent.click(copyButton)
+
+    expect(writeTextSpy).toHaveBeenCalledWith('initial text')
+
+    rerender(<CopyButton value="updated text" />)
+
+    const copyButtonRerendered = screen.getByRole('button')
+    await userEvent.click(copyButtonRerendered)
+    expect(writeTextSpy).toHaveBeenCalledWith('updated text')
+  })
 })

--- a/packages/utils/src/hooks/useClipboard.test.ts
+++ b/packages/utils/src/hooks/useClipboard.test.ts
@@ -118,4 +118,25 @@ describe('hooks - useClipboard', () => {
 
     expect(clearTimeoutSpy).toHaveBeenCalled()
   })
+
+  it('should update clipboard text when text prop changes', async () => {
+    const writeTextSpy = vi.fn().mockResolvedValue(undefined)
+    navigator.clipboard.writeText = writeTextSpy
+
+    const { result, rerender } = renderHook(({ text }) => useClipboard(text), {
+      initialProps: { text: 'initial text' },
+    })
+
+    await act(async () => {
+      await result.current[1]()
+    })
+    expect(writeTextSpy).toHaveBeenCalledWith('initial text')
+
+    rerender({ text: 'updated text' })
+
+    await act(async () => {
+      await result.current[1]()
+    })
+    expect(writeTextSpy).toHaveBeenCalledWith('updated text')
+  })
 })

--- a/packages/utils/src/hooks/useClipboard.ts
+++ b/packages/utils/src/hooks/useClipboard.ts
@@ -21,6 +21,10 @@ export function useClipboard(
   const paramsRef = useRef({ text, options })
 
   useEffect(() => {
+    paramsRef.current = { text, options }
+  }, [text, options])
+
+  useEffect(() => {
     let id: number | undefined
     if (isCopied && successDuration) {
       id = setTimeout(() => {


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?
`useClipboard`: fix hook not reacting to prop updates. Clipboard operations now always use the latest values of `text` and `options`