### PR TITLE
fix: docgen controls storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -43,6 +43,7 @@ const main = defineMain({
       compilerOptions: {
         esModuleInterop: true,
       },
+      shouldRemoveUndefinedFromOptional: true,
     },
   },
 })


### PR DESCRIPTION
## Summary

## Type

- Bug
- Documentation


### Summarize concisely:

#### What is expected?
Issue with controls in storybook

Before:
<img width="1078" height="472" alt="Capture d’écran 2026-04-17 à 10 29 59" src="https://github.com/user-attachments/assets/1306968d-0900-4d11-b40f-618d43f56833" />

After:
<img width="1092" height="494" alt="Capture d’écran 2026-04-17 à 10 30 09" src="https://github.com/user-attachments/assets/231de0be-325e-42f6-a764-09d3929a0afc" />
