### PR TITLE
test(form): use renderWithForm instead of renderHook

### DIFF
--- a/packages/form/src/components/CheckboxField/__tests__/index.test.tsx
+++ b/packages/form/src/components/CheckboxField/__tests__/index.test.tsx
@@ -1,10 +1,8 @@
-import { act, renderHook, screen } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { mockFormErrors, renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { mockFormErrors, renderWithForm } from '@utils/test'
 import { describe, expect, vi, it } from 'vitest'
 import { CheckboxField } from '../..'
-import { Form } from '../../Form'
 
 describe('checkboxField', () => {
   it('should render correctly', () => {
@@ -70,14 +68,15 @@ describe('checkboxField', () => {
   })
 
   it('should render correctly with errors', async () => {
-    const { result } = renderHook(() => useForm({ mode: 'onChange' }))
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={() => {}}>
+    const { asFragment } = renderWithForm(
+      <>
         <CheckboxField name="test" required errorLabel="errorLabel">
           Checkbox field error
         </CheckboxField>
         <div>Focus</div>
-      </Form>,
+      </>,
+      { mode: 'onChange' },
+      { errors: mockFormErrors },
     )
 
     await userEvent.click(screen.getByRole('checkbox', { hidden: true }))

--- a/packages/form/src/components/Form/__tests__/index.test.tsx
+++ b/packages/form/src/components/Form/__tests__/index.test.tsx
@@ -1,30 +1,18 @@
-import { renderHook, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { mockFormErrors, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { renderWithForm } from '@utils/test'
 import { describe, expect, vi, it } from 'vitest'
-import { Form } from '..'
 
 describe('form', () => {
   it('renders correctly with node children', () => {
-    const { result } = renderHook(() => useForm())
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={() => {}}>
-        Test
-      </Form>,
-    )
+    const { asFragment } = renderWithForm(<>Test</>)
     expect(asFragment()).toMatchSnapshot()
   })
 
   it('renders correctly with onSubmit', async () => {
     const onSubmit = vi.fn(() => {})
-    const { result } = renderHook(() => useForm())
 
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={onSubmit}>
-        <button type="submit">Submit</button>
-      </Form>,
-    )
+    const { asFragment } = renderWithForm(<button type="submit">Submit</button>, undefined, { onSubmit })
     await userEvent.click(screen.getByText('Submit'))
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
     expect(asFragment()).toMatchSnapshot()

--- a/packages/form/src/components/NumberInputField/__tests__/index.test.tsx
+++ b/packages/form/src/components/NumberInputField/__tests__/index.test.tsx
@@ -1,10 +1,8 @@
-import { act, renderHook, screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { mockFormErrors, renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { mockFormErrors, renderWithForm } from '@utils/test'
 import { describe, expect, vi, it } from 'vitest'
 import { NumberInputField, Submit } from '../..'
-import { Form } from '../../Form'
 
 describe('numberInputField', () => {
   it('should render correctly', () => {
@@ -29,26 +27,23 @@ describe('numberInputField', () => {
 
   it('should work fine with form setValue', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() =>
-      useForm<{ test: number | null }>({
+    const { resultForm } = renderWithForm(
+      <>
+        <NumberInputField label="Test" name="test" required />
+        <Submit>Submit</Submit>
+      </>,
+      {
         defaultValues: {
           test: 10,
         },
         mode: 'onChange',
-      }),
-    )
-
-    renderWithTheme(
-      <Form
-        errors={mockFormErrors}
-        methods={result.current}
-        onSubmit={value => {
+      },
+      {
+        errors: mockFormErrors,
+        onSubmit: value => {
           onSubmit(value)
-        }}
-      >
-        <NumberInputField label="Test" name="test" required />
-        <Submit>Submit</Submit>
-      </Form>,
+        },
+      },
     )
 
     const numberInput = screen.getByLabelText('Test')
@@ -62,7 +57,7 @@ describe('numberInputField', () => {
     expect(numberInput).toHaveValue(null)
     expect(submit).toBeDisabled()
     act(() => {
-      result.current.setValue('test', 40, { shouldValidate: true })
+      resultForm.current.setValue('test', 40, { shouldValidate: true })
     })
     await waitFor(() => {
       expect(numberInput).toHaveValue(40)

--- a/packages/form/src/components/SliderField/__tests__/index.test.tsx
+++ b/packages/form/src/components/SliderField/__tests__/index.test.tsx
@@ -1,10 +1,8 @@
-import { act, fireEvent, renderHook, screen } from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { mockFormErrors, renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { mockFormErrors, renderWithForm } from '@utils/test'
 import { describe, expect, vi, it } from 'vitest'
 import { SliderField, Submit } from '../..'
-import { Form } from '../../Form'
 
 const options = [
   { label: '1Mb', value: 1 },
@@ -58,31 +56,29 @@ describe('sliderField', () => {
   it('should work fine with form setValue', async () => {
     const onSubmit = vi.fn()
     const onBlur = vi.fn(() => {})
-    const { result } = renderHook(() =>
-      useForm<{ test: number | null }>({
+    const { resultForm } = renderWithForm(
+      <>
+        <SliderField input label="Test" max={10} min={0} name="test" onBlur={onBlur} required />
+        <Submit>Submit</Submit>
+      </>,
+      {
         defaultValues: {
           test: 10,
         },
         mode: 'onChange',
-      }),
-    )
-
-    renderWithTheme(
-      <Form
-        errors={mockFormErrors}
-        methods={result.current}
-        onSubmit={value => {
+      },
+      {
+        errors: mockFormErrors,
+        onSubmit: value => {
           onSubmit(value)
-        }}
-      >
-        <SliderField input label="Test" max={10} min={0} name="test" onBlur={onBlur} required />
-        <Submit>Submit</Submit>
-      </Form>,
+        },
+      },
     )
 
     const slider = screen.getByRole<HTMLInputElement>('slider')
     const submit = screen.getByText('Submit')
     expect(slider).toHaveValue('10')
+    expect(resultForm.current.getValues('test')).toBe(10)
     await userEvent.click(submit)
     expect(onSubmit).toHaveBeenCalledWith({
       test: 10,
@@ -95,43 +91,35 @@ describe('sliderField', () => {
   })
 
   it('should work correctly with possibleValues', () => {
-    const { result } = renderHook(() => useForm({ mode: 'onChange' }))
-
-    renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={() => {}}>
-        <SliderField label="Test" name="test" options={options} />
-      </Form>,
-    )
+    const { resultForm } = renderWithForm(<SliderField label="Test" name="test" options={options} />, {
+      mode: 'onChange',
+    })
 
     const input = screen.getByRole('slider', { hidden: true })
 
     fireEvent.change(input, { target: { value: '2' } })
     expect(input).toHaveValue('2')
-    expect(result.current.getValues('test')).toBe(5)
+    expect(resultForm.current.getValues('test')).toBe(5)
 
     fireEvent.change(input, { target: { value: '5' } })
     expect(input).toHaveValue('5')
-    expect(result.current.getValues('test')).toBe(100)
+    expect(resultForm.current.getValues('test')).toBe(100)
   })
 
   it('should work correctly with possibleValues and double', () => {
-    const { result } = renderHook(() => useForm({ mode: 'onChange' }))
-
-    renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={() => {}}>
-        <SliderField double label="Test" name="test" options={options} />
-      </Form>,
-    )
+    const { resultForm } = renderWithForm(<SliderField double label="Test" name="test" options={options} />, {
+      mode: 'onChange',
+    })
 
     const input1 = screen.getAllByRole('slider', { hidden: true })[0]
     const input2 = screen.getAllByRole('slider', { hidden: true })[1]
 
     fireEvent.change(input1, { target: { value: '2' } })
     expect(input1).toHaveValue('2')
-    expect(result.current.getValues('test')).toStrictEqual([5, 500])
+    expect(resultForm.current.getValues('test')).toStrictEqual([5, 500])
 
     fireEvent.change(input2, { target: { value: '5' } })
     expect(input2).toHaveValue('5')
-    expect(result.current.getValues('test')).toStrictEqual([5, 100])
+    expect(resultForm.current.getValues('test')).toStrictEqual([5, 100])
   })
 })

--- a/packages/form/src/components/SwitchButtonField/__tests__/index.test.tsx
+++ b/packages/form/src/components/SwitchButtonField/__tests__/index.test.tsx
@@ -1,9 +1,8 @@
-import { renderHook, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { renderWithForm } from '@utils/test'
 import { describe, expect, vi, it } from 'vitest'
-import { Form, Submit, SwitchButtonField } from '../..'
+import { Submit, SwitchButtonField } from '../..'
 import { mockErrors } from '../../../mocks'
 
 describe('switchButtonField', () => {
@@ -19,16 +18,17 @@ describe('switchButtonField', () => {
 
   it('should works with defaultValues', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() => useForm<{ test: string[] }>({ defaultValues: { test: ['right'] } }))
 
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockErrors} methods={result.current} onSubmit={onSubmit}>
+    const { asFragment } = renderWithForm(
+      <>
         <SwitchButtonField name="test" onChange={() => vi.fn()}>
           <SwitchButtonField.Option value="left">Left</SwitchButtonField.Option>
           <SwitchButtonField.Option value="right">Right</SwitchButtonField.Option>
         </SwitchButtonField>
         ,<Submit>Submit</Submit>
-      </Form>,
+      </>,
+      { defaultValues: { test: ['right'] } },
+      { onSubmit, errors: mockErrors },
     )
 
     await userEvent.click(screen.getByText('Submit'))

--- a/packages/form/src/components/TagInputField/__tests__/index.test.tsx
+++ b/packages/form/src/components/TagInputField/__tests__/index.test.tsx
@@ -1,9 +1,8 @@
-import { renderHook, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { renderWithForm } from '@utils/test'
 import { describe, expect, vi, it } from 'vitest'
-import { Form, Submit, TagInputField } from '../..'
+import { Submit, TagInputField } from '../..'
 import { mockErrors } from '../../../mocks'
 
 const alpha = /^[a-zA-Z]*$/
@@ -27,13 +26,14 @@ describe('tagInputField', () => {
 
   it('should works with defaultValues', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() => useForm<{ test: string[] }>({ defaultValues: { test: ['First'] } }))
 
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockErrors} methods={result.current} onSubmit={onSubmit}>
+    const { asFragment } = renderWithForm(
+      <>
         <TagInputField clearable label="Test" name="test" required />
         <Submit>Submit</Submit>
-      </Form>,
+      </>,
+      { defaultValues: { test: ['First'] } },
+      { errors: mockErrors, onSubmit },
     )
 
     await userEvent.click(screen.getByText('Submit'))

--- a/packages/form/src/components/TextAreaField/__tests__/index.test.tsx
+++ b/packages/form/src/components/TextAreaField/__tests__/index.test.tsx
@@ -1,11 +1,9 @@
-import { renderHook, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { mockFormErrors, renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { mockFormErrors, renderWithForm } from '@utils/test'
 import { describe, expect, it, vi } from 'vitest'
 import { TextAreaField } from '..'
 import { Submit } from '../..'
-import { Form } from '../../Form'
 
 describe('textAreaField', () => {
   it('should render correctly', () => {
@@ -15,13 +13,14 @@ describe('textAreaField', () => {
 
   it('should submit with onSubmitEnter prop', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() => useForm<{ test: string }>())
 
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={onSubmit}>
+    const { asFragment } = renderWithForm(
+      <>
         <TextAreaField label="Test" name="test" submitOnEnter />
         <Submit>Submit</Submit>
-      </Form>,
+      </>,
+      undefined,
+      { errors: mockFormErrors, onSubmit },
     )
 
     await waitFor(() => {
@@ -39,13 +38,14 @@ describe('textAreaField', () => {
 
   it('should render correctly generated', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() => useForm<{ test: string }>())
 
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={onSubmit}>
+    const { asFragment } = renderWithForm(
+      <>
         <TextAreaField clearable label="Test" name="test" required />
         <Submit>Submit</Submit>
-      </Form>,
+      </>,
+      undefined,
+      { errors: mockFormErrors, onSubmit },
     )
 
     await userEvent.click(screen.getByText('Submit'))

--- a/packages/form/src/components/TextInputField/__tests__/index.test.tsx
+++ b/packages/form/src/components/TextInputField/__tests__/index.test.tsx
@@ -1,11 +1,9 @@
-import { renderHook, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { mockFormErrors, renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { mockFormErrors, renderWithForm } from '@utils/test'
 import { describe, expect, it, vi } from 'vitest'
 import { TextInputField } from '..'
 import { Submit } from '../..'
-import { Form } from '../../Form'
 
 describe('textInputField', () => {
   it('should render correctly', () => {
@@ -15,13 +13,14 @@ describe('textInputField', () => {
 
   it('should render correctly generated', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() => useForm<{ test: string | null }>({ defaultValues: { test: null } }))
 
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={onSubmit}>
+    const { asFragment } = renderWithForm(
+      <>
         <TextInputField clearable label="Test" name="test" required />
         <Submit>Submit</Submit>
-      </Form>,
+      </>,
+      { defaultValues: { test: null } },
+      { errors: mockFormErrors, onSubmit },
     )
 
     await userEvent.click(screen.getByText('Submit'))

--- a/packages/form/src/components/UnitInputField/__tests__/index.test.tsx
+++ b/packages/form/src/components/UnitInputField/__tests__/index.test.tsx
@@ -1,11 +1,9 @@
-import { renderHook, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { renderWithForm, renderWithTheme } from '@utils/test'
-import { useForm } from 'react-hook-form'
+import { renderWithForm } from '@utils/test'
 import { describe, expect, it, vi } from 'vitest'
 import { Submit, UnitInputField } from '../..'
 import { mockErrors } from '../../../mocks'
-import { Form } from '../../Form'
 
 const optionsSelect = [
   {
@@ -33,23 +31,9 @@ describe('unitInputField', () => {
 
   it('should handles onChange and selection', async () => {
     const onSubmit = vi.fn()
-    const { result } = renderHook(() =>
-      useForm<{ test: number | null }>({
-        defaultValues: {
-          test: 10,
-        },
-        mode: 'onChange',
-      }),
-    )
 
-    const { asFragment } = renderWithTheme(
-      <Form
-        errors={mockErrors}
-        methods={result.current}
-        onSubmit={value => {
-          onSubmit(value)
-        }}
-      >
+    const { asFragment } = renderWithForm(
+      <>
         <UnitInputField
           label="Test"
           name="test"
@@ -59,7 +43,19 @@ describe('unitInputField', () => {
           required
         />
         <Submit>Submit</Submit>
-      </Form>,
+      </>,
+      {
+        defaultValues: {
+          test: 10,
+        },
+        mode: 'onChange',
+      },
+      {
+        errors: mockErrors,
+        onSubmit: value => {
+          onSubmit(value)
+        },
+      },
     )
 
     const selectBar = screen.getByTestId('select-input-test-unit')

--- a/packages/form/src/providers/ErrorContext/__tests__/index.test.tsx
+++ b/packages/form/src/providers/ErrorContext/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react'
-import { mockFormErrors, renderWithTheme } from '@utils/test'
+import { mockFormErrors, renderWithForm } from '@utils/test'
 import type { ReactNode } from 'react'
 import { useForm } from 'react-hook-form'
 import { describe, expect, it } from 'vitest'
@@ -18,12 +18,7 @@ const HookWrapper = ({ children }: { children: ReactNode }) => {
 
 describe('errorProvider', () => {
   it('renders correctly ', () => {
-    const { result } = renderHook(() => useForm())
-    const { asFragment } = renderWithTheme(
-      <Form errors={mockFormErrors} methods={result.current} onSubmit={() => null}>
-        Test
-      </Form>,
-    )
+    const { asFragment } = renderWithForm(<>Test</>)
     expect(asFragment()).toMatchSnapshot()
   })
 


### PR DESCRIPTION
## Summary

1.  Consistency: All form tests now use the same testing pattern
2. Simplicity: Reduces boilerplate code in test files
3. Maintainability: Changes to form setup only need to be made in one place (renderWithForm utility)
4. Cleaner imports: Removes unnecessary imports of renderHook, useForm, renderWithTheme, and Form from test files