### PR TITLE
feat: add hooks useFlip and usePrefersReducedMotion

### DIFF
--- a/.changeset/proud-beans-know.md
+++ b/.changeset/proud-beans-know.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/animations": major
+---
+
+Initialize the package `@ultraviolet/animations` with a hook `usePrefersReducedMotion` to disable animations in React components

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -111,6 +111,7 @@
         "vitest/prefer-to-be-falsy": "off",
         "vitest/prefer-to-be-truthy": "off",
         "vitest/require-test-timeout": "off",
+        "vitest/require-mock-type-parameters": "off",
       },
     },
     {

--- a/packages/animations/README.md
+++ b/packages/animations/README.md
@@ -1,0 +1,13 @@
+# Ultraviolet animations
+
+A collection of hooks, constants and helpers for creating animations.
+
+## Get Started
+
+```sh
+$ pnpm add @ultraviolet/animations
+```
+
+## License
+
+Apache-2.0

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@ultraviolet/animations",
+  "version": "0.1.0",
+  "description": "Ultraviolet animations",
+  "homepage": "https://github.com/scaleway/ultraviolet#readme",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scaleway/ultraviolet.git",
+    "directory": "packages/animations"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "vite build && pnpm type:generate",
+    "lintpublish": "publint",
+    "test:unit": "vitest --run",
+    "test:unit:coverage": "pnpm test:unit --coverage",
+    "test:watch": "vitest",
+    "type:generate": "tsgo --declaration -p tsconfig.build.json",
+    "typecheck": "tsgo --noEmit"
+  },
+  "devDependencies": {
+    "@repo/config": "workspace:*",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "@utils/test": "workspace:*",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "vite": "8.0.10",
+    "vitest": "4.1.5"
+  },
+  "engines": {
+    "node": ">=18.x",
+    "pnpm": ">=9.x"
+  }
+}

--- a/packages/animations/src/hooks/__tests__/useFlip.test.tsx
+++ b/packages/animations/src/hooks/__tests__/useFlip.test.tsx
@@ -1,0 +1,190 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import { useFlip } from '../useFlip'
+
+const createMockRect = (
+  options: Partial<DOMRect> = {},
+): ReturnType<Element['getBoundingClientRect']> => ({
+  left: 0,
+  top: 0,
+  right: 100,
+  bottom: 100,
+  width: 100,
+  height: 100,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+  ...options,
+})
+
+const createContainer = () => {
+  const container = document.createElement('div')
+  Object.assign(container, { animate: vi.fn() })
+  return container
+}
+
+const createElement = (flipId: string) => {
+  const element = document.createElement('div')
+  element.dataset['flipId'] = flipId
+  return element
+}
+
+describe(useFlip, () => {
+  it('should return prepareAnimation and animate functions', () => {
+    const ref = { current: document.createElement('div') }
+    const { result } = renderHook(() => useFlip(ref))
+
+    expectTypeOf(result.current.prepareAnimation).toBeFunction()
+    expectTypeOf(result.current.animate).toBeFunction()
+  })
+
+  it('should animate elements that have moved', async () => {
+    const container = createContainer()
+    const element = createElement('item1')
+    container.appendChild(element)
+
+    const mockAnimate = vi.fn(() => ({ finished: vi.fn() }))
+    Object.assign(element, { animate: mockAnimate })
+
+    const ref = { current: container }
+    const { result } = renderHook(() => useFlip(ref))
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValueOnce(
+      createMockRect({ left: 0, top: 0 }),
+    )
+
+    act(() => {
+      result.current.prepareAnimation()
+    })
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValueOnce(
+      createMockRect({ left: 50, top: 50 }),
+    )
+
+    await act(async () => {
+      await result.current.animate()
+    })
+
+    expect(mockAnimate).toHaveBeenCalledWith(
+      [{ transform: 'translate(-50px, -50px)' }, {}],
+      {
+        duration: 250,
+        easing: 'ease',
+      },
+    )
+  })
+
+  it('should not animate elements that have not moved', async () => {
+    const container = createContainer()
+    const element = createElement('item1')
+    container.appendChild(element)
+
+    const mockAnimate = vi.fn(() => ({
+      finished: vi.fn(),
+    }))
+    Object.assign(element, { animate: mockAnimate })
+
+    const ref = { current: container }
+    const { result } = renderHook(() => useFlip(ref))
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValueOnce(
+      createMockRect({ left: 0, top: 0 }),
+    )
+
+    act(() => {
+      result.current.prepareAnimation()
+    })
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValueOnce(
+      createMockRect({ left: 0, top: 0 }),
+    )
+
+    await act(async () => {
+      await result.current.animate()
+    })
+
+    expect(mockAnimate).not.toHaveBeenCalled()
+  })
+
+  it('should cancel existing animation when starting new one', async () => {
+    const container = createContainer()
+    const element = createElement('item1')
+    container.appendChild(element)
+
+    const mockAnimation = {
+      finished: Promise.resolve(),
+      cancel: vi.fn(),
+    }
+
+    Object.assign(element, { animate: vi.fn(() => mockAnimation) })
+
+    const ref = { current: container }
+    const { result } = renderHook(() => useFlip(ref))
+
+    act(() => {
+      result.current.prepareAnimation()
+    })
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValueOnce(
+      createMockRect({ left: 0, top: 0 }),
+    )
+
+    act(() => {
+      result.current.prepareAnimation()
+    })
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValueOnce(
+      createMockRect({ left: 50, top: 50 }),
+    )
+
+    await act(async () => {
+      await result.current.animate()
+    })
+
+    act(() => {
+      result.current.prepareAnimation()
+    })
+
+    await act(async () => {
+      await result.current.animate()
+    })
+
+    expect(mockAnimation.cancel).toHaveBeenCalled()
+  })
+
+  it('should handle null ref in prepareAnimation', () => {
+    const ref = { current: null }
+    const { result } = renderHook(() => useFlip(ref))
+
+    expect(() => {
+      act(() => {
+        result.current.prepareAnimation()
+      })
+    }).not.toThrow()
+  })
+
+  it('should handle null ref in animate', async () => {
+    const ref = { current: null }
+    const { result } = renderHook(() => useFlip(ref))
+
+    await expect(result.current.animate()).resolves.toBeUndefined()
+  })
+
+  it('should return resolved promise when element does not support animate', async () => {
+    const container = createContainer()
+    const element = createElement('item1')
+    container.appendChild(element)
+
+    Object.assign(container, { animate: undefined })
+
+    const ref = { current: container }
+    const { result } = renderHook(() => useFlip(ref))
+
+    act(() => {
+      result.current.prepareAnimation()
+    })
+
+    await expect(result.current.animate()).resolves.toBeUndefined()
+  })
+})

--- a/packages/animations/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
+++ b/packages/animations/src/hooks/__tests__/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { usePrefersReducedMotion } from '../usePrefersReducedMotion'
+
+describe(usePrefersReducedMotion, () => {
+  it('should return true when prefers-reduced-motion is enabled', () => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const { result } = renderHook(() => usePrefersReducedMotion())
+
+    expect(result.current).toBe(true)
+  })
+
+  it('should return false when prefers-reduced-motion is disabled', () => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+
+    const { result } = renderHook(() => usePrefersReducedMotion())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('should cleanup event listener on unmount', () => {
+    const mockRemoveListener = vi.fn()
+
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: mockRemoveListener,
+    }))
+
+    const { unmount } = renderHook(() => usePrefersReducedMotion())
+
+    unmount()
+
+    expect(mockRemoveListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function),
+    )
+  })
+})

--- a/packages/animations/src/hooks/useFlip.ts
+++ b/packages/animations/src/hooks/useFlip.ts
@@ -1,0 +1,108 @@
+import { useCallback, useRef } from 'react'
+
+import type { RefObject } from 'react'
+
+type UseFlipOptions = {
+  duration?: number
+  easing?: string
+}
+
+/**
+ * Simplified implementation of the FLIP animation technique.
+ * @see https://css-tricks.com/animating-layouts-with-the-flip-technique/
+ *
+ * This implementation only animates the position of the objects.
+ *
+ * @example
+ * ```tsx
+ * function MyList() {
+ *   const ref = useRef<HTMLDivElement>(null)
+ *   const { prepareAnimation, animate } = useFlip(ref)
+ *
+ *   const handleReorder = async () => {
+ *     prepareAnimation()
+ *     // Reorder items...
+ *     requestAnimationFrame(() => {
+ *       animate()
+ *     })
+ *   }
+ *
+ *   return (
+ *     <div ref={ref}>
+ *       {items.map(item => (
+ *         <div key={item.id} data-flip-id={item.id}>
+ *           {item.name}
+ *         </div>
+ *       ))}
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export const useFlip = (
+  ref: RefObject<HTMLElement | null>,
+  options: UseFlipOptions = {},
+) => {
+  const { duration = 250, easing = 'ease' } = options
+
+  const firstPositions = useRef<Map<string, DOMRect>>(new Map())
+  const animations = useRef<Animation[]>([])
+
+  const prepareAnimation = useCallback(() => {
+    if (!ref.current || typeof ref.current.animate !== 'function') {
+      return
+    }
+
+    const elements = ref.current.querySelectorAll<HTMLElement>('[data-flip-id]')
+    const positions = new Map<string, DOMRect>()
+
+    elements.forEach(element => {
+      const id = element.dataset['flipId']
+      if (id) {
+        positions.set(id, element.getBoundingClientRect())
+      }
+    })
+
+    firstPositions.current = positions
+  }, [ref])
+
+  const animate = useCallback(() => {
+    if (!ref.current || typeof ref.current.animate !== 'function') {
+      return Promise.resolve()
+    }
+
+    animations.current.forEach(animation => animation.cancel())
+
+    const elements = ref.current.querySelectorAll<HTMLElement>('[data-flip-id]')
+
+    animations.current = [...elements]
+      .map(element => {
+        const id = element.dataset['flipId']
+        if (!id || !firstPositions.current.has(id)) {
+          return null
+        }
+
+        const first = firstPositions.current.get(id)!
+        const last = element.getBoundingClientRect()
+
+        const deltaX = first.left - last.left
+        const deltaY = first.top - last.top
+
+        if (deltaX === 0 && deltaY === 0) {
+          return null
+        }
+
+        return element.animate(
+          [{ transform: `translate(${deltaX}px, ${deltaY}px)` }, {}],
+          { duration, easing },
+        )
+      })
+      .filter(animation => animation !== null)
+
+    return Promise.allSettled(
+      animations.current.map(animation => animation.finished),
+    )
+  }, [ref, duration, easing])
+
+  return { prepareAnimation, animate }
+}

--- a/packages/animations/src/hooks/usePrefersReducedMotion.ts
+++ b/packages/animations/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: no-preference)'
+
+/**
+ * Check if the user has enabled reduced motion in their system settings.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const prefersReducedMotion = usePrefersReducedMotion()
+ *
+ *   return (
+ *     <div style={{ animation: prefersReducedMotion ? 'none' : 'slideIn 1s' }}>
+ *       Content
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    typeof window === 'undefined' ? true : !window.matchMedia(QUERY).matches,
+  )
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(QUERY)
+
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(!event.matches)
+    }
+
+    mediaQueryList.addEventListener('change', listener)
+    return () => {
+      mediaQueryList.removeEventListener('change', listener)
+    }
+  }, [])
+
+  return prefersReducedMotion
+}

--- a/packages/animations/src/index.ts
+++ b/packages/animations/src/index.ts
@@ -1,0 +1,2 @@
+export { useFlip } from './hooks/useFlip'
+export { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'

--- a/packages/animations/tsconfig.build.json
+++ b/packages/animations/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": [
+    "*.config.ts",
+    "*.setup.ts",
+    "**/__tests__",
+    "**/__mocks__",
+    "**/__stories__",
+    "src/**/*.test.tsx"
+  ],
+  "extends": "@repo/config/tsconfig/build.json",
+  "include": ["src"]
+}

--- a/packages/animations/tsconfig.json
+++ b/packages/animations/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "extends": "@repo/config/tsconfig/base.json",
+  "include": ["src"]
+}

--- a/packages/animations/vite.config.ts
+++ b/packages/animations/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+
+import { defaultConfig } from '../../utils/config/vite/vite.config'
+
+export default defineConfig(defaultConfig)

--- a/packages/animations/vitest.config.ts
+++ b/packages/animations/vitest.config.ts
@@ -1,0 +1,8 @@
+import { createVitestConfig } from '@utils/test/config'
+
+export const vitestConfig = createVitestConfig({
+  dom: true,
+  name: 'animations',
+})
+
+export default vitestConfig

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -11,7 +11,6 @@ export const vitestConfig = {
   ],
   test: {
     ...createVitestConfig({
-      environment: 'json',
       testTimeout: 10_000,
       dom: true,
       name: 'ui',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,33 @@ importers:
         specifier: 8.0.10
         version: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/animations:
+    devDependencies:
+      '@repo/config':
+        specifier: workspace:*
+        version: link:../../utils/config
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@utils/test':
+        specifier: workspace:*
+        version: link:../../utils/test
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
+      vite:
+        specifier: 8.0.10
+        version: 8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@types/node@25.5.0)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/fonts:
     devDependencies:
       '@repo/config':

--- a/utils/stories/src/Guides/Animations.mdx
+++ b/utils/stories/src/Guides/Animations.mdx
@@ -57,6 +57,35 @@ const MyComponent = () => (
 )
 ```
 
+## Reducing animations
+
+Some animations can trigger discomfort for people with [vestibular motion disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/). Animations such as scaling or panning large objects can be vestibular motion triggers.
+
+In CSS you can use the media query [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion) to trigger animations only if the user has not enabled a setting on their device to reduce animations.
+
+```css
+@media (prefers-reduced-motion: no-preference) {
+  .animated {
+    animation: bounce 1s;
+  }
+}
+```
+
+For animations that are controlled in JavaScript, we provide a React hook to detect if the user has enabled the setting.
+
+```tsx
+import { usePrefersReducedMotion } from '@ultraviolet/animations'
+
+function MyComponent() {
+  const prefersReducedMotion = usePrefersReducedMotion()
+  return (
+    <div style={{ animation: prefersReducedMotion ? 'none' : 'bounce 1s' }}>
+      Content
+    </div>
+  )
+}
+```
+
 ## List
 
 - <ShowcaseAnimations animation="bounce" />

--- a/utils/test/package.json
+++ b/utils/test/package.json
@@ -12,6 +12,7 @@
   "files": [
     "src/*"
   ],
+  "type": "module",
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarize concisely:

create a new package `@ultraviolet/animations` with hooks to help with animations

#### What is expected?

Nothing is visible in the PR, see https://github.com/scaleway/ultraviolet/pull/6398 for the preview

#### The following changes were made:

1. add a hook `useFlip` with a simple implementation of the [FLIP animation technique](https://css-tricks.com/animating-layouts-with-the-flip-technique/)
2. add a hook `usePrefersReducedMotion` to disable animations based on user setting
3. add tests