### PR TITLE
fix(CodeEditor): fix the position of the tooltip on the CopyButton

### DIFF
--- a/.changeset/three-mice-vanish.md
+++ b/.changeset/three-mice-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`CodeEditor`: fix the position of the tooltip on the CopyButton

--- a/packages/ui/src/components/Popup/styles.css.ts
+++ b/packages/ui/src/components/Popup/styles.css.ts
@@ -2,6 +2,7 @@ import { theme } from '@ultraviolet/themes'
 import { keyframes, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 import { DEFAULT_ARROW_WIDTH } from './helpers'
+import { codeEditorStyle } from '../../compositions/CodeEditor/styles.css'
 import { tagStyle } from '../Tag/styles.css'
 import { tagListStyle } from '../TagList/styles.css'
 import { textStyle } from '../Text/style.css'
@@ -124,6 +125,11 @@ const childrenContainer = recipe({
       },
       [`&:has(.${textStyle.oneLine})`]: {
         minWidth: 0,
+      },
+      [`&:has(> ${codeEditorStyle.copyButton})`]: {
+        position: 'absolute',
+        right: theme.space[1],
+        top: theme.space[1],
       },
     },
   },

--- a/packages/ui/src/components/Popup/styles.css.ts
+++ b/packages/ui/src/components/Popup/styles.css.ts
@@ -2,7 +2,6 @@ import { theme } from '@ultraviolet/themes'
 import { keyframes, styleVariants } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 import { DEFAULT_ARROW_WIDTH } from './helpers'
-import { codeEditorStyle } from '../../compositions/CodeEditor/styles.css'
 import { tagStyle } from '../Tag/styles.css'
 import { tagListStyle } from '../TagList/styles.css'
 import { textStyle } from '../Text/style.css'
@@ -125,11 +124,6 @@ const childrenContainer = recipe({
       },
       [`&:has(.${textStyle.oneLine})`]: {
         minWidth: 0,
-      },
-      [`&:has(> ${codeEditorStyle.copyButton})`]: {
-        position: 'absolute',
-        right: theme.space[1],
-        top: theme.space[1],
       },
     },
   },

--- a/packages/ui/src/compositions/CodeEditor/styles.css.ts
+++ b/packages/ui/src/compositions/CodeEditor/styles.css.ts
@@ -8,19 +8,26 @@ export const disabledStack = style({ cursor: 'not-allowed' })
 const copyButton = style({
   backgroundColor: consoleDarkTheme.colors.neutral.backgroundWeak,
   color: consoleDarkTheme.colors.neutral.textStrong,
-  position: 'absolute',
-  right: theme.space[1],
   selectors: {
     '&:hover': {
       backgroundColor: consoleDarkTheme.colors.neutral.backgroundHover,
       color: consoleDarkTheme.colors.neutral.textStrongHover,
     },
   },
+})
+
+// FIXME: remove this patch when we fix the Tooltip so that it doesn't generate a div around the button
+globalStyle(`div[aria-describedby]:has(> ${copyButton})`, {
+  position: 'absolute',
+  right: theme.space[1],
   top: theme.space[1],
 })
 
-globalStyle(`${copyButton} svg > path`, {
-  fill: consoleDarkTheme.colors.other.icon.product.original.fill,
+// FIXME: put this fallback style back in the button when the Tooltip is fixed
+globalStyle(`div:not([aria-describedby]) > ${copyButton}`, {
+  position: 'absolute',
+  right: theme.space[1],
+  top: theme.space[1],
 })
 
 const codeEditorBase = style({

--- a/packages/ui/src/compositions/CodeEditor/styles.css.ts
+++ b/packages/ui/src/compositions/CodeEditor/styles.css.ts
@@ -16,6 +16,13 @@ const copyButton = style({
   },
 })
 
+// FIXME: remove this patch when we fix the Tooltip so that it doesn't generate a div around the button
+globalStyle(`div[aria-describedby]:has(> ${copyButton})`, {
+  position: 'absolute',
+  right: theme.space[1],
+  top: theme.space[1],
+})
+
 // FIXME: put this fallback style back in the button when the Tooltip is fixed
 globalStyle(`div:not([aria-describedby]) > ${copyButton}`, {
   position: 'absolute',

--- a/packages/ui/src/compositions/CodeEditor/styles.css.ts
+++ b/packages/ui/src/compositions/CodeEditor/styles.css.ts
@@ -16,13 +16,6 @@ const copyButton = style({
   },
 })
 
-// FIXME: remove this patch when we fix the Tooltip so that it doesn't generate a div around the button
-globalStyle(`div[aria-describedby]:has(> ${copyButton})`, {
-  position: 'absolute',
-  right: theme.space[1],
-  top: theme.space[1],
-})
-
 // FIXME: put this fallback style back in the button when the Tooltip is fixed
 globalStyle(`div:not([aria-describedby]) > ${copyButton}`, {
   position: 'absolute',


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

The tooltip on the CopyButton in the CodeEditor is correctly positionned

#### The following changes were made:

(Describe what you did)

- add the positionning style on the div generated by the tooltip
- add a fallback style on the button to avoid breaking it if we forget to update the style when the Tooltip is fixed

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="818" height="427" alt="image" src="https://github.com/user-attachments/assets/942108c5-1847-475a-863a-eff56aadf568" /> | <img width="818" height="427" alt="image" src="https://github.com/user-attachments/assets/55262be3-8475-4f73-91b1-5f3e0393f0bd" /> |

