### PR TITLE
fix(Drawer): content full height and empty footer

### DIFF
--- a/.changeset/pretty-yaks-fry.md
+++ b/.changeset/pretty-yaks-fry.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Drawer`: 
+- content should be full height
+- remove empty div when `footer` is undefined

--- a/packages/ui/src/components/Drawer/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Drawer/__tests__/__snapshots__/index.test.tsx.snap
@@ -214,9 +214,6 @@ exports[`drawer > renders with disclosure and onClose 1`] = `
               </div>
             </div>
           </div>
-          <div
-            class="styles__1iezf7ya styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d"
-          />
         </div>
         <div
           class="styles__lrojhc2"

--- a/packages/ui/src/components/Drawer/index.tsx
+++ b/packages/ui/src/components/Drawer/index.tsx
@@ -152,9 +152,11 @@ export const BaseDrawer = ({
             <div className={drawerStyle.childrenWrapper}>
               {noPadding ? content : <DrawerContent>{content}</DrawerContent>}
             </div>
-            <Stack className={drawerStyle.footer}>
-              {typeof footer === 'function' ? footer(modalProps) : footer}
-            </Stack>
+            {footer ? (
+              <Stack className={drawerStyle.footer}>
+                {typeof footer === 'function' ? footer(modalProps) : footer}
+              </Stack>
+            ) : null}
           </Stack>
         )
       }}

--- a/packages/ui/src/components/Drawer/styles.css.ts
+++ b/packages/ui/src/components/Drawer/styles.css.ts
@@ -55,6 +55,7 @@ const childrenWrapper = style({
 
 const content = style({
   paddingInline: theme.space[2],
+  height: '100%',
 })
 
 const header = style({


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

`Drawer`: 
- content should be full height
- remove empty div when `footer` is undefined