### PR TITLE
fix: prevent the Navigation from having a width smaller than the minimal width

### DIFF
--- a/.changeset/empty-turtles-jump.md
+++ b/.changeset/empty-turtles-jump.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Navigation`: prevent the Navigation from having a width smaller than the minimal width

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,7 +10,9 @@ import {
   consoleLightTheme as lightTheme,
   ThemeProvider as ThemeProviderUI,
 } from '@ultraviolet/themes'
+import type { ReactNode } from 'react'
 import { scan } from 'react-scan'
+import { Fragment } from 'react/jsx-runtime'
 import { themes } from 'storybook/theming'
 import DocsContainer from './components/DocsContainer'
 import Page from './components/Page'
@@ -124,13 +126,29 @@ const getThemeColor = (theme: string) => {
   return { background, textColor }
 }
 
+function DottedBackground({ theme, children }: { theme: string; children: ReactNode }) {
+  const { background, textColor } = getThemeColor(theme)
+
+  return (
+    <div
+      style={{
+        background,
+        backgroundPosition: '-4px -4px',
+        backgroundSize: '12px 12px',
+        color: textColor,
+        padding: '30px',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
 const decorators: Decorator[] = [
   (Story, args) => {
     const { context } = args
     const { theme: globalTheme } = context.globals
     const theme = (globalTheme as 'light' | 'dark' | undefined) || 'light'
-
-    const { background, textColor } = getThemeColor(theme)
     const finalTheme = () => {
       if (theme === 'light') {
         return lightTheme
@@ -142,20 +160,14 @@ const decorators: Decorator[] = [
       return darkerTheme
     }
 
+    const Wrapper = context.parameters['layout'] === 'fullscreen' ? Fragment : DottedBackground
+
     return (
-      <div
-        style={{
-          background,
-          backgroundPosition: '-4px -4px',
-          backgroundSize: '12px 12px',
-          color: textColor,
-          padding: '30px',
-        }}
-      >
+      <Wrapper theme={theme}>
         <ThemeProviderUI theme={finalTheme()}>
           <Story {...context} />
         </ThemeProviderUI>
-      </div>
+      </Wrapper>
     )
   },
   withThemeByClassName({

--- a/packages/ui/src/compositions/Navigation/NavigationContent.tsx
+++ b/packages/ui/src/compositions/Navigation/NavigationContent.tsx
@@ -36,6 +36,7 @@ export const NavigationContent = ({
   }
 
   const { setWidth, width, expanded, toggleExpand, navigationRef, allowNavigationResize, shouldAnimate } = context
+  const clampedWidth = clamp(NAVIGATION_MIN_WIDTH, width, NAVIGATION_MAX_WIDTH)
 
   const sliderRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
@@ -80,7 +81,7 @@ export const NavigationContent = ({
           onToggleExpand?.(!expanded)
           if (navigationRef.current) {
             setElementVars(navigationRef.current, {
-              [widthNavigationContainerExpanded]: `${width}px`,
+              [widthNavigationContainerExpanded]: `${clampedWidth}px`,
             })
           }
         }
@@ -114,7 +115,7 @@ export const NavigationContent = ({
     return () => {
       sliderRefCurrent?.removeEventListener('mousedown', mousedown)
     }
-  }, [expanded, navigationRef, onToggleExpand, onWidthResize, setWidth, toggleExpand, shouldAnimate, width])
+  }, [expanded, navigationRef, onToggleExpand, onWidthResize, setWidth, toggleExpand, shouldAnimate, clampedWidth])
 
   return (
     <nav className={cn(className, navigationStyle.navigation)} data-testid={dataTestId} id={id}>
@@ -122,8 +123,8 @@ export const NavigationContent = ({
         className={navigationStyle.container()}
         ref={navigationRef}
         style={assignInlineVars({
-          [widthNavigationContainer]: `${expanded ? width : NAVIGATION_COLLASPED_WIDTH}px`,
-          [widthNavigationContainerExpanded]: `${width}px`,
+          [widthNavigationContainer]: `${expanded ? clampedWidth : NAVIGATION_COLLASPED_WIDTH}px`,
+          [widthNavigationContainerExpanded]: `${clampedWidth}px`,
           [widthNavigationContainerDuration]: `${shouldAnimate ? ANIMATION_DURATION : 0}ms`,
         })}
       >

--- a/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
@@ -22,6 +22,7 @@ export default {
       'specific-patterns': false,
     },
     experimental: true,
+    layout: 'fullscreen',
   },
 } as Meta
 

--- a/packages/ui/src/compositions/Navigation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/Navigation/__tests__/__snapshots__/index.test.tsx.snap
@@ -929,8 +929,8 @@ exports[`navigation > pin and unpin an item 1`] = `
                         class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                       >
                         <div
-                          aria-controls="_r_3e_"
-                          aria-describedby="_r_3e_"
+                          aria-controls="_r_3s_"
+                          aria-describedby="_r_3s_"
                           class="styles__w40vpo9"
                           tabindex="-1"
                         >
@@ -975,12 +975,12 @@ exports[`navigation > pin and unpin an item 1`] = `
             <hr
               aria-orientation="horizontal"
               class="styles__riihzv7 styles__bu43fbb styles_direction_horizontal__bu43fbc styles_sentiment_neutral__bu43fbi"
-              data-flip-id="_r_2v_"
+              data-flip-id="_r_3d_"
               style="--bu43fb0: 1px;"
             />
             <div
               class="styles__riihzv2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-              data-flip-id="_r_30_"
+              data-flip-id="_r_3e_"
             >
               <span
                 class="styles__riihzv0 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
@@ -1111,8 +1111,8 @@ exports[`navigation > pin and unpin an item 1`] = `
                   class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                 >
                   <div
-                    aria-controls="_r_34_"
-                    aria-describedby="_r_34_"
+                    aria-controls="_r_3i_"
+                    aria-describedby="_r_3i_"
                     class="styles__w40vpo9"
                     tabindex="-1"
                   >
@@ -1248,8 +1248,8 @@ exports[`navigation > pin and unpin an item 1`] = `
                       class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                     >
                       <div
-                        aria-controls="_r_37_"
-                        aria-describedby="_r_37_"
+                        aria-controls="_r_3l_"
+                        aria-describedby="_r_3l_"
                         class="styles__w40vpo9"
                         tabindex="-1"
                       >
@@ -1289,8 +1289,8 @@ exports[`navigation > pin and unpin an item 1`] = `
             class="styles__9d0sn0 styles_overflow_false__9d0sn1"
           >
             <div
-              aria-controls="_r_39_"
-              aria-describedby="_r_39_"
+              aria-controls="_r_3n_"
+              aria-describedby="_r_3n_"
               class="styles__w40vpo9"
               tabindex="0"
             >
@@ -1478,8 +1478,8 @@ exports[`navigation > pin and unpin an item 2`] = `
                         class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                       >
                         <div
-                          aria-controls="_r_3e_"
-                          aria-describedby="_r_3e_"
+                          aria-controls="_r_3s_"
+                          aria-describedby="_r_3s_"
                           class="styles__w40vpo9"
                           tabindex="-1"
                         >
@@ -1524,12 +1524,12 @@ exports[`navigation > pin and unpin an item 2`] = `
             <hr
               aria-orientation="horizontal"
               class="styles__riihzv7 styles__bu43fbb styles_direction_horizontal__bu43fbc styles_sentiment_neutral__bu43fbi"
-              data-flip-id="_r_2v_"
+              data-flip-id="_r_3d_"
               style="--bu43fb0: 1px;"
             />
             <div
               class="styles__riihzv2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-              data-flip-id="_r_30_"
+              data-flip-id="_r_3e_"
             >
               <span
                 class="styles__riihzv0 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
@@ -1660,8 +1660,8 @@ exports[`navigation > pin and unpin an item 2`] = `
                   class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                 >
                   <div
-                    aria-controls="_r_34_"
-                    aria-describedby="_r_34_"
+                    aria-controls="_r_3i_"
+                    aria-describedby="_r_3i_"
                     class="styles__w40vpo9"
                     tabindex="-1"
                   >
@@ -1797,8 +1797,8 @@ exports[`navigation > pin and unpin an item 2`] = `
                       class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                     >
                       <div
-                        aria-controls="_r_37_"
-                        aria-describedby="_r_37_"
+                        aria-controls="_r_3l_"
+                        aria-describedby="_r_3l_"
                         class="styles__w40vpo9"
                         tabindex="-1"
                       >
@@ -1838,8 +1838,8 @@ exports[`navigation > pin and unpin an item 2`] = `
             class="styles__9d0sn0 styles_overflow_false__9d0sn1"
           >
             <div
-              aria-controls="_r_39_"
-              aria-describedby="_r_39_"
+              aria-controls="_r_3n_"
+              aria-describedby="_r_3n_"
               class="styles__w40vpo9"
               tabindex="0"
             >
@@ -2006,12 +2006,12 @@ exports[`navigation > pin and unpin an item 3`] = `
             <hr
               aria-orientation="horizontal"
               class="styles__riihzv7 styles__bu43fbb styles_direction_horizontal__bu43fbc styles_sentiment_neutral__bu43fbi"
-              data-flip-id="_r_2v_"
+              data-flip-id="_r_3d_"
               style="--bu43fb0: 1px;"
             />
             <div
               class="styles__riihzv2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-              data-flip-id="_r_30_"
+              data-flip-id="_r_3e_"
             >
               <span
                 class="styles__riihzv0 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
@@ -2142,8 +2142,8 @@ exports[`navigation > pin and unpin an item 3`] = `
                   class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                 >
                   <div
-                    aria-controls="_r_34_"
-                    aria-describedby="_r_34_"
+                    aria-controls="_r_3i_"
+                    aria-describedby="_r_3i_"
                     class="styles__w40vpo9"
                     tabindex="-1"
                   >
@@ -2280,8 +2280,8 @@ exports[`navigation > pin and unpin an item 3`] = `
                       class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j"
                     >
                       <div
-                        aria-controls="_r_37_"
-                        aria-describedby="_r_37_"
+                        aria-controls="_r_3l_"
+                        aria-describedby="_r_3l_"
                         class="styles__w40vpo9"
                         tabindex="-1"
                       >
@@ -2321,8 +2321,8 @@ exports[`navigation > pin and unpin an item 3`] = `
             class="styles__9d0sn0 styles_overflow_false__9d0sn1"
           >
             <div
-              aria-controls="_r_39_"
-              aria-describedby="_r_39_"
+              aria-controls="_r_3n_"
+              aria-describedby="_r_3n_"
               class="styles__w40vpo9"
               tabindex="0"
             >
@@ -4122,15 +4122,15 @@ exports[`navigation > with nested items 1`] = `
           >
             <div
               class="styles__riihzv2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-              data-flip-id="_r_42_"
+              data-flip-id="_r_4g_"
             >
               <div
                 class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p styles_justifyContent_flex-start_xxsmall__toi52u6j"
                 data-flip-id="compute"
               >
                 <div
-                  aria-controls="menu-_r_43_"
-                  aria-describedby="menu-_r_43_"
+                  aria-controls="menu-_r_4h_"
+                  aria-describedby="menu-_r_4h_"
                   class="styles__w40vpo9"
                   tabindex="-1"
                 >
@@ -4189,8 +4189,8 @@ exports[`navigation > with nested items 1`] = `
             class="styles__9d0sn0 styles_overflow_false__9d0sn1"
           >
             <div
-              aria-controls="_r_4i_"
-              aria-describedby="_r_4i_"
+              aria-controls="_r_50_"
+              aria-describedby="_r_50_"
               class="styles__w40vpo9"
               tabindex="0"
             >
@@ -4260,20 +4260,20 @@ exports[`navigation > with show hide feature - collapsed 1`] = `
             <hr
               aria-orientation="horizontal"
               class="styles__riihzv7 styles__bu43fbb styles_direction_horizontal__bu43fbc styles_sentiment_neutral__bu43fbi"
-              data-flip-id="_r_3o_"
+              data-flip-id="_r_46_"
               style="--bu43fb0: 1px;"
             />
             <div
               class="styles__riihzv2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-              data-flip-id="_r_3p_"
+              data-flip-id="_r_47_"
             >
               <div
                 class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p styles_justifyContent_flex-start_xxsmall__toi52u6j"
                 data-flip-id="item1"
               >
                 <div
-                  aria-controls="_r_40_"
-                  aria-describedby="_r_40_"
+                  aria-controls="_r_4e_"
+                  aria-describedby="_r_4e_"
                   class="styles__w40vpo9"
                   tabindex="-1"
                 >
@@ -4352,8 +4352,8 @@ exports[`navigation > with show hide feature - collapsed 1`] = `
             class="styles__9d0sn0 styles_overflow_false__9d0sn1"
           >
             <div
-              aria-controls="_r_3u_"
-              aria-describedby="_r_3u_"
+              aria-controls="_r_4c_"
+              aria-describedby="_r_4c_"
               class="styles__w40vpo9"
               tabindex="0"
             >
@@ -4423,12 +4423,12 @@ exports[`navigation > with show hide feature 1`] = `
             <hr
               aria-orientation="horizontal"
               class="styles__riihzv7 styles__bu43fbb styles_direction_horizontal__bu43fbc styles_sentiment_neutral__bu43fbi"
-              data-flip-id="_r_3g_"
+              data-flip-id="_r_3u_"
               style="--bu43fb0: 1px;"
             />
             <div
               class="styles__riihzv2 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.125rem_xxsmall__toi52u5d"
-              data-flip-id="_r_3h_"
+              data-flip-id="_r_3v_"
             >
               <span
                 class="styles__riihzv0 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmallStrong__m4c9owl style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
@@ -4512,8 +4512,8 @@ exports[`navigation > with show hide feature 1`] = `
             class="styles__9d0sn0 styles_overflow_false__9d0sn1"
           >
             <div
-              aria-controls="_r_3m_"
-              aria-describedby="_r_3m_"
+              aria-controls="_r_44_"
+              aria-describedby="_r_44_"
               class="styles__w40vpo9"
               tabindex="0"
             >

--- a/packages/ui/src/compositions/Navigation/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/Navigation/__tests__/index.test.tsx
@@ -5,11 +5,12 @@ import { renderWithTheme } from '@utils/test'
 import type { ComponentProps } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { Navigation, NavigationProvider } from '..'
+import { NAVIGATION_MIN_WIDTH } from '../constants'
 
-type BasicNavigationProps = Pick<ComponentProps<typeof NavigationProvider>, 'pinnedFeature'>
+type BasicNavigationProps = Partial<ComponentProps<typeof NavigationProvider>>
 
-const BasicNavigation = ({ pinnedFeature = true }: BasicNavigationProps) => (
-  <NavigationProvider animation={false} pinnedFeature={pinnedFeature}>
+const BasicNavigation = ({ initialWidth, pinnedFeature = true }: BasicNavigationProps) => (
+  <NavigationProvider animation={false} pinnedFeature={pinnedFeature} initialWidth={initialWidth}>
     <Navigation logo={<p>Logo</p>}>
       <Navigation.PinnedItems />
       <Navigation.Separator />
@@ -162,6 +163,15 @@ describe('navigation', () => {
     slider.dispatchEvent(mouseEventExtend)
 
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should not accept an initialWidth smaller than the minimum accepted width', () => {
+    renderWithTheme(<BasicNavigation initialWidth={100} />)
+
+    expect(document.querySelector('nav > div')).toHaveAttribute(
+      'style',
+      expect.stringContaining(NAVIGATION_MIN_WIDTH.toString()),
+    )
   })
 
   it('pin and unpin an item', async () => {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

The width of the Navigation is stored in localStorage. If the user has a bad value (width too small or too big), it was still applied so the Navigation could be too narrow.

To check the fix:
1. open the [navigation story](https://fixnavminwidthstorybook.storybook.ultraviolet.scaleway.com/?path=/story/compositions-navigation--playground) and expand the Navigation
2. go to the devtools, Application > localStorage, and change the width to 120 (you might need to resize the Navigation first to make the value appear)
3. reload
4. the Navigation should have a width of 220px (the minimum)

#### The following changes were made:

- add a clamp to the width to keep it in the accepted range
- update the stories to remove the padding around the Navigation. This is not related to this bug, but it allows to see another one: in the story ShowHide, when the Navigation is collapsed, the tooltip on the button show/hide is not correctly positioned

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="374" height="826" alt="image" src="https://github.com/user-attachments/assets/da36d709-8ac1-46a0-adf4-dd0dbebce20c" /> | <img width="374" height="826" alt="image" src="https://github.com/user-attachments/assets/1ad6af9f-b382-4eab-95da-b24672470449" /> |
