### PR TITLE
fix(FileInput): validator return type and onDrop file name

### DIFF
--- a/.changeset/late-camels-pick.md
+++ b/.changeset/late-camels-pick.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`FileInput`: update validator type so that it can return `null` or `undefined`, fix `fileRejection` (in `onChange`) to return correct file names and fix wrapper overlay width

--- a/packages/ui/src/components/FileInput/index.tsx
+++ b/packages/ui/src/components/FileInput/index.tsx
@@ -123,7 +123,7 @@ const FileInputBase = ({
           : 'Error'
 
         errorFiles.push({
-          fileName: name,
+          fileName: file.name,
           error: customError ?? defaultMessage,
         })
       }

--- a/packages/ui/src/components/FileInput/styles.css.ts
+++ b/packages/ui/src/components/FileInput/styles.css.ts
@@ -84,7 +84,6 @@ const titleSmall = styleVariants({
 const overlayWrapper = style({
   height: 'fit-content',
   position: 'relative',
-  width: 'fit-content',
 })
 
 const dropzoneOverlayBase = style({

--- a/packages/ui/src/components/FileInput/types.ts
+++ b/packages/ui/src/components/FileInput/types.ts
@@ -70,7 +70,7 @@ export type FileInputProps = {
   helper?: string
   onDrop?: (
     event: DragEvent<HTMLElement>,
-    accetedFiles: File[],
+    acceptedFiles: File[],
     errorFiles?: ErrorType[],
   ) => void
   accept?: HTMLInputElement['accept']
@@ -82,7 +82,7 @@ export type FileInputProps = {
   error?: boolean | string
   disabledDragndrop?: boolean
   onChange?: (files: FileList) => void
-  validator?: (file: File) => string
+  validator?: (file: File) => string | null | undefined
 } & (OverlayVariantProps | DropzoneVariantProps) &
   LabelType &
   Pick<


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:
`FileInput`: update validator type so that it can return `null` or `undefined` and fix `fileRejection` (in `onChange`) to return correct file names