### PR TITLE
fix(SelectInput): fix font sizes on small size

### DIFF
--- a/.changeset/heavy-turtles-wear.md
+++ b/.changeset/heavy-turtles-wear.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SelectInput`: fix font sizes on small size

--- a/packages/ui/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Pagination/__tests__/__snapshots__/index.test.tsx.snap
@@ -763,7 +763,7 @@ exports[`pagination > should render correctly with perPage - default values 1`] 
                 tabindex="0"
               >
                 <span
-                  class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                  class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                 >
                   10
                 </span>
@@ -950,7 +950,7 @@ exports[`pagination > should render correctly with perPage 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                  class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                 >
                   10
                 </span>

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -2438,7 +2438,7 @@ exports[`selectInput > renders correctly small 1`] = `
             tabindex="0"
           >
             <span
-              class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
             >
               Select item
             </span>

--- a/packages/ui/src/components/SelectInput/components/Dropdown/AddOption.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/AddOption.tsx
@@ -11,7 +11,7 @@ export const AddOption = ({
   isEmpty,
 }: {
   option: OptionType
-  textVariant: 'caption' | 'body' | 'bodySmall'
+  textVariant: 'body' | 'bodySmall'
   addOption?: {
     text: string
     onClick: (searchText: string) => void

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Content.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Content.tsx
@@ -2,7 +2,7 @@
 
 import { PlusIcon } from '@ultraviolet/icons/PlusIcon'
 import { cn } from '@ultraviolet/utils'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import type { KeyboardEvent, ReactNode } from 'react'
 import { Skeleton } from '../../../Skeleton'
 import { Stack } from '../../../Stack'
@@ -30,25 +30,25 @@ type CreateDropdownProps = {
 }
 
 const moveFocusDown = () => {
-  const options = document.querySelectorAll(OPTION_SELECTOR)
+  const options = document.querySelectorAll<HTMLElement>(OPTION_SELECTOR)
   const activeItem = document.activeElement
   if (options) {
     for (let i = 0; i < options?.length; i += 1) {
       const listLength = options.length
       if (activeItem === options[i] && activeItem !== options[listLength - 1]) {
-        ;(options[i + 1] as HTMLElement).focus()
+        options[i + 1].focus()
       }
     }
   }
 }
 const moveFocusUp = () => {
-  const options = document.querySelectorAll(OPTION_SELECTOR)
+  const options = document.querySelectorAll<HTMLElement>(OPTION_SELECTOR)
   const activeItem = document.activeElement
 
   if (options) {
     for (let i = 0; i < options.length; i += 1) {
       if (activeItem === options[i] && activeItem !== options[0]) {
-        ;(options[i - 1] as HTMLElement).focus()
+        options[i - 1].focus()
       }
     }
   }
@@ -92,18 +92,8 @@ export const CreateDropdown = ({
     }
   }, [defaultSearchValue])
 
-  const textVariant = useMemo(() => {
-    if (size === 'large') {
-      return 'body'
-    }
-    if (size === 'medium') {
-      return 'bodySmall'
-    }
+  const textVariant = size === 'large' ? 'body' : 'bodySmall'
 
-    return 'caption'
-  }, [size])
-
-  const textVariantSmall = size === 'small' ? 'captionStrong' : 'bodySmallStrong'
   const sizeVariantIcon = size === 'small' ? 'xsmall' : 'small'
 
   const computedEmptyState = emptyState ?? (
@@ -115,7 +105,7 @@ export const CreateDropdown = ({
   const addOptionLabel = (
     <Stack alignItems="center" direction="row" gap="1">
       <PlusIcon sentiment="primary" size={sizeVariantIcon} />
-      <Text as="span" sentiment="primary" variant={textVariantSmall}>
+      <Text as="span" sentiment="primary" variant="bodySmallStrong">
         {addOption?.text} {searchInput}
       </Text>
     </Stack>

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Item.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Item.tsx
@@ -22,7 +22,7 @@ export const Item = ({
   defaultSearchValue: string | null
   focusedItemRef: RefObject<HTMLDivElement | null>
   descriptionDirection: 'column' | 'row'
-  textVariant: 'caption' | 'body' | 'bodySmall'
+  textVariant: 'body' | 'bodySmall'
   optionalInfoPlacement: 'left' | 'right'
 }) => {
   const { setIsDropdownVisible, onChange, multiselect, setSelectedData, selectedData, size } = useSelectInput()

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
@@ -11,7 +11,7 @@ type DisplayOptionProps = {
   option: OptionType
   descriptionDirection: 'row' | 'column'
   optionalInfoPlacement: 'left' | 'right'
-  textVariant: 'body' | 'bodySmall' | 'caption'
+  textVariant: 'body' | 'bodySmall'
 }
 
 export const DisplayOption = ({
@@ -20,17 +20,7 @@ export const DisplayOption = ({
   descriptionDirection,
   textVariant,
 }: DisplayOptionProps) => {
-  const captionSize = useMemo(() => {
-    if (textVariant === 'body') {
-      return 'bodySmall'
-    }
-
-    if (textVariant === 'bodySmall') {
-      return 'caption'
-    }
-
-    return 'captionSmall'
-  }, [textVariant])
+  const captionSize = useMemo(() => (textVariant === 'body' ? 'bodySmall' : 'caption'), [textVariant])
 
   const optionDescription = option.description ? (
     <Text

--- a/packages/ui/src/components/SelectInput/components/Dropdown/SelectAll.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/SelectAll.tsx
@@ -6,7 +6,7 @@ import { useSelectInput } from '../../SelectInputProvider'
 import type { OptionType } from '../../types'
 import { selectInputStyle } from '../../styles.css'
 
-export const SelectAll = ({ textVariant }: { textVariant: 'body' | 'bodySmall' | 'caption' }) => {
+export const SelectAll = ({ textVariant }: { textVariant: 'body' | 'bodySmall' }) => {
   const { onChange, options, multiselect, selectAll, setSelectedData, selectedData, size } = useSelectInput()
   const selectAllOptions = () => {
     if (multiselect) {
@@ -69,7 +69,7 @@ export const SelectAll = ({ textVariant }: { textVariant: 'body' | 'bodySmall' |
               placement="left"
               prominence="weak"
               sentiment="neutral"
-              variant={size === 'small' ? 'captionSmall' : 'bodySmall'}
+              variant={size === 'large' ? 'bodySmall' : 'caption'}
             >
               {selectAll?.description}
             </Text>

--- a/packages/ui/src/components/SelectInput/components/SelectBar/SelectBar.tsx
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/SelectBar.tsx
@@ -167,16 +167,7 @@ const SelectBar = ({
     )
   }, [multiselect, options, potentiallyNonOverflowedValues.length, selectedData.selectedValues])
 
-  const textVariant = useMemo(() => {
-    if (size === 'large') {
-      return 'body'
-    }
-    if (size === 'medium') {
-      return 'bodySmall'
-    }
-
-    return 'caption'
-  }, [size])
+  const textVariant = useMemo(() => (size === 'large' ? 'body' : 'bodySmall'), [size])
 
   return (
     <Tooltip disableAnimation text={tooltip}>

--- a/packages/ui/src/components/SelectInput/components/SelectBar/Values.tsx
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/Values.tsx
@@ -26,7 +26,7 @@ type DisplayValuesProps = {
   overflow?: boolean
   refPlusTag: RefObject<HTMLDivElement | null>
   displayShadowCopy?: boolean
-  textVariant: 'body' | 'bodySmall' | 'caption'
+  textVariant: 'body' | 'bodySmall'
 }
 
 export const DisplayValues = ({

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -1415,7 +1415,7 @@ exports[`unitInput > renders with size small 1`] = `
                 tabindex="0"
               >
                 <span
-                  class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
                 >
                   Select item
                 </span>

--- a/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -836,7 +836,7 @@ exports[`orderSummary > should work with anchors 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -1088,7 +1088,7 @@ exports[`orderSummary > should work with children 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -2436,7 +2436,7 @@ exports[`orderSummary > should work with discount 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -2627,7 +2627,7 @@ exports[`orderSummary > should work with discount in  % 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -2818,7 +2818,7 @@ exports[`orderSummary > should work with discount of 100% 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -3009,7 +3009,7 @@ exports[`orderSummary > should work with footer 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -3731,7 +3731,7 @@ exports[`orderSummary > should work with fractionDigits 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -3922,7 +3922,7 @@ exports[`orderSummary > should work with hide before price 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -4104,7 +4104,7 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -4447,7 +4447,7 @@ exports[`orderSummary > should work with price as a range 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -4630,7 +4630,7 @@ exports[`orderSummary > should work with price information 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -5352,7 +5352,7 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -6074,7 +6074,7 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -6800,7 +6800,7 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -8157,7 +8157,7 @@ exports[`orderSummary > works compact 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -8316,7 +8316,7 @@ exports[`orderSummary > works compact with total price info 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -8480,7 +8480,7 @@ exports[`orderSummary > works with calculator icon 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>
@@ -8746,7 +8746,7 @@ exports[`orderSummary > works with negative category price 1`] = `
                       tabindex="0"
                     >
                       <span
-                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+                        class="selectBar__r8qe4m style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
                       >
                         Hour(s)
                       </span>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

Correct font-sizes on small size

Affected components:
- SelectInput
- UnitInput
- Pagination

#### The following changes were made:

- update font sizes

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| SelectInput  | <img width="399" height="441" alt="image" src="https://github.com/user-attachments/assets/63e2b7d0-1dee-45de-a4ea-a54be698dadd" /> | <img width="399" height="441" alt="image" src="https://github.com/user-attachments/assets/fdc9fa07-16ca-4bd3-a758-615bf1fd9c75" /> |
| UnitInput |  <img width="609" height="234" alt="image" src="https://github.com/user-attachments/assets/df6abd3d-8af9-4ff0-9399-e7d508b2d0df" /> | <img width="609" height="234" alt="image" src="https://github.com/user-attachments/assets/7803069f-6338-4ccb-8143-f61768076b53" /> |
| Pagination | <img width="530" height="234" alt="image" src="https://github.com/user-attachments/assets/9eabf56a-300b-4710-bb2e-98218daa5d6a" /> | <img width="530" height="234" alt="image" src="https://github.com/user-attachments/assets/67699d50-ef44-4d66-b490-dbe6b6af027f" /> |

