### PR TITLE
feat: add a header to the legend of the Pie chart

### DIFF
--- a/.changeset/loose-trees-stare.md
+++ b/.changeset/loose-trees-stare.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+Pie Chart: add a header to the legend to display the unit

--- a/packages/ui/src/components/PieChart/Legends.tsx
+++ b/packages/ui/src/components/PieChart/Legends.tsx
@@ -1,58 +1,70 @@
 'use client'
 
 import { assignInlineVars } from '@vanilla-extract/dynamic'
+import { Text } from '../Text'
 import { Tooltip } from '../Tooltip'
-import { Tooltip as TooltipContainer } from './Tooltip'
+import { TooltipContent } from './Tooltip'
 import type { Data } from './types'
 import { colorBullet, pieChartStyle } from './styles.css'
 
 type LegendsProps = {
   data?: Data[]
+  legendHeader?: string
   focused?: string
   onFocusChange: (index?: string) => void
   colors: string[]
 }
 
-export const Legends = ({ focused, data, onFocusChange, colors }: LegendsProps) => (
-  <ul className={pieChartStyle.list}>
-    {data?.map((item, index) => {
-      const isSegmentFocused = focused !== undefined && item.id === focused
+export const Legends = ({ focused, data, legendHeader, onFocusChange, colors }: LegendsProps) => (
+  <div className={pieChartStyle.legendContainer}>
+    {legendHeader ? (
+      <Text
+        as="span"
+        variant="captionStrong"
+        sentiment="neutral"
+        prominence="weak"
+        className={pieChartStyle.legendHeader}
+      >
+        {legendHeader}
+      </Text>
+    ) : null}
+    <ul className={pieChartStyle.list}>
+      {data?.map((item, index) => {
+        const isSegmentFocused = focused !== undefined && item.id === focused
 
-      const id = `chart-legend-${item.id}`
+        const id = `chart-legend-${item.id}`
 
-      return (
-        <Tooltip id={id} key={item.id} text={<TooltipContainer data={item} />} visible={isSegmentFocused}>
-          <li className={pieChartStyle.listItem({ isFocused: isSegmentFocused })}>
-            <div
-              className={pieChartStyle.toggleBox}
-              data-testid={id}
+        return (
+          <Tooltip key={item.id} text={<TooltipContent data={item} />} visible={isSegmentFocused}>
+            <li
+              className={pieChartStyle.listItem({
+                isFocused: isSegmentFocused,
+              })}
               onBlur={() => onFocusChange()}
               onFocus={() => onFocusChange(item.id)}
               onMouseOut={() => onFocusChange()}
               onMouseOver={() => onFocusChange(item.id)}
-            />
-            <div
-              className={pieChartStyle.bullet({ isFocused: isSegmentFocused })}
-              color={colors[index]}
-              id={`chart-legend-${item.id}`}
-              style={assignInlineVars({
-                [colorBullet]: colors[index],
-              })}
-            />
-            <div className={pieChartStyle.label}>
-              <span className={pieChartStyle.text({ isFocused: isSegmentFocused })}>{item.name}</span>
-              <span className={pieChartStyle.line}>
-                <span
-                  className={pieChartStyle.progressiveLine({
-                    isFocused: isSegmentFocused,
-                  })}
-                />
-              </span>
-            </div>
-            <div className={pieChartStyle.value[isSegmentFocused ? 'isFocused' : 'default']}>{item.value}</div>
-          </li>
-        </Tooltip>
-      )
-    })}
-  </ul>
+              data-testid={id}
+            >
+              <span
+                className={pieChartStyle.bullet}
+                color={colors[index]}
+                id={id}
+                style={assignInlineVars({
+                  [colorBullet]: colors[index],
+                })}
+              />
+              <Text as="span" variant={isSegmentFocused ? 'bodySmallStrong' : 'bodySmall'} oneLine>
+                {item.name}
+              </Text>
+              <span className={pieChartStyle.line} />
+              <Text as="span" variant="bodySmallStrong">
+                {item.value}
+              </Text>
+            </li>
+          </Tooltip>
+        )
+      })}
+    </ul>
+  </div>
 )

--- a/packages/ui/src/components/PieChart/Tooltip.tsx
+++ b/packages/ui/src/components/PieChart/Tooltip.tsx
@@ -16,27 +16,25 @@ type TooltipProps = {
   }
 }
 
-export const Tooltip = ({ data }: TooltipProps) => (
-  <div role="tooltip" tabIndex={-1}>
-    <ul className={pieChartStyle.listTooltip}>
-      <li className={pieChartStyle.itemTooltip}>
-        <Text as="p" prominence="stronger" variant="body">
-          {data.name}
+export const TooltipContent = ({ data }: TooltipProps) => (
+  <ul className={pieChartStyle.listTooltip}>
+    <li className={pieChartStyle.itemTooltip}>
+      <Text as="p" prominence="stronger" variant="body">
+        {data.name}
+      </Text>
+      <Text as="p" prominence="stronger" variant="body">
+        {data.value}
+      </Text>
+    </li>
+    {data.details?.map(detail => (
+      <li className={pieChartStyle.itemTooltip} key={detail.name}>
+        <Text as="p" prominence="stronger" variant="bodySmall">
+          {detail.name}
         </Text>
-        <Text as="p" prominence="stronger" variant="body">
-          {data.value}
+        <Text as="p" prominence="stronger" variant="bodySmall">
+          {detail.value}
         </Text>
       </li>
-      {data.details?.map(detail => (
-        <li className={pieChartStyle.itemTooltip} key={detail.name}>
-          <Text as="p" prominence="stronger" variant="bodySmall">
-            {detail.name}
-          </Text>
-          <Text as="p" prominence="stronger" variant="bodySmall">
-            {detail.value}
-          </Text>
-        </li>
-      ))}
-    </ul>
-  </div>
+    ))}
+  </ul>
 )

--- a/packages/ui/src/components/PieChart/__stories__/Legends.stories.tsx
+++ b/packages/ui/src/components/PieChart/__stories__/Legends.stories.tsx
@@ -6,5 +6,6 @@ export const Legends = Template.bind({})
 Legends.args = {
   content: '€20',
   data: dataWithLegends,
+  legendHeader: 'Euro (€)',
   withLegend: true,
 }

--- a/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/PieChart/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`pieChart > renders correctly when legend is focused 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -80,94 +80,76 @@ exports[`pieChart > renders correctly when legend is focused 1`] = `
           </svg>
         </div>
       </div>
-      <ul
-        class="styles__6tpqrj6"
+      <div
+        class="styles__6tpqrj9"
       >
-        <div
-          aria-controls="chart-legend-compute"
-          aria-describedby="chart-legend-compute"
-          class="styles__w40vpo9"
-          tabindex="0"
+        <ul
+          class="styles__6tpqrj6"
         >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_true__6tpqrj9"
+          <div
+            aria-controls="_r_1l_"
+            aria-describedby="_r_1l_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7 styles_isFocused_true__6tpqrj8"
               data-testid="chart-legend-compute"
-            />
-            <div
-              class="styles__6tpqrja styles_isFocused_true__6tpqrjb"
-              color="#5e47be"
-              id="chart-legend-compute"
-              style="--_6tpqrj1: #5e47be;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_true__6tpqrjh"
+                class="styles__6tpqrjb"
+                color="#5e47be"
+                id="chart-legend-compute"
+                style="--_6tpqrj1: #5e47be;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Compute
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_true__6tpqrjm"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_isFocused__6tpqrje"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-gpu"
-          aria-describedby="chart-legend-gpu"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_1o_"
+            aria-describedby="_r_1o_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-gpu"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#0083e6"
-              id="chart-legend-gpu"
-              style="--_6tpqrj1: #0083e6;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#0083e6"
+                id="chart-legend-gpu"
+                style="--_6tpqrj1: #0083e6;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 GPU Instances
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-      </ul>
+            </li>
+          </div>
+        </ul>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -179,11 +161,11 @@ exports[`pieChart > renders correctly when legend is hovered 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -253,94 +235,76 @@ exports[`pieChart > renders correctly when legend is hovered 1`] = `
           </svg>
         </div>
       </div>
-      <ul
-        class="styles__6tpqrj6"
+      <div
+        class="styles__6tpqrj9"
       >
-        <div
-          aria-controls="chart-legend-compute"
-          aria-describedby="chart-legend-compute"
-          class="styles__w40vpo9"
-          tabindex="0"
+        <ul
+          class="styles__6tpqrj6"
         >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_true__6tpqrj9"
+          <div
+            aria-controls="_r_1f_"
+            aria-describedby="_r_1f_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7 styles_isFocused_true__6tpqrj8"
               data-testid="chart-legend-compute"
-            />
-            <div
-              class="styles__6tpqrja styles_isFocused_true__6tpqrjb"
-              color="#5e47be"
-              id="chart-legend-compute"
-              style="--_6tpqrj1: #5e47be;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_true__6tpqrjh"
+                class="styles__6tpqrjb"
+                color="#5e47be"
+                id="chart-legend-compute"
+                style="--_6tpqrj1: #5e47be;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Compute
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_true__6tpqrjm"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_isFocused__6tpqrje"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-gpu"
-          aria-describedby="chart-legend-gpu"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_1i_"
+            aria-describedby="_r_1i_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-gpu"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#0083e6"
-              id="chart-legend-gpu"
-              style="--_6tpqrj1: #0083e6;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#0083e6"
+                id="chart-legend-gpu"
+                style="--_6tpqrj1: #0083e6;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 GPU Instances
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-      </ul>
+            </li>
+          </div>
+        </ul>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -352,11 +316,11 @@ exports[`pieChart > renders correctly with data 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -437,11 +401,11 @@ exports[`pieChart > renders correctly with data and content 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -527,11 +491,11 @@ exports[`pieChart > renders correctly with detailed legend 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -601,94 +565,76 @@ exports[`pieChart > renders correctly with detailed legend 1`] = `
           </svg>
         </div>
       </div>
-      <ul
-        class="styles__6tpqrj6"
+      <div
+        class="styles__6tpqrj9"
       >
-        <div
-          aria-controls="chart-legend-compute"
-          aria-describedby="chart-legend-compute"
-          class="styles__w40vpo9"
-          tabindex="0"
+        <ul
+          class="styles__6tpqrj6"
         >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+          <div
+            aria-controls="_r_u_"
+            aria-describedby="_r_u_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-compute"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#5e47be"
-              id="chart-legend-compute"
-              style="--_6tpqrj1: #5e47be;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#5e47be"
+                id="chart-legend-compute"
+                style="--_6tpqrj1: #5e47be;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Compute
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-gpu"
-          aria-describedby="chart-legend-gpu"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_11_"
+            aria-describedby="_r_11_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-gpu"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#0083e6"
-              id="chart-legend-gpu"
-              style="--_6tpqrj1: #0083e6;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#0083e6"
+                id="chart-legend-gpu"
+                style="--_6tpqrj1: #0083e6;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 GPU Instances
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-      </ul>
+            </li>
+          </div>
+        </ul>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -700,11 +646,11 @@ exports[`pieChart > renders correctly with detailed legend and discount 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -766,52 +712,45 @@ exports[`pieChart > renders correctly with detailed legend and discount 1`] = `
           </svg>
         </div>
       </div>
-      <ul
-        class="styles__6tpqrj6"
+      <div
+        class="styles__6tpqrj9"
       >
-        <div
-          aria-controls="chart-legend-discount"
-          aria-describedby="chart-legend-discount"
-          class="styles__w40vpo9"
-          tabindex="0"
+        <ul
+          class="styles__6tpqrj6"
         >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+          <div
+            aria-controls="_r_1b_"
+            aria-describedby="_r_1b_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-discount"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#5e47be"
-              id="chart-legend-discount"
-              style="--_6tpqrj1: #5e47be;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#5e47be"
+                id="chart-legend-discount"
+                style="--_6tpqrj1: #5e47be;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 GPU Instances
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-      </ul>
+            </li>
+          </div>
+        </ul>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -823,11 +762,11 @@ exports[`pieChart > renders correctly with empty legend placeholder 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -889,15 +828,11 @@ exports[`pieChart > renders correctly with empty legend placeholder 1`] = `
           </svg>
         </div>
       </div>
-      <div
-        class="styles__6tpqrj4"
+      <p
+        class="styles__6tpqrj4 style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
       >
-        <p
-          class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
-        >
-          I am a legend
-        </p>
-      </div>
+        I am a legend
+      </p>
     </div>
   </div>
 </DocumentFragment>
@@ -909,11 +844,11 @@ exports[`pieChart > renders correctly with legend 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"
@@ -1047,430 +982,324 @@ exports[`pieChart > renders correctly with legend 1`] = `
           </svg>
         </div>
       </div>
-      <ul
-        class="styles__6tpqrj6"
+      <div
+        class="styles__6tpqrj9"
       >
-        <div
-          aria-controls="chart-legend-compute"
-          aria-describedby="chart-legend-compute"
-          class="styles__w40vpo9"
-          tabindex="0"
+        <ul
+          class="styles__6tpqrj6"
         >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+          <div
+            aria-controls="_r_0_"
+            aria-describedby="_r_0_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-compute"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#5e47be"
-              id="chart-legend-compute"
-              style="--_6tpqrj1: #5e47be;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#5e47be"
+                id="chart-legend-compute"
+                style="--_6tpqrj1: #5e47be;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Compute
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-gpu"
-          aria-describedby="chart-legend-gpu"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_3_"
+            aria-describedby="_r_3_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-gpu"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#0083e6"
-              id="chart-legend-gpu"
-              style="--_6tpqrj1: #0083e6;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#0083e6"
+                id="chart-legend-gpu"
+                style="--_6tpqrj1: #0083e6;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 GPU Instances
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-functions"
-          aria-describedby="chart-legend-functions"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_6_"
+            aria-describedby="_r_6_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-functions"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#3ebd8f"
-              id="chart-legend-functions"
-              style="--_6tpqrj1: #3ebd8f;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#3ebd8f"
+                id="chart-legend-functions"
+                style="--_6tpqrj1: #3ebd8f;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Serverless Functions
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-containers"
-          aria-describedby="chart-legend-containers"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_9_"
+            aria-describedby="_r_9_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-containers"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#ac2740"
-              id="chart-legend-containers"
-              style="--_6tpqrj1: #ac2740;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#ac2740"
+                id="chart-legend-containers"
+                style="--_6tpqrj1: #ac2740;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Serverless Containers
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-s3"
-          aria-describedby="chart-legend-s3"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_c_"
+            aria-describedby="_r_c_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-s3"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#9a85ec"
-              id="chart-legend-s3"
-              style="--_6tpqrj1: #9a85ec;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#9a85ec"
+                id="chart-legend-s3"
+                style="--_6tpqrj1: #9a85ec;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Object Storage
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-dns"
-          aria-describedby="chart-legend-dns"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_f_"
+            aria-describedby="_r_f_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-dns"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#ff602e"
-              id="chart-legend-dns"
-              style="--_6tpqrj1: #ff602e;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#ff602e"
+                id="chart-legend-dns"
+                style="--_6tpqrj1: #ff602e;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Domain zones
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-appleSilicon"
-          aria-describedby="chart-legend-appleSilicon"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_i_"
+            aria-describedby="_r_i_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-appleSilicon"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#483800"
-              id="chart-legend-appleSilicon"
-              style="--_6tpqrj1: #483800;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#483800"
+                id="chart-legend-appleSilicon"
+                style="--_6tpqrj1: #483800;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Apple Silicon
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-baremetal"
-          aria-describedby="chart-legend-baremetal"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_l_"
+            aria-describedby="_r_l_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-baremetal"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#02a5ad"
-              id="chart-legend-baremetal"
-              style="--_6tpqrj1: #02a5ad;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#02a5ad"
+                id="chart-legend-baremetal"
+                style="--_6tpqrj1: #02a5ad;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Baremetal
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-database"
-          aria-describedby="chart-legend-database"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_o_"
+            aria-describedby="_r_o_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-database"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#ffa488"
-              id="chart-legend-database"
-              style="--_6tpqrj1: #ffa488;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#ffa488"
+                id="chart-legend-database"
+                style="--_6tpqrj1: #ffa488;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Database
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-        <div
-          aria-controls="chart-legend-lb"
-          aria-describedby="chart-legend-lb"
-          class="styles__w40vpo9"
-          tabindex="0"
-        >
-          <li
-            class="styles__6tpqrj7 styles_isFocused_false__6tpqrj8"
+            </li>
+          </div>
+          <div
+            aria-controls="_r_r_"
+            aria-describedby="_r_r_"
+            class="styles__w40vpo9"
+            tabindex="0"
           >
-            <div
-              class="styles__6tpqrji"
+            <li
+              class="styles__6tpqrj7"
               data-testid="chart-legend-lb"
-            />
-            <div
-              class="styles__6tpqrja"
-              color="#96edf2"
-              id="chart-legend-lb"
-              style="--_6tpqrj1: #96edf2;"
-            />
-            <div
-              class="styles__6tpqrjc"
             >
               <span
-                class="styles__6tpqrjf styles_isFocused_false__6tpqrjg"
+                class="styles__6tpqrjb"
+                color="#96edf2"
+                id="chart-legend-lb"
+                style="--_6tpqrj1: #96edf2;"
+              />
+              <span
+                class="style__m4c9ow0 style_oneLine_true__m4c9ow3 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style__m4c9ow3e"
               >
                 Load Balancer
               </span>
               <span
-                class="styles__6tpqrjj"
+                class="styles__6tpqrje"
+              />
+              <span
+                class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
               >
-                <span
-                  class="styles__6tpqrjk styles_isFocused_false__6tpqrjl"
-                />
+                20
               </span>
-            </div>
-            <div
-              class="styles_default__6tpqrjd"
-            >
-              20
-            </div>
-          </li>
-        </div>
-      </ul>
+            </li>
+          </div>
+        </ul>
+      </div>
     </div>
   </div>
 </DocumentFragment>
@@ -1482,11 +1311,11 @@ exports[`pieChart > renders correctly with no props 1`] = `
     data-testid="testing"
   >
     <div
-      class="styles__6tpqrj3"
+      class="styles__6tpqrj2"
       style="--_6tpqrj0: 206px;"
     >
       <div
-        style="position: relative;"
+        class="styles__6tpqrj3"
       >
         <div
           style="position: relative;"

--- a/packages/ui/src/components/PieChart/__tests__/index.test.tsx
+++ b/packages/ui/src/components/PieChart/__tests__/index.test.tsx
@@ -46,6 +46,11 @@ describe('pieChart', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  it('displays a header above the legend to display the unit', () => {
+    renderWithTheme(<PieChart data={dataWithLegendsAndDetails} legendHeader="Euro (€)" withLegend />)
+    expect(screen.getByText('Euro (€)')).toBeVisible()
+  })
+
   it('renders correctly with detailed legend and discount', () => {
     const { asFragment } = renderWithTheme(<PieChart data={dataWithLegendsDetailsAndDiscount} withLegend />)
     expect(asFragment()).toMatchSnapshot()

--- a/packages/ui/src/components/PieChart/index.tsx
+++ b/packages/ui/src/components/PieChart/index.tsx
@@ -20,6 +20,7 @@ type PieChartProps = {
   height?: number
   width?: number
   emptyLegend?: string
+  legendHeader?: string
   content?: ReactNode
   withLegend?: boolean
   margin?: Box
@@ -39,6 +40,7 @@ export const PieChart = ({
   width = 206,
   data = undefined,
   emptyLegend,
+  legendHeader,
   content,
   withLegend = false,
   margin = DEFAULT_MARGIN,
@@ -50,30 +52,8 @@ export const PieChart = ({
   const emptyTooltip = useCallback(() => <span />, [])
   const isEmpty = !data || data.length === 0
 
-  const EmptyLegendDisplayed = useCallback(
-    () =>
-      emptyLegend ? (
-        <div className={pieChartStyle.emptyLegend}>
-          <Text as="p" variant="body">
-            {emptyLegend}
-          </Text>
-        </div>
-      ) : null,
-    [emptyLegend],
-  )
-
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const localColors = getLegendColor(theme as typeof UVTheme)
-
-  const LegendDisplayer = useCallback(
-    () =>
-      isEmpty ? (
-        <EmptyLegendDisplayed />
-      ) : (
-        <Legends colors={localColors} data={data} focused={currentFocusIndex} onFocusChange={setCurrentFocusIndex} />
-      ),
-    [isEmpty, currentFocusIndex, data, EmptyLegendDisplayed, localColors],
-  )
 
   return (
     <div
@@ -85,7 +65,7 @@ export const PieChart = ({
         ...style,
       }}
     >
-      <div style={{ position: 'relative' }}>
+      <div className={pieChartStyle.pieContainer}>
         <Pie
           activeOuterRadiusOffset={isEmpty ? 0 : 4}
           colors={localColors}
@@ -133,7 +113,22 @@ export const PieChart = ({
         />
         {content ? <div className={pieChartStyle.content}>{content}</div> : null}
       </div>
-      {withLegend ? <LegendDisplayer /> : null}
+
+      {withLegend && !isEmpty ? (
+        <Legends
+          colors={localColors}
+          data={data}
+          legendHeader={legendHeader}
+          focused={currentFocusIndex}
+          onFocusChange={setCurrentFocusIndex}
+        />
+      ) : null}
+
+      {withLegend && isEmpty && emptyLegend ? (
+        <Text as="p" variant="body" className={pieChartStyle.emptyLegend}>
+          {emptyLegend}
+        </Text>
+      ) : null}
     </div>
   )
 }

--- a/packages/ui/src/components/PieChart/styles.css.ts
+++ b/packages/ui/src/components/PieChart/styles.css.ts
@@ -1,32 +1,30 @@
 import { theme } from '@ultraviolet/themes'
-import { createVar, keyframes, style, styleVariants } from '@vanilla-extract/css'
+import { createVar, globalStyle, style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
+import { flash } from '../../utils'
 
 export const heightContainerPie = createVar()
 export const colorBullet = createVar()
 
-const bulletFlashAnimation = keyframes({
-  '0%': {
-    opacity: 1,
-  },
-  '50%': {
-    opacity: 0.1,
-  },
-  '100%': {
-    opacity: 1,
-  },
+const container = style({
+  alignItems: 'start',
+  display: 'flex',
+  gap: `${85 - 12}px`, // compensate for the space inside the Pie component
+  height: heightContainerPie,
+  padding: `0 ${theme.space[1.5]}`,
 })
 
-const container = style({
-  alignItems: 'center',
+const pieContainer = style({
+  position: 'relative',
+})
+
+// patch the div container in the Pie component which has a wrong height
+globalStyle(`${pieContainer} > div:first-child`, {
   display: 'flex',
-  height: heightContainerPie,
 })
 
 const emptyLegend = style({
-  alignItems: 'center',
-  display: 'flex',
-  marginLeft: theme.space[5],
+  alignSelf: 'center',
 })
 
 const content = style({
@@ -46,45 +44,57 @@ const list = style({
   display: 'flex',
   flex: '1',
   flexDirection: 'column',
+  gap: theme.space[1],
   fontSize: theme.typography.bodySmall.fontSize,
   listStyleType: 'none',
   maxHeight: '100%',
   overflowY: 'auto',
+  margin: 0,
+  padding: 0,
 })
 
 const listItem = recipe({
   base: {
     alignItems: 'center',
     display: 'flex',
-    marginTop: theme.space[1],
+    gap: theme.space[1],
     width: '100%',
+    color: theme.colors.neutral.text,
   },
   variants: {
     isFocused: {
-      false: {
-        color: theme.colors.neutral.text,
-      },
       true: {
         color: theme.colors.primary.text,
+        fontWeight: 500,
       },
     },
   },
 })
 
-const bullet = recipe({
-  base: {
-    background: colorBullet,
-    borderRadius: theme.radii.circle,
-    display: 'inline-block',
-    height: 10,
-    margin: `0 ${theme.space[1]}`,
-    width: 10,
-  },
-  variants: {
-    isFocused: {
-      true: {
-        animation: `${bulletFlashAnimation} linear 1500ms infinite`,
-      },
+const legendContainer = style({
+  display: 'flex',
+  flex: '1',
+  flexDirection: 'column',
+  gap: theme.space[1],
+  maxHeight: '100%',
+  overflowY: 'auto',
+  padding: `${theme.space[1.5]} 0`,
+})
+
+const legendHeader = style({
+  textAlign: 'end',
+})
+
+const bullet = style({
+  background: colorBullet,
+  borderRadius: theme.radii.circle,
+  display: 'inline-block',
+  height: 10,
+  width: 10,
+  flexShrink: 0,
+  selectors: {
+    [`${listItem.classNames.variants.isFocused.true} &`]: {
+      animation: `${flash} linear 1500ms infinite`,
     },
   },
 })
@@ -95,35 +105,6 @@ const label = style({
   flex: '1',
 })
 
-const value = styleVariants({
-  default: {
-    fontWeight: 400,
-    marginLeft: theme.space[1],
-  },
-  isFocused: {
-    fontWeight: 500,
-    marginLeft: theme.space[1],
-  },
-})
-
-const text = recipe({
-  base: {
-    flex: 'none',
-    marginRight: theme.space[1],
-    maxWidth: '100%',
-  },
-  variants: {
-    isFocused: {
-      false: {
-        fontWeight: 400,
-      },
-      true: {
-        fontWeight: 500,
-      },
-    },
-  },
-})
-
 const toggleBox = style({
   height: 21,
   position: 'absolute',
@@ -132,27 +113,11 @@ const toggleBox = style({
 
 const line = style({
   borderBottom: `1px solid ${theme.colors.neutral.border}`,
-  position: 'relative',
-  width: '100%',
-})
-
-const progressiveLine = recipe({
-  base: {
-    borderBottom: `1px solid ${theme.colors.primary.border}`,
-    bottom: -1,
-    left: 0,
-    position: 'absolute',
-    top: 0,
-    transition: 'width 500ms ease',
-  },
-  variants: {
-    isFocused: {
-      false: {
-        width: '0%',
-      },
-      true: {
-        width: '100%',
-      },
+  flex: 1,
+  paddingTop: theme.space[1],
+  selectors: {
+    [`${listItem.classNames.variants.isFocused.true} &`]: {
+      borderColor: theme.colors.primary.border,
     },
   },
 })
@@ -175,16 +140,16 @@ const itemTooltip = style({
 export const pieChartStyle = {
   container,
   emptyLegend,
+  legendContainer,
+  legendHeader,
+  pieContainer,
   content,
   listItem,
   list,
   bullet,
   label,
-  value,
-  text,
   toggleBox,
   line,
-  progressiveLine,
   listTooltip,
   itemTooltip,
 }


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

#### What is expected?

Allo to display the unit of the legend in the header instead of repeat it on each line

#### The following changes were made:

- add a prop `legendHeader` on the PieChart component to display the unit. It's optional for backward compatibility, so users can still have the unit inline until they decide to move it to the header
- clean and simplify the component : fewer DOM nodes, fewer styles
- update the styles to match the Figma design (things have moved a little bit)

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/bcbee840-8cde-468d-afbd-ae21e8dc9ce0" /> | <img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/7e33922e-3363-4fe8-b2d8-6508d708dc16" /> |
| url  | <img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/b2a1fb70-87b5-4a52-89cd-111050257656" /> | <img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/3d471706-1a51-46f8-b609-fed42efbb6d4" /> |
| url | <img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/83ba6e41-b00c-490c-a357-42f1fa8b959f" /> | <img width="681" height="281" alt="image" src="https://github.com/user-attachments/assets/9582a7e3-9179-49e1-9863-dd6a8ec83698" /> |