### PR TITLE
chore: update renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,15 +12,25 @@
   "prConcurrentLimit": 10,
   "reviewers": ["team:console"],
   "reviewersSampleSize": 2,
-  "semanticCommitType": "chore",
-  "semanticCommitScope": "deps",
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchDepTypes": ["engines", "peerDependencies"],
       "rangeStrategy": "widen"
     },
     {
-      "matchManagers": ["dockerfile", "github-actions", "packageManager", "devDependencies"],
+      "matchDepTypes": ["dependencies"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    },
+    {
+      "matchManagers": ["dockerfile", "github-actions"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "devDeps"
+    },
+    {
+      "matchDepTypes": ["packageManager", "devDependencies"],
+      "semanticCommitType": "chore",
       "semanticCommitScope": "devDeps"
     },
     {


### PR DESCRIPTION
## Summary

### Summarize concisely:

#### What is expected?

- "dependencies" label added on all Renovate PRs (like dependabot)
- all Renovate PRs have commit type "chore" instead of the default "fix" for prod dependencies
- fix the condition to change the commit scope "devDeps" for devDependencies
