### PR TITLE
feat(Modal): choose close button sentiment + fix border-radius

### DIFF
--- a/.changeset/floppy-parents-drop.md
+++ b/.changeset/floppy-parents-drop.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Modal`: 
+- add a prop `closeButtonSentiment` to change the sentiment of the close button to have good contrast with the background image
+- fix the top border radius when using a background image

--- a/packages/ui/src/components/Modal/ModalContent.tsx
+++ b/packages/ui/src/components/Modal/ModalContent.tsx
@@ -41,6 +41,7 @@ export const ModalContent = ({
   handleToggle,
   finalId,
   image,
+  closeButtonSentiment,
   style,
   ref,
   isDrawer,
@@ -79,7 +80,7 @@ export const ModalContent = ({
             aria-label="close"
             data-testid={dataTestId ? `${dataTestId}-close-button` : undefined}
             onClick={handleClose}
-            sentiment="neutral"
+            sentiment={closeButtonSentiment}
             size="small"
             variant="ghost"
           >

--- a/packages/ui/src/components/Modal/__stories__/Image.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/Image.stories.tsx
@@ -9,7 +9,13 @@ import imageCorrectFormat from './assets/illustrationCorrectFormat.webp'
 
 export const Image: StoryFn = props => (
   <Stack direction="row" gap={2}>
-    <Modal disclosure={<Button>Open Modal with image (incorrect ratio)</Button>} image={image} size="medium" {...props}>
+    <Modal
+      disclosure={<Button>Open Modal with image (incorrect ratio)</Button>}
+      image={image}
+      size="medium"
+      closeButtonSentiment="white"
+      {...props}
+    >
       <Stack direction="column" gap="2">
         <Badge prominence="strong" sentiment="warning">
           Beta
@@ -27,6 +33,7 @@ export const Image: StoryFn = props => (
     <Modal
       disclosure={<Button>Open Modal with image (correct ratio)</Button>}
       image={imageCorrectFormat}
+      closeButtonSentiment="white"
       size="xsmall"
       {...props}
     >

--- a/packages/ui/src/components/Modal/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Modal/__tests__/index.test.tsx
@@ -124,8 +124,8 @@ describe('modal', () => {
         container: document.body,
       },
     )
-    await userEvent.click(screen.getByText('Open modal'))
-    const closeButton = screen.getByTestId('test-close-button')
+    await userEvent.click(screen.getByRole('button', { name: 'Open modal' }))
+    const closeButton = screen.getByRole('button', { name: 'close' })
     await userEvent.click(closeButton)
     expect(count).toBe(1)
 
@@ -152,11 +152,30 @@ describe('modal', () => {
       },
     )
 
-    await userEvent.click(screen.getByText('Open modal'))
-    const closeButton = screen.getByTestId('test-close-button')
+    await userEvent.click(screen.getByRole('button', { name: 'Open modal' }))
+    const closeButton = screen.getByRole('button', { name: 'close' })
     await userEvent.click(closeButton)
     expect(count).toBe(1)
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should allow to change the sentiment of the close button on dark background image', async () => {
+    renderWithTheme(
+      <Modal
+        ariaLabel="modal-test"
+        disclosure={<button type="button">Open modal</button>}
+        image="dark-image.png"
+        closeButtonSentiment="white"
+      >
+        <div>modal</div>
+      </Modal>,
+      consoleLightTheme,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open modal' }))
+
+    const closeButton = screen.getByRole('button', { name: 'close' })
+    expect(closeButton.className).toContain('sentiment_white')
   })
 
   it('disclosure function render onClick props is called', async () => {

--- a/packages/ui/src/components/Modal/index.tsx
+++ b/packages/ui/src/components/Modal/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useContext, useId, useRef, useState } from 'react'
+import { Fragment, useCallback, useContext, useId, useRef, useState } from 'react'
 import type { CSSProperties, ReactElement, ReactNode, RefObject } from 'react'
 import { Disclosure } from './components/Disclosure'
 import { ModalContent } from './ModalContent'
@@ -15,6 +15,14 @@ export type ModalProps = {
   ariaLabel?: string
   disclosure?: ReactElement | ((state: ModalState) => ReactElement)
   isClosable?: boolean
+  /**
+   * When using a background image, set the sentiment of the close button so that it has a good contrast with the image:
+   * - 'neutral': default value for when there is no background image
+   * - 'black': use on light images
+   * - 'white': use on dark images
+   * @default 'neutral'
+   */
+  closeButtonSentiment?: 'neutral' | 'black' | 'white'
   onClose?: () => void
   onOpen?: () => void
   onBeforeClose?: () => Promise<void> | void
@@ -46,6 +54,7 @@ export const Modal = ({
   hideOnClickOutside = true,
   hideOnEsc = true,
   isClosable = true,
+  closeButtonSentiment = 'neutral',
   onClose,
   onBeforeClose,
   onOpen,
@@ -95,6 +104,8 @@ export const Modal = ({
   // the first modal to render will create the context, and the others will use it.
   const context = useContext(ModalContext)
 
+  const Container = context ? Fragment : ModalProvider
+
   return (
     <>
       {disclosure ? (
@@ -108,7 +119,7 @@ export const Modal = ({
           visible={visible}
         />
       ) : null}
-      {context ? (
+      <Container>
         <ModalContent
           ariaLabel={ariaLabel}
           backdropClassName={backdropClassName}
@@ -122,6 +133,7 @@ export const Modal = ({
           hideOnClickOutside={hideOnClickOutside}
           hideOnEsc={hideOnEsc}
           image={image}
+          closeButtonSentiment={closeButtonSentiment}
           isClosable={isClosable}
           isDrawer={isDrawer}
           open={open}
@@ -133,34 +145,7 @@ export const Modal = ({
         >
           {children}
         </ModalContent>
-      ) : (
-        <ModalProvider>
-          <ModalContent
-            ariaLabel={ariaLabel}
-            backdropClassName={backdropClassName}
-            className={className}
-            dataTestId={dataTestId}
-            finalId={finalId}
-            finalSize={size}
-            handleClose={handleClose}
-            handleOpen={handleOpen}
-            handleToggle={handleToggle}
-            hideOnClickOutside={hideOnClickOutside}
-            hideOnEsc={hideOnEsc}
-            image={image}
-            isClosable={isClosable}
-            isDrawer={isDrawer}
-            open={open}
-            placement={placement}
-            preventBodyScroll={preventBodyScroll}
-            ref={ref}
-            style={style}
-            visible={visible}
-          >
-            {children}
-          </ModalContent>
-        </ModalProvider>
-      )}
+      </Container>
     </>
   )
 }

--- a/packages/ui/src/components/Modal/styles.css.ts
+++ b/packages/ui/src/components/Modal/styles.css.ts
@@ -17,6 +17,8 @@ const container = style({
 
 const imageContainer = style({
   backgroundColor: theme.colors.primary.background,
+  borderTopLeftRadius: 'inherit',
+  borderTopRightRadius: 'inherit',
   height: '15rem',
   overflow: 'hidden',
   width: '100%',


### PR DESCRIPTION
## Summary

## Type

- Bug
- Feature

### Summarize concisely:

#### What is expected?

- correct border-radius on the top when using an image
- ability to have a light close button on dark images

#### The following changes were made:

- fix styles
- add a prop `closeButtonSentiment` on the Modal
- update tests

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="460" height="134" alt="image" src="https://github.com/user-attachments/assets/97c3f282-d180-411b-a6b2-ed6fa862a25f" /> | <img width="460" height="134" alt="image" src="https://github.com/user-attachments/assets/89f23092-5595-474f-9602-319d391540f1" /> |
