### PR TITLE
fix: correct display of the close button on the tag

### DIFF
--- a/.changeset/bright-bears-take.md
+++ b/.changeset/bright-bears-take.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+correct display of the close button on the tag

--- a/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,16 +71,16 @@ exports[`tagInputField > should render correctly with regex 1`] = `
               class="uv_sjgcm24"
             >
               <span
-                class="uv_d6zknp0 uv_d6zknp5"
+                class="uv_d6zknp0 uv_d6zknp6 uv_d6zknp3"
               >
                 <span
-                  class="uv_d6zknp1c uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a uv_m4c9ow3e"
+                  class="uv_d6zknp1d uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a uv_m4c9ow3e"
                 >
                   4
                 </span>
                 <button
                   aria-label="Close tag"
-                  class="uv_d6zknp1d uv_e1wcoe0 uv_e1wcoe1 uv_e1wcoe3 uv_e1wcoe8 uv_e1wcoeg uv_e1wcoej uv_e1wcoe19"
+                  class="uv_e1wcoe0 uv_e1wcoe1 uv_e1wcoe3 uv_e1wcoe8 uv_e1wcoeh uv_e1wcoej uv_e1wcoe19"
                   data-testid="close-tag"
                   type="button"
                 >
@@ -177,16 +177,16 @@ exports[`tagInputField > should works with defaultValues 1`] = `
               class="uv_sjgcm24"
             >
               <span
-                class="uv_d6zknp0 uv_d6zknp5"
+                class="uv_d6zknp0 uv_d6zknp6 uv_d6zknp3"
               >
                 <span
-                  class="uv_d6zknp1c uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a uv_m4c9ow3e"
+                  class="uv_d6zknp1d uv_m4c9ow0 uv_m4c9ow3 uv_m4c9ow4 uv_m4c9owp uv_m4c9ow1a uv_m4c9ow3e"
                 >
                   First
                 </span>
                 <button
                   aria-label="Close tag"
-                  class="uv_d6zknp1d uv_e1wcoe0 uv_e1wcoe1 uv_e1wcoe3 uv_e1wcoe8 uv_e1wcoeg uv_e1wcoej uv_e1wcoe19"
+                  class="uv_e1wcoe0 uv_e1wcoe1 uv_e1wcoe3 uv_e1wcoe8 uv_e1wcoeh uv_e1wcoej uv_e1wcoe19"
                   data-testid="close-tag"
                   type="button"
                 >

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -934,18 +934,18 @@ exports[`selectInput > renders correctly multiselect 1`] = `
               class="selectBar__r8qe4o styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_nowrap_xxsmall__toi52u31 styles_gap_0.5rem_xxsmall__toi52u3p"
             >
               <span
-                class="selectBar_visible__r8qe4l selectBar__r8qe4j styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+                class="selectBar_visible__r8qe4l selectBar__r8qe4j styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_closable_true__d6zknp3"
                 data-testid="selected-options-tags"
                 style="--r8qe41: auto; --r8qe40: 1024px;"
               >
                 <span
-                  class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                  class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                 >
                   Pluto
                 </span>
                 <button
                   aria-label="Close tag"
-                  class="styles__d6zknp1d styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                  class="styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_xsmall__e1wcoeh styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
                   data-testid="close-tag"
                   type="button"
                 >
@@ -2512,12 +2512,12 @@ exports[`selectInput > renders correctly unclosable tags when readonly 1`] = `
               class="selectBar__r8qe4o styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_flexWrap_nowrap_xxsmall__toi52u31 styles_gap_0.5rem_xxsmall__toi52u3p"
             >
               <span
-                class="selectBar_visible__r8qe4l selectBar__r8qe4j styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+                class="selectBar_visible__r8qe4l selectBar__r8qe4j styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
                 data-testid="selected-options-tags"
                 style="--r8qe41: auto; --r8qe40: 1024px;"
               >
                 <span
-                  class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                  class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
                 >
                   Venus
                 </span>

--- a/packages/ui/src/components/Tag/TagInner.tsx
+++ b/packages/ui/src/components/Tag/TagInner.tsx
@@ -23,6 +23,7 @@ export const TagInner = ({
   disabled = false,
   copiable,
   variant,
+  sentiment,
   copyButton,
 }: TagInnerProps) => (
   <>
@@ -41,12 +42,11 @@ export const TagInner = ({
     {onClose && !isLoading ? (
       <Button
         aria-label="Close tag"
-        className={tagStyle.closeButton}
         data-testid="close-tag"
         disabled={disabled}
         onClick={onClose}
-        sentiment="neutral"
-        size="small"
+        sentiment={sentiment}
+        size="xsmall"
         variant="ghost"
       >
         <CloseIcon size="small" />

--- a/packages/ui/src/components/Tag/__stories__/Sentiments.stories.tsx
+++ b/packages/ui/src/components/Tag/__stories__/Sentiments.stories.tsx
@@ -16,6 +16,7 @@ export const Sentiments = (props: ComponentProps<typeof Tag>) =>
       key={sentiment}
       sentiment={sentiment}
       variant={props.variant}
+      onClose={() => {}}
     >
       {sentiment}
     </Tag>

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`tag > renders correctly 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -24,10 +24,10 @@ exports[`tag > renders correctly colored 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_primary__d6zknp6"
+      class="styles__d6zknp0 styles_sentiment_primary__d6zknp7"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -42,10 +42,10 @@ exports[`tag > renders correctly disabled 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_disabled_true__d6zknp2 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_23__d6zknp10"
+      class="styles__d6zknp0 styles_disabled_true__d6zknp2 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_23__d6zknp11"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -60,10 +60,10 @@ exports[`tag > renders correctly neutral 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -78,10 +78,10 @@ exports[`tag > renders correctly with code variant 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_code__m4c9owv style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_code__m4c9owv style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -102,11 +102,11 @@ exports[`tag > renders correctly with copiable 1`] = `
       tabindex="0"
     >
       <button
-        class="styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+        class="styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
         type="button"
       >
         <span
-          class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+          class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
         >
           test
         </span>
@@ -128,11 +128,11 @@ exports[`tag > renders correctly with copiable and copy button 1`] = `
       tabindex="0"
     >
       <button
-        class="styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+        class="styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
         type="button"
       >
         <span
-          class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+          class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
         >
           test
         </span>
@@ -168,10 +168,10 @@ exports[`tag > renders correctly with icon 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         <svg
           class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
@@ -201,10 +201,10 @@ exports[`tag > renders correctly with isLoading 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
@@ -251,19 +251,19 @@ exports[`tag > renders correctly with key-value variant 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5 styles_isKey_true__d6zknpa styles_isKeyValue_true__d6zknpc styles_undefined_compound_9__d6zknpm styles_undefined_compound_16__d6zknpt"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_isKey_true__d6zknpb styles_isKeyValue_true__d6zknpd styles_undefined_compound_9__d6zknpn styles_undefined_compound_16__d6zknpu"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         key
       </span>
     </span>
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5 styles_isValue_true__d6zknpb styles_isKeyValue_true__d6zknpc styles_undefined_compound_16__d6zknpt"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_isValue_true__d6zknpc styles_isKeyValue_true__d6zknpd styles_undefined_compound_16__d6zknpu"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         value
       </span>
@@ -278,16 +278,16 @@ exports[`tag > renders correctly with onClose 1`] = `
     data-testid="testing"
   >
     <span
-      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+      class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_closable_true__d6zknp3"
     >
       <span
-        class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+        class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
       >
         test
       </span>
       <button
         aria-label="Close tag"
-        class="styles__d6zknp1d styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+        class="styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_xsmall__e1wcoeh styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
         data-testid="close-tag"
         type="button"
       >

--- a/packages/ui/src/components/Tag/index.tsx
+++ b/packages/ui/src/components/Tag/index.tsx
@@ -107,7 +107,12 @@ export const Tag = ({
         <button
           className={cn(
             className,
-            tagStyle.container({ copiable, disabled, sentiment }),
+            tagStyle.container({
+              copiable,
+              disabled,
+              sentiment,
+              closable: !!onClose,
+            }),
           )}
           data-testid={dataTestId}
           disabled={disabled}
@@ -122,6 +127,7 @@ export const Tag = ({
             disabled={disabled}
             isLoading={isLoading}
             onClose={onClose}
+            sentiment={sentiment}
             variant={variant}
           >
             {children}
@@ -133,7 +139,10 @@ export const Tag = ({
 
   return (
     <span
-      className={cn(className, tagStyle.container({ disabled, sentiment }))}
+      className={cn(
+        className,
+        tagStyle.container({ disabled, sentiment, closable: !!onClose }),
+      )}
       data-testid={dataTestId}
       style={style}
     >
@@ -141,6 +150,7 @@ export const Tag = ({
         disabled={disabled}
         isLoading={isLoading}
         onClose={onClose}
+        sentiment={sentiment}
         variant={variant}
       >
         {children}

--- a/packages/ui/src/components/Tag/styles.css.ts
+++ b/packages/ui/src/components/Tag/styles.css.ts
@@ -46,6 +46,12 @@ const container = recipe({
         cursor: 'not-allowed',
       },
     },
+    closable: {
+      true: {
+        paddingRight: theme.space[0.5],
+        gap: theme.space[0.5],
+      },
+    },
 
     sentiment: Object.fromEntries(
       SENTIMENTS.map(sentiment => [
@@ -127,10 +133,4 @@ const text = style({
   maxWidth: '14.5rem',
 })
 
-const closeButton = style({
-  height: 'fit-content',
-  padding: theme.space['0.25'],
-  width: 'fit-content',
-})
-
-export const tagStyle = { container, text, closeButton }
+export const tagStyle = { container, text }

--- a/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -293,16 +293,16 @@ exports[`tagInput > should renders correctly with some tags 1`] = `
             class="styles__sjgcm24"
           >
             <span
-              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_closable_true__d6zknp3"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 hello
               </span>
               <button
                 aria-label="Close tag"
-                class="styles__d6zknp1d styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                class="styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_xsmall__e1wcoeh styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
                 data-testid="close-tag"
                 type="button"
               >
@@ -322,16 +322,16 @@ exports[`tagInput > should renders correctly with some tags 1`] = `
               </button>
             </span>
             <span
-              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_closable_true__d6zknp3"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 world
               </span>
               <button
                 aria-label="Close tag"
-                class="styles__d6zknp1d styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                class="styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_xsmall__e1wcoeh styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
                 data-testid="close-tag"
                 type="button"
               >
@@ -387,16 +387,16 @@ exports[`tagInput > should renders correctly with some tags objects 1`] = `
             class="styles__sjgcm24"
           >
             <span
-              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_closable_true__d6zknp3"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 hello
               </span>
               <button
                 aria-label="Close tag"
-                class="styles__d6zknp1d styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                class="styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_xsmall__e1wcoeh styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
                 data-testid="close-tag"
                 type="button"
               >
@@ -416,16 +416,16 @@ exports[`tagInput > should renders correctly with some tags objects 1`] = `
               </button>
             </span>
             <span
-              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+              class="styles__d6zknp0 styles_sentiment_neutral__d6zknp6 styles_closable_true__d6zknp3"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 world
               </span>
               <button
                 aria-label="Close tag"
-                class="styles__d6zknp1d styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                class="styles__e1wcoe0 styles_disabled_false__e1wcoe1 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_xsmall__e1wcoeh styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
                 data-testid="close-tag"
                 type="button"
               >

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -16,41 +16,41 @@ exports[`tagList > hide items after maxLength 1`] = `
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
         </span>
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
         </span>
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             provider
           </span>
         </span>
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             database
           </span>
@@ -64,41 +64,41 @@ exports[`tagList > hide items after maxLength 1`] = `
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="provider"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               provider
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="database"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               database
             </span>
@@ -140,11 +140,11 @@ exports[`tagList > renders correctly 1`] = `
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -158,11 +158,11 @@ exports[`tagList > renders correctly 1`] = `
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -204,51 +204,51 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             very
           </span>
         </span>
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
         </span>
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
         </span>
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
         </span>
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             item
           </span>
@@ -262,51 +262,51 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="very"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               very
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="item"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               item
             </span>
@@ -355,11 +355,11 @@ exports[`tagList > renders correctly and add ellipsis to the first tag as it too
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway is the best cloud provider ever invented"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway is the best cloud provider ever invented
             </span>
@@ -408,21 +408,21 @@ exports[`tagList > renders correctly and ignore custom threshold as it does not 
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -464,11 +464,11 @@ exports[`tagList > renders correctly when maxLength is smaller than first tag 1`
         style="--_1f9zr5y0: 0px;"
       >
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -482,11 +482,11 @@ exports[`tagList > renders correctly when maxLength is smaller than first tag 1`
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -520,12 +520,12 @@ exports[`tagList > renders correctly with copiable 1`] = `
           tabindex="0"
         >
           <button
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
             data-testid=""
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -538,12 +538,12 @@ exports[`tagList > renders correctly with copiable 1`] = `
           tabindex="0"
         >
           <button
-            class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+            class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
             data-testid=""
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -564,12 +564,12 @@ exports[`tagList > renders correctly with copiable 1`] = `
             tabindex="0"
           >
             <button
-              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
               data-testid="scaleway"
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 scaleway
               </span>
@@ -582,12 +582,12 @@ exports[`tagList > renders correctly with copiable 1`] = `
             tabindex="0"
           >
             <button
-              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
               data-testid="cloud"
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 cloud
               </span>
@@ -616,21 +616,21 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
         style="--_1f9zr5y0: 0px;"
       >
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
         </span>
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -644,21 +644,21 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -686,21 +686,21 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
         </span>
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -714,21 +714,21 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -770,11 +770,11 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -788,11 +788,11 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -840,12 +840,12 @@ exports[`tagList > renders correctly with icons 1`] = `
           tabindex="0"
         >
           <button
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
             data-testid=""
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
@@ -858,12 +858,12 @@ exports[`tagList > renders correctly with icons 1`] = `
           tabindex="0"
         >
           <button
-            class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+            class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
             data-testid=""
             type="button"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -884,12 +884,12 @@ exports[`tagList > renders correctly with icons 1`] = `
             tabindex="0"
           >
             <button
-              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
               data-testid="scaleway"
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 scaleway
               </span>
@@ -902,12 +902,12 @@ exports[`tagList > renders correctly with icons 1`] = `
             tabindex="0"
           >
             <button
-              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp5 styles_undefined_compound_2__d6zknpf"
+              class="styles__1f9zr5y5 styles__d6zknp0 styles_copiable_true__d6zknp1 styles_sentiment_neutral__d6zknp6 styles_undefined_compound_2__d6zknpg"
               data-testid="cloud"
               type="button"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 cloud
               </span>
@@ -936,21 +936,21 @@ exports[`tagList > renders correctly with multiline 1`] = `
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
         </span>
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             cloud
           </span>
@@ -964,21 +964,21 @@ exports[`tagList > renders correctly with multiline 1`] = `
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>
           </span>
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="cloud"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               cloud
             </span>
@@ -1048,11 +1048,11 @@ exports[`tagList > renders correctly with placement 1`] = `
         style="--_1f9zr5y0: 50px;"
       >
         <span
-          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+          class="ellipsed styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
           data-testid=""
         >
           <span
-            class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+            class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
           >
             scaleway
           </span>
@@ -1066,11 +1066,11 @@ exports[`tagList > renders correctly with placement 1`] = `
           data-testid="taglist-measure-container"
         >
           <span
-            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+            class="styles__1f9zr5y5 styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             data-testid="scaleway"
           >
             <span
-              class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+              class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
             >
               scaleway
             </span>

--- a/packages/ui/src/compositions/Conversation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/Conversation/__tests__/__snapshots__/index.test.tsx.snap
@@ -28,10 +28,10 @@ exports[`conversation > should work with Default 1`] = `
               Hello
             </div>
             <span
-              class="styles__18j62h6c styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+              class="styles__18j62h6c styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Hello
               </span>
@@ -61,10 +61,10 @@ exports[`conversation > should work with Default 1`] = `
               Hello
             </div>
             <span
-              class="styles__18j62h6c styles__d6zknp0 styles_sentiment_neutral__d6zknp5"
+              class="styles__18j62h6c styles__d6zknp0 styles_sentiment_neutral__d6zknp6"
             >
               <span
-                class="styles__d6zknp1c style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
+                class="styles__d6zknp1d style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Hello
               </span>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

Fix the close button on the tags (which also fixes the multiselect)

#### The following changes were made:

- update the size of the close button
- update the gap and right padding accordingly
- set the right sentiment on the close button (it was always neutral)

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="807" height="84" alt="image" src="https://github.com/user-attachments/assets/4aadc945-d0fa-48de-a4d2-ff907cacfbaf" /> | <img width="688" height="84" alt="image" src="https://github.com/user-attachments/assets/a8545590-3fec-4dc6-aef0-29ce1a67490d" /> |
| url  | <img width="498" height="114" alt="image" src="https://github.com/user-attachments/assets/55a2fc70-868d-4e90-a535-93838e6e9274" /> | <img width="498" height="114" alt="image" src="https://github.com/user-attachments/assets/436d624b-3320-4526-8a97-59200766f938" /> |
