### PR TITLE
fix(OptionSelector): remove unwanted padding and margin

### DIFF
--- a/.changeset/twelve-eagles-try.md
+++ b/.changeset/twelve-eagles-try.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`OptionSelector`: remove unwanted browser default padding and margin from fieldset

--- a/packages/ui/src/compositions/OptionSelector/styles.css.ts
+++ b/packages/ui/src/compositions/OptionSelector/styles.css.ts
@@ -7,6 +7,8 @@ import { selectInputStyle } from '../../components/styles'
 const wrapper = recipe({
   base: {
     border: 'none',
+    padding: 0,
+    margin: 0,
   },
   variants: {
     direction: {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:


`OptionSelector`: remove unwanted browser default padding and margin from fieldset