### PR TITLE
fix(Menu): remove stop propagation on item

### DIFF
--- a/.changeset/tiny-sites-bathe.md
+++ b/.changeset/tiny-sites-bathe.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Menu`: remove event.stopPropagation on nested menu items

--- a/packages/ui/src/components/Menu/MenuContent.tsx
+++ b/packages/ui/src/components/Menu/MenuContent.tsx
@@ -110,10 +110,6 @@ export const Menu = forwardRef(
       'aria-haspopup': 'dialog',
       onClick: (event: MouseEvent<HTMLButtonElement>) => {
         target.props.onClick?.(event)
-        if (isNested) {
-          event.preventDefault()
-          event.stopPropagation()
-        }
         setIsVisible(!isVisible)
       },
       // @ts-expect-error not sure how to fix this

--- a/packages/ui/src/components/Menu/components/Item.tsx
+++ b/packages/ui/src/components/Menu/components/Item.tsx
@@ -208,7 +208,6 @@ export const Item = forwardRef<HTMLElement, ItemProps>(
             disabled={disabled}
             onClick={event => {
               if (isNested) {
-                event.stopPropagation()
                 event.preventDefault()
               }
               onClick?.(event)


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:
`Menu`: remove event.stopPropagation on nested menu items