### PR TITLE
chore: remove devDependencies from changesets

### DIFF
--- a/.github/workflows/changesets-renovate.yml
+++ b/.github/workflows/changesets-renovate.yml
@@ -31,3 +31,5 @@ jobs:
           cache: 'pnpm'
       - name: Run changesets-renovate
         run: pnpm dlx @scaleway/changesets-renovate
+        env:
+          EXCLUDE_DEVDEPS: true

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,22 +10,20 @@
     "preview": "vite preview",
     "start": "vite"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@playwright/test": "1.59.1",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
     "@ultraviolet/fonts": "workspace:*",
     "@ultraviolet/form": "workspace:*",
     "@ultraviolet/icons": "workspace:*",
     "@ultraviolet/themes": "workspace:*",
     "@ultraviolet/ui": "workspace:*",
-    "react": "19.2.6",
-    "react-dom": "19.2.6",
-    "react-router-dom": "7.15.1"
-  },
-  "devDependencies": {
-    "@playwright/test": "1.59.1",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
     "globals": "17.6.0",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "react-router-dom": "7.15.1",
     "typescript": "6.0.3",
     "vite": "8.0.13"
   }

--- a/examples/next-app-router/package.json
+++ b/examples/next-app-router/package.json
@@ -8,8 +8,11 @@
     "start": "next start",
     "typecheck": "tsgo --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
     "@scaleway/regex": "5.8.1",
+    "@types/node": "24.12.4",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
     "@ultraviolet/fonts": "workspace:*",
     "@ultraviolet/form": "workspace:*",
     "@ultraviolet/icons": "workspace:*",
@@ -18,12 +21,7 @@
     "@ultraviolet/ui": "workspace:*",
     "next": "16.2.6",
     "react": "19.2.6",
-    "react-dom": "19.2.6"
-  },
-  "devDependencies": {
-    "@types/node": "24.12.4",
-    "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3",
+    "react-dom": "19.2.6",
     "typescript": "6.0.3"
   }
 }

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -15,8 +15,12 @@
     "start": "next start",
     "typecheck": "tsgo --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
+    "@babel/core": "7.29.0",
     "@scaleway/regex": "5.8.1",
+    "@types/node": "24.12.4",
+    "@types/react": "19.2.14",
+    "@types/react-syntax-highlighter": "15.5.13",
     "@ultraviolet/fonts": "workspace:*",
     "@ultraviolet/form": "workspace:*",
     "@ultraviolet/icons": "workspace:*",
@@ -25,18 +29,12 @@
     "@ultraviolet/ui": "workspace:*",
     "@ultraviolet/utils": "workspace:*",
     "next": "16.2.6",
+    "next-transpile-modules": "10.0.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-schemaorg": "2.0.1",
     "react-syntax-highlighter": "16.1.1",
     "sass": "1.99.0",
     "schema-dts": "2.0.0"
-  },
-  "devDependencies": {
-    "@babel/core": "7.29.0",
-    "@types/node": "24.12.4",
-    "@types/react": "19.2.14",
-    "@types/react-syntax-highlighter": "15.5.13",
-    "next-transpile-modules": "10.0.1"
   }
 }

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -9,16 +9,14 @@
     "start": "vite",
     "typecheck": "tsgo --noEmit"
   },
-  "dependencies": {
-    "@ultraviolet/themes": "workspace:*",
-    "@ultraviolet/ui": "workspace:*",
-    "react": "19.2.6",
-    "react-dom": "19.2.6"
-  },
   "devDependencies": {
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@ultraviolet/themes": "workspace:*",
+    "@ultraviolet/ui": "workspace:*",
     "@vitejs/plugin-react": "6.0.1",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
     "typescript": "6.0.3",
     "vite": "8.0.13"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,7 +263,16 @@ importers:
         version: 4.4.2
 
   e2e:
-    dependencies:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.59.1
+        version: 1.59.1
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@ultraviolet/fonts':
         specifier: workspace:*
         version: link:../packages/fonts
@@ -279,6 +288,12 @@ importers:
       '@ultraviolet/ui':
         specifier: workspace:*
         version: link:../packages/ui
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      globals:
+        specifier: 17.6.0
+        version: 17.6.0
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -288,22 +303,6 @@ importers:
       react-router-dom:
         specifier: 7.15.1
         version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-    devDependencies:
-      '@playwright/test':
-        specifier: 1.59.1
-        version: 1.59.1
-      '@types/react':
-        specifier: 19.2.14
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: 6.0.1
-        version: 6.0.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
-      globals:
-        specifier: 17.6.0
-        version: 17.6.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -312,10 +311,22 @@ importers:
         version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/next:
-    dependencies:
+    devDependencies:
+      '@babel/core':
+        specifier: 7.29.0
+        version: 7.29.0
       '@scaleway/regex':
         specifier: 5.8.1
         version: 5.8.1
+      '@types/node':
+        specifier: 24.12.4
+        version: 24.12.4
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-syntax-highlighter':
+        specifier: 15.5.13
+        version: 15.5.13
       '@ultraviolet/fonts':
         specifier: workspace:*
         version: link:../../packages/fonts
@@ -340,6 +351,9 @@ importers:
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.99.0)
+      next-transpile-modules:
+        specifier: 10.0.1
+        version: 10.0.1
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -358,28 +372,21 @@ importers:
       schema-dts:
         specifier: 2.0.0
         version: 2.0.0(typescript@6.0.3)
+
+  examples/next-app-router:
     devDependencies:
-      '@babel/core':
-        specifier: 7.29.0
-        version: 7.29.0
+      '@scaleway/regex':
+        specifier: 5.8.1
+        version: 5.8.1
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
-      '@types/react-syntax-highlighter':
-        specifier: 15.5.13
-        version: 15.5.13
-      next-transpile-modules:
-        specifier: 10.0.1
-        version: 10.0.1
-
-  examples/next-app-router:
-    dependencies:
-      '@scaleway/regex':
-        specifier: 5.8.1
-        version: 5.8.1
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@ultraviolet/fonts':
         specifier: workspace:*
         version: link:../../packages/fonts
@@ -407,44 +414,33 @@ importers:
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+  examples/vite:
     devDependencies:
-      '@types/node':
-        specifier: 24.12.4
-        version: 24.12.4
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
-
-  examples/vite:
-    dependencies:
       '@ultraviolet/themes':
         specifier: workspace:*
         version: link:../../packages/themes
       '@ultraviolet/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
-    devDependencies:
-      '@types/react':
-        specifier: 19.2.14
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: 19.2.3
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: 6.0.1
-        version: 6.0.1(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -804,13 +800,13 @@ importers:
         version: 4.1.5(@types/node@24.12.4)(@vitest/coverage-istanbul@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   utils/config:
-    dependencies:
+    devDependencies:
       vite:
         specifier: 8.0.13
         version: 8.0.13(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
 
   utils/stories:
-    dependencies:
+    devDependencies:
       '@repo/config':
         specifier: workspace:*
         version: link:../config
@@ -880,9 +876,6 @@ importers:
       '@ultraviolet/themes':
         specifier: workspace:*
         version: link:../../packages/themes
-      react:
-        specifier: 19.2.6
-        version: 19.2.6
     devDependencies:
       '@types/node':
         specifier: 24.12.4

--- a/utils/config/package.json
+++ b/utils/config/package.json
@@ -5,7 +5,7 @@
   "files": [
     "tsconfig/"
   ],
-  "dependencies": {
+  "devDependencies": {
     "vite": "8.0.13"
   },
   "export": {

--- a/utils/stories/package.json
+++ b/utils/stories/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsgo --noEmit",
     "typecheck:go": "tsgo --noEmit"
   },
-  "dependencies": {
+  "devDependencies": {
     "@repo/config": "workspace:*",
     "@storybook/addon-a11y": "10.3.6",
     "@storybook/addon-docs": "10.3.6",

--- a/utils/test/package.json
+++ b/utils/test/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
-    "@ultraviolet/themes": "workspace:*",
-    "react": "19.2.6"
+    "@ultraviolet/themes": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "24.12.4",


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarize concisely:

#### What is expected?

non-production dependencies don't generate a changeset

#### The following changes were made:

1. enable the flag on the CLI `@scaleway/changesets-renovate` to exclude devDeps
2. move packages from `dependencies` to `devDependencies` so that they don't generate a changeset
