### PR TITLE
feat(Menu.Item): add hideOnClickItem props

### DIFF
--- a/.changeset/swift-bikes-buy.md
+++ b/.changeset/swift-bikes-buy.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+Add hideOnClickItem on Menu.Item in addition to Menu

--- a/packages/ui/src/components/Menu/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Menu/__tests__/index.test.tsx
@@ -559,5 +559,38 @@ describe('menu', () => {
           <Menu.Item active>Active Props</Menu.Item>
         </Menu>,
       ))
+
+    test('should hideOnClick for specific item', async () => {
+      renderWithTheme(
+        <Menu disclosure={() => disclosure} id="menu">
+          <Menu.Item hideOnClick data-testid="hide-item">
+            Should Hide
+          </Menu.Item>
+          <Menu.Item data-testid="dont-hide-item">Should not Hide</Menu.Item>
+        </Menu>,
+      )
+      const menuButton = screen.getByRole<HTMLButtonElement>('button')
+      // Open Menu
+      await userEvent.click(menuButton)
+      const dialog = screen.getByRole('dialog')
+
+      await waitFor(() => {
+        expect(dialog).toBeVisible()
+      })
+
+      // Click item that should NOT close the menu
+      const itemNoHide = screen.getByTestId('dont-hide-item')
+      await userEvent.click(itemNoHide)
+      await waitFor(() => {
+        expect(dialog).toBeVisible()
+      })
+
+      // Click item that SHOULD close the menu
+      const itemHide = screen.getByTestId('hide-item')
+      await userEvent.click(itemHide)
+      await waitFor(() => {
+        expect(dialog).not.toBeVisible()
+      })
+    })
   })
 })

--- a/packages/ui/src/components/Menu/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Menu/__tests__/index.test.tsx
@@ -563,33 +563,35 @@ describe('menu', () => {
     test('should hideOnClick for specific item', async () => {
       renderWithTheme(
         <Menu disclosure={() => disclosure} id="menu">
-          <Menu.Item hideOnClick data-testid="hide-item">
-            Should Hide
-          </Menu.Item>
-          <Menu.Item data-testid="dont-hide-item">Should not Hide</Menu.Item>
+          <Menu.Item hideOnClick>Should Hide</Menu.Item>
+          <Menu.Item>Should not Hide</Menu.Item>
         </Menu>,
       )
       const menuButton = screen.getByRole<HTMLButtonElement>('button')
       // Open Menu
       await userEvent.click(menuButton)
-      const dialog = screen.getByRole('dialog')
+      const menu = screen.getByRole('menu')
 
       await waitFor(() => {
-        expect(dialog).toBeVisible()
+        expect(menu).toBeVisible()
       })
 
       // Click item that should NOT close the menu
-      const itemNoHide = screen.getByTestId('dont-hide-item')
+      const itemNoHide = screen.getByRole<HTMLLinkElement>('menuitem', {
+        name: 'Should not Hide',
+      })
       await userEvent.click(itemNoHide)
       await waitFor(() => {
-        expect(dialog).toBeVisible()
+        expect(menu).toBeVisible()
       })
 
       // Click item that SHOULD close the menu
-      const itemHide = screen.getByTestId('hide-item')
+      const itemHide = screen.getByRole<HTMLLinkElement>('menuitem', {
+        name: 'Should Hide',
+      })
       await userEvent.click(itemHide)
       await waitFor(() => {
-        expect(dialog).not.toBeVisible()
+        expect(menu).not.toBeVisible()
       })
     })
   })

--- a/packages/ui/src/components/Menu/components/Item.tsx
+++ b/packages/ui/src/components/Menu/components/Item.tsx
@@ -40,7 +40,7 @@ type ItemProps = {
   searchText?: string
   style?: CSSProperties
   rightComponent?: ReactNode
-  hideOnClickItem?: boolean | undefined
+  hideOnClick?: boolean | undefined
 }
 
 const focusFistElement = (
@@ -72,12 +72,12 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
       'data-testid': dataTestId,
       style,
       rightComponent,
-      hideOnClickItem,
+      hideOnClick,
     },
     ref,
   ) => {
     const {
-      hideOnClickItem: menuHideOnClickItem,
+      hideOnClickItem,
       setIsVisible,
       isVisible,
       menuRef,
@@ -93,13 +93,13 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
           return undefined
         }
         onClick?.(event)
-        if (hideOnClickItem || menuHideOnClickItem) {
+        if (hideOnClickItem || hideOnClick) {
           setIsVisible(false)
         }
 
         return undefined
       },
-      [disabled, hideOnClickItem, menuHideOnClickItem, onClick, setIsVisible],
+      [disabled, hideOnClickItem, hideOnClick, onClick, setIsVisible],
     )
 
     const handleKeyDown = (
@@ -214,7 +214,7 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
                 event.preventDefault()
               }
               onClick?.(event)
-              if (hideOnClickItem || menuHideOnClickItem) {
+              if (hideOnClickItem || hideOnClick) {
                 setIsVisible(false)
               }
             }}

--- a/packages/ui/src/components/Menu/components/Item.tsx
+++ b/packages/ui/src/components/Menu/components/Item.tsx
@@ -40,6 +40,7 @@ type ItemProps = {
   searchText?: string
   style?: CSSProperties
   rightComponent?: ReactNode
+  hideOnClickItem?: boolean | undefined
 }
 
 const focusFistElement = (
@@ -71,11 +72,12 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
       'data-testid': dataTestId,
       style,
       rightComponent,
+      hideOnClickItem,
     },
     ref,
   ) => {
     const {
-      hideOnClickItem,
+      hideOnClickItem: MenuHideOnClickItem,
       setIsVisible,
       isVisible,
       menuRef,
@@ -91,13 +93,13 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
           return undefined
         }
         onClick?.(event)
-        if (hideOnClickItem) {
+        if (hideOnClickItem || MenuHideOnClickItem) {
           setIsVisible(false)
         }
 
         return undefined
       },
-      [disabled, hideOnClickItem, onClick, setIsVisible],
+      [disabled, hideOnClickItem, MenuHideOnClickItem, onClick, setIsVisible],
     )
 
     const handleKeyDown = (
@@ -212,7 +214,7 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
                 event.preventDefault()
               }
               onClick?.(event)
-              if (hideOnClickItem) {
+              if (hideOnClickItem || MenuHideOnClickItem) {
                 setIsVisible(false)
               }
             }}

--- a/packages/ui/src/components/Menu/components/Item.tsx
+++ b/packages/ui/src/components/Menu/components/Item.tsx
@@ -77,7 +77,7 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
     ref,
   ) => {
     const {
-      hideOnClickItem: MenuHideOnClickItem,
+      hideOnClickItem: menuHideOnClickItem,
       setIsVisible,
       isVisible,
       menuRef,
@@ -93,13 +93,13 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
           return undefined
         }
         onClick?.(event)
-        if (hideOnClickItem || MenuHideOnClickItem) {
+        if (hideOnClickItem || menuHideOnClickItem) {
           setIsVisible(false)
         }
 
         return undefined
       },
-      [disabled, hideOnClickItem, MenuHideOnClickItem, onClick, setIsVisible],
+      [disabled, hideOnClickItem, menuHideOnClickItem, onClick, setIsVisible],
     )
 
     const handleKeyDown = (
@@ -214,7 +214,7 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
                 event.preventDefault()
               }
               onClick?.(event)
-              if (hideOnClickItem || MenuHideOnClickItem) {
+              if (hideOnClickItem || menuHideOnClickItem) {
                 setIsVisible(false)
               }
             }}


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarize concisely:

Propal : Add hideOnClickItem on Menu.Item props in addition to Menu props to be able to specify which item close the menu and which does not

#### What is expected?

hideOnClickItem on Menu.Item close the menu on click on the specific item even if the Menu does not have hideOnClickItem set to true

#### The following changes were made:

1. Added hideOnClickItem on Menu.Item


#### Why is that needed?

I need this feature to be able to close the menu when a particular element is clicked but not when other are clicked. For exemple:  I have a modal setup with a disclosure on my Menu, I do not want to hide the menu on click for that particular element because that would close the modal also. But another button on that menu open a drawer with no disclosure and that push body, so i need to close the menu on that particular element click.
