### PR TITLE
ci: update steps definitions and add pnpm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: ['24']
+        node: ['24', '25']
     runs-on: ubuntu-24.04
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -24,15 +24,11 @@ jobs:
       - uses: actions/setup-node@v6.3.0
         with:
           node-version: ${{ matrix.node }}
-      - name: build
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run build
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
 
   build_storybook:
-    strategy:
-      matrix:
-        node: ['24']
     runs-on: ubuntu-24.04
     needs: [build]
     env:
@@ -43,12 +39,11 @@ jobs:
       - uses: pnpm/action-setup@v5.0.0
       - uses: actions/setup-node@v6.3.0
         with:
-          node-version: ${{ matrix.node }}
-      - name: build
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run build
-          pnpm run build:storybook
+          node-version: 24.15.0
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run build:storybook
 
   build_examples:
     runs-on: ubuntu-24.04
@@ -61,10 +56,9 @@ jobs:
       - uses: actions/setup-node@v6.3.0
         with:
           node-version: 24.15.0
-      - name: build
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run build:examples
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:examples
 
   manypkg:
     runs-on: ubuntu-24.04
@@ -78,10 +72,8 @@ jobs:
         with:
           node-version: 24.15.0
           cache: 'pnpm'
-      - name: manypkg
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec manypkg check
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec manypkg check
 
   typecheck:
     runs-on: ubuntu-24.04
@@ -96,11 +88,9 @@ jobs:
         with:
           node-version: 24.15.0
           cache: 'pnpm'
-      - name: typecheck
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm typecheck
-          pnpm typecheck:root
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm typecheck:root
 
   lint:
     runs-on: ubuntu-24.04
@@ -115,11 +105,9 @@ jobs:
         with:
           node-version: 24.15.0
           cache: 'pnpm'
-      - name: lint
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run build
-          pnpm run oxc:type-aware --quiet
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm run oxc:type-aware --quiet
 
   format:
     runs-on: ubuntu-24.04
@@ -133,9 +121,8 @@ jobs:
         with:
           node-version: 24.15.0
           cache: 'pnpm'
-      - run: |
-          pnpm install --frozen-lockfile
-          pnpm run format:ci
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run format:ci
 
   test:
     runs-on: ubuntu-24.04
@@ -145,7 +132,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        node: ['24']
+        node: ['24', '25']
     steps:
       - uses: actions/checkout@v6
         with:
@@ -155,9 +142,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
-      - run: |
-          pnpm install --frozen-lockfile
-          pnpm run test:unit:coverage --concurrency 1
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:unit:coverage --concurrency 1
       - uses: codecov/codecov-action@v6.0.0
         with:
           # files: packages/**/coverage/cobertura-coverage.xmls
@@ -195,10 +181,9 @@ jobs:
         with:
           node-version: 24.15.0
           cache: 'pnpm'
-      - run: |
-          pnpm install --frozen-lockfile
-          pnpm build
-          pnpm publint packages/*
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm publint packages/*
 
   deploy:
     runs-on: ubuntu-24.04
@@ -326,7 +311,7 @@ jobs:
 
   e2e:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [typecheck, format]
     env:
       CI: true
@@ -338,12 +323,9 @@ jobs:
         with:
           node-version: 24.15.0
           cache: 'pnpm'
-      - name: install pnpm deps
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install --with-deps
-      - name: run e2e
-        run: pnpm run test:e2e
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm run test:e2e
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   merge_group:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
   push:
     branches:
       - main

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -12,8 +12,7 @@ jobs:
         uses: actions/setup-node@v6.3.0
         with:
           node-version: 24.15.0
-      - run: |
-          pnpm install
-          pnpm run size
+      - run: pnpm install
+      - run: pnpm run size
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,7 +1,7 @@
 name: 'size'
 on:
   pull_request:
-    types: ['opened', 'edited', 'reopened', 'synchronize']
+
 jobs:
   size:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarize concisely:

Proposal to improve the readability of the CI.

#### What is expected?

By separating the pnpm commands in different steps, we can more easily :
- see the different steps in the UI
- see their individual duration
- browse the logs of a specific script (i.e. see the logs of the build without going through the logs of the install command)

#### The following changes were made:

- separate pnpm commands in different steps
- remove node-version matrix because we only use one version
- add pnpm cache where it was not specified
- edit the conditions to trigger the CI to avoid trigger when updating the PR title or description

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| GitHub UI  | <img width="666" height="446" alt="image" src="https://github.com/user-attachments/assets/2c782d0a-d100-42dd-9fe5-068ebc13bf85" /> | <img width="649" height="504" alt="image" src="https://github.com/user-attachments/assets/be4986bc-83b5-4b79-a179-1eaafe93ce03" /> |
