### PR TITLE
chore(storybook): rename a11y property to a11y-status 

### DIFF
--- a/.oxlint/rules/storybook-a11y-partial.cjs
+++ b/.oxlint/rules/storybook-a11y-partial.cjs
@@ -30,7 +30,7 @@ const STORYBOOK_A11Y_PARTIAL = {
       Property(node) {
         if (
           node.key.type === 'Identifier' &&
-          node.key.name === 'a11y' &&
+          node.key.name === 'a11yStatus' &&
           node.value.type === 'Literal' &&
           node.value.value === 'partial'
         ) {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -44,6 +44,12 @@ scan({
 })
 
 const parameters: Preview['parameters'] = {
+  a11y: {
+    context: 'body',
+    config: {},
+    options: {},
+    test: '',
+  },
   backgrounds: {
     disable: true,
     grid: {
@@ -185,4 +191,10 @@ export default definePreview({
   parameters,
   addons: [addonDocs(), addonLinks(), addonA11y(), addonTheme()],
   tags: ['autodocs'],
+  initialGlobals: {
+    a11y: {
+      // Optional flag to prevent the automatic check
+      manual: false,
+    },
+  },
 })

--- a/packages/ui/src/components/ActionBar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/index.stories.tsx
@@ -4,8 +4,12 @@ import { ActionBar } from '..'
 export default {
   component: ActionBar,
   title: 'UI/Overlay/ActionBar',
+  tags: [],
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
+    a11y: {
+      test: 'error',
+    },
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,
@@ -14,7 +18,7 @@ export default {
       'specific-patterns': false,
     },
   },
-} as Meta
+} satisfies Meta<typeof ActionBar>
 
 export { Playground } from './Playground.stories'
 export { Ranks } from './Ranks.stories'

--- a/packages/ui/src/components/Alert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Alert,
   title: 'UI/Feedback/Alert',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Avatar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Avatar,
   title: 'UI/Other/Avatar',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Badge/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Badge/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Badge,
   title: 'UI/Badges/Badge',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Banner/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Banner,
   title: 'UI/Other/Banner',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/BarChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: BarChart,
   title: 'UI/Data Display/Chart/BarChart',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/BarStack/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/BarStack/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: BarStack,
   title: 'UI/Data Display/BarStack',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Breadcrumbs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/index.stories.tsx
@@ -7,7 +7,7 @@ export default {
   subcomponents: { 'Breadcrumbs.Item': Item },
   title: 'UI/Navigation/Breadcrumbs',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Bullet/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Bullet,
   title: 'UI/Badges/Bullet',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Button/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/index.stories.tsx
@@ -5,7 +5,10 @@ export default {
   component: Button,
   title: 'UI/Action/Button',
   parameters: {
-    a11y: 'partial',
+    a11y: {
+      statut: 'partial',
+      test: 'error',
+    },
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Card/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Card,
   title: 'UI/Layout/Card',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Carousel/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Carousel/__stories__/index.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'UI/Data Display/Carousel',
   subcomponents: { 'Carousel.Item': Carousel.Item },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Checkbox/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Checkbox/__stories__/index.stories.tsx
@@ -12,7 +12,7 @@ export default {
   ],
   title: 'UI/Data Entry/Checkbox',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/CheckboxGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/index.stories.tsx
@@ -17,7 +17,7 @@ export default {
     value: ['value-1'],
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Chip/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Chip/__stories__/index.stories.tsx
@@ -15,7 +15,7 @@ export default {
   ],
   title: 'UI/Badges/Chip',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/CopyButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/CopyButton/__stories__/index.stories.tsx
@@ -13,7 +13,7 @@ export default {
   ],
   title: 'UI/Action/CopyButton',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/DateInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: DateInput,
   title: 'UI/Data Entry/DateInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Dialog/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Dialog/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Dialog,
   title: 'UI/Overlay/Dialog',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Drawer/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Drawer/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Drawer,
   title: 'UI/Overlay/Drawer',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/EmptyState/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/EmptyState/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: EmptyState,
   title: 'UI/Data Display/EmptyState',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Expandable/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Expandable/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Expandable,
   title: 'UI/Action/Expandable',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/ExpandableCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ExpandableCard/__stories__/index.stories.tsx
@@ -8,7 +8,7 @@ export default {
     'ExpandableCard.Title': ExpandableCard.Title,
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/FileInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/FileInput/__stories__/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
   title: 'UI/Data Entry/FileInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'UI/Feedback/GlobalAlert',
   subcomponents: { 'GlobalAlert.Link': GlobalAlert.Link },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/InfiniteScroll/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/InfiniteScroll/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: InfiniteScroll,
   title: 'UI/Data Display/InfiniteScroll',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Key/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Key/__stories__/index.stories.tsx
@@ -13,7 +13,7 @@ export default {
   ],
   title: 'UI/Other/Key',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Label/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Label/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Label,
   title: 'UI/Typography/Label',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Link/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Link,
   title: 'UI/Action/Link',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/List/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
     'List.Cell': List.Cell,
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Loader/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/index.stories.tsx
@@ -13,7 +13,7 @@ export default {
     ),
   ],
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Menu/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
     ),
   ],
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Meter/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Meter/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Meter,
   title: 'UI/Feedback/Meter',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Modal/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Modal,
   title: 'UI/Overlay/Modal',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Notice/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Notice/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Notice,
   title: 'UI/Feedback/Notice',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Notification/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Notification/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: NotificationContainer,
   title: 'UI/Feedback/Notification',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
@@ -16,7 +16,7 @@ export default {
   ],
   title: 'UI/Data Entry/NumberInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/PasswordCheck/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PasswordCheck/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: PasswordCheck,
   title: 'UI/Feedback/PasswordCheck',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Popover/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Popover/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Popover,
   title: 'UI/Overlay/Popover',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/ProgressBar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ProgressBar/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: ProgressBar,
   title: 'UI/Feedback/ProgressBar',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Radio/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Radio,
   title: 'UI/Data Entry/Radio',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/RadioGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: RadioGroup,
   title: 'UI/Data Entry/RadioGroup',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/SearchInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SearchInput/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: SearchInput,
   title: 'UI/Data Entry/SearchInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/SelectInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/index.stories.tsx
@@ -13,7 +13,7 @@ export default {
 
   title: 'UI/Data Entry/SelectInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/SelectableCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: SelectableCard,
   title: 'UI/Data Entry/SelectableCard',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/SelectableCardGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: SelectableCardGroup,
   title: 'UI/Data Entry/SelectableCardGroup',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/SelectableCardOptionGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectableCardOptionGroup/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: SelectableCardOptionGroup,
   title: 'UI/Data Entry/SelectableCardOptionGroup',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Separator/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Separator,
   title: 'UI/Layout/Separator',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Skeleton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Skeleton/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Skeleton,
   title: 'UI/Feedback/Skeleton',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Slider/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Slider/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Slider,
   title: 'UI/Data Entry/Slider',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Snippet/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/index.stories.tsx
@@ -13,7 +13,7 @@ export default {
   ],
   title: 'UI/Data Display/Snippet',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Status/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Status/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Status,
   title: 'UI/Feedback/Status',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Stepper/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Stepper/__stories__/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
   },
   title: 'UI/Navigation/Stepper',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/SwitchButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SwitchButton/__stories__/index.stories.tsx
@@ -8,7 +8,7 @@ export default {
   },
   title: 'UI/Action/SwitchButton',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Table/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/index.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'UI/Data Display/Table',
   subcomponents: { 'Table.Row': Table.Row, 'Table.Cell': Table.Cell },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Tabs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tabs/__stories__/index.stories.tsx
@@ -6,7 +6,7 @@ export default {
   subcomponents: { 'Tabs.Tab': Tabs.Tab },
   title: 'UI/Navigation/Tabs',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Tag/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tag/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Tag,
   title: 'UI/Badges/Tag',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/TagInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TagInput/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: TagInput,
   title: 'UI/Data Entry/TagInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/TagList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/index.stories.tsx
@@ -12,7 +12,7 @@ export default {
   ],
   title: 'UI/Data Display/TagList',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Text/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Text/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Text,
   title: 'UI/Typography/Text',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/TextArea/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextArea/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: TextArea,
   title: 'UI/Data Entry/TextArea',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: TextInput,
   title: 'UI/Data Entry/TextInput',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'UI/Data Entry/TimeInput',
   decorators: [Story => <Story />],
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Toggle/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Toggle,
   title: 'UI/Data Entry/Toggle',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/ToggleGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/index.stories.tsx
@@ -17,7 +17,7 @@ export default {
     value: ['weekly-save'],
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/Tooltip/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tooltip/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Tooltip,
   title: 'UI/Overlay/Tooltip',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/UnitInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/UnitInput/__stories__/index.stories.tsx
@@ -12,7 +12,7 @@ export default {
     ),
   ],
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/components/VerificationCode/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: VerificationCode,
   title: 'UI/Data Entry/VerificationCode',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/CodeEditor/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/CodeEditor/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: CodeEditor,
   title: 'Compositions/CodeEditor',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/ContentCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/ContentCard/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: ContentCard,
   title: 'Compositions/ContentCard',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/ContentCardGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/ContentCardGroup/__stories__/index.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Compositions/ContentCardGroup',
   subcomponents: { 'ContentCardGroup.Card': ContentCardGroup.Card },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/Conversation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Conversation/__stories__/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
   },
   title: 'Compositions/Conversation',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/CustomerSatisfaction/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/CustomerSatisfaction/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: CustomerSatisfaction,
   title: 'Compositions/CustomerSatisfaction',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/EstimateCost/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/EstimateCost/__stories__/index.stories.tsx
@@ -21,7 +21,7 @@ export default {
   },
   title: 'Compositions/EstimateCost',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/FAQ/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/FAQ/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: FAQ,
   title: 'Compositions/FAQ',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/InfoTable/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/InfoTable/__stories__/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
     'InfoTable.CellWithCopyButton': InfoTable.CellWithCopyButton,
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
@@ -13,7 +13,7 @@ export default {
     'Navigation.ShowHide': Navigation.ShowHide,
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/OfferList/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OfferList/__stories__/index.stories.tsx
@@ -10,7 +10,7 @@ export default {
     'OfferList.Cell': OfferList.Cell,
   },
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/OptionSelector/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OptionSelector/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: OptionSelector,
   title: 'Compositions/OptionSelector',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/OrderSummary/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OrderSummary/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: OrderSummary,
   title: 'Compositions/OrderSummary',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/Plans/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Plans/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: Plans,
   title: 'Compositions/Plans',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/packages/ui/src/compositions/SteppedListCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/SteppedListCard/__stories__/index.stories.tsx
@@ -5,7 +5,7 @@ export default {
   component: SteppedListCard,
   title: 'Compositions/SteppedListCard',
   parameters: {
-    a11y: 'partial',
+    a11yStatus: 'partial',
     audit: {
       'keyboard-focus': false,
       'contrast-visuals': false,

--- a/utils/stories/src/AccessibilityAudit/constants.tsx
+++ b/utils/stories/src/AccessibilityAudit/constants.tsx
@@ -322,7 +322,7 @@ export type AuditCategories = {
 export type ComponentStoryParameters = {
   deprecated?: boolean
   experimental?: boolean
-  a11y?: boolean | A11yLevel
+  a11yStatus?: boolean | A11yLevel
   audit?: ComponentAuditStatus
 }
 
@@ -337,12 +337,12 @@ export const getComponentAuditCategories = (parameters: ComponentStoryParameters
   }))
 }
 
-export const findA11yStatus = (parameters: { a11y?: boolean | A11yLevel }) => {
-  if (!parameters?.a11y) {
+export const findA11yStatus = (parameters: { a11yStatus?: boolean | A11yLevel }) => {
+  if (!parameters?.a11yStatus) {
     return null
   }
 
-  const a11yLevel = typeof parameters.a11y === 'string' ? parameters.a11y : 'compliant'
+  const a11yLevel = typeof parameters.a11yStatus === 'string' ? parameters.a11yStatus : 'compliant'
 
   return A11Y_LEVELS[a11yLevel]
 }

--- a/utils/stories/src/ComponentState/ComponentState.tsx
+++ b/utils/stories/src/ComponentState/ComponentState.tsx
@@ -9,7 +9,7 @@ const ComponentState = () => {
     | PromiseSettledResult<{
         default: {
           title: string
-          parameters: { deprecated: boolean; a11y: boolean }
+          parameters: { deprecated: boolean }
         }
       }>[]
     | null


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

Migrate status a11y to a11YStatus to avoid override a11y addon
