### PR TITLE
fix(OfferList): disable expand on a row

### DIFF
--- a/.changeset/twelve-years-see.md
+++ b/.changeset/twelve-years-see.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`OfferList`: disabled expand button on a row when `expandable={false}`

--- a/packages/ui/src/compositions/OfferList/__stories__/Expandable.stories.tsx
+++ b/packages/ui/src/compositions/OfferList/__stories__/Expandable.stories.tsx
@@ -6,7 +6,12 @@ import { columns, data } from './resources'
 export const Expandable: StoryFn<ComponentProps<typeof OfferList>> = props => (
   <OfferList {...props} expandable>
     {data.map(planet => (
-      <OfferList.Row expandable="expand content" id={planet.id} key={planet.id} offerName={planet.id}>
+      <OfferList.Row
+        expandable={planet.id === 'mars' ? false : 'Expand content'}
+        id={planet.id}
+        key={planet.id}
+        offerName={planet.id}
+      >
         <OfferList.Cell>{planet.name}</OfferList.Cell>
         <OfferList.Cell>{planet.perihelion}AU</OfferList.Cell>
         <OfferList.Cell>{planet.aphelion}AU</OfferList.Cell>

--- a/packages/ui/src/compositions/OfferList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/OfferList/__tests__/__snapshots__/index.test.tsx.snap
@@ -5902,6 +5902,951 @@ exports[`offerList > should work with expandable 1`] = `
 </DocumentFragment>
 `;
 
+exports[`offerList > should work with expandable false on a row 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <div
+      class="styles__inoh541"
+    >
+      <table
+        class="styles__6c7s4u1 styles__inoh542"
+      >
+        <thead>
+          <tr
+            class="styles__inoh546"
+          >
+            <th
+              class="styles__inoh545"
+              tabindex="-1"
+            >
+              <div
+                class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+              />
+            </th>
+            <th
+              class="styles__inoh545"
+              tabindex="-1"
+            >
+              <div
+                class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+              />
+            </th>
+            <th
+              class="styles__inoh545"
+              tabindex="-1"
+            >
+              <div
+                class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+              >
+                Solar system Planet
+              </div>
+            </th>
+            <th
+              class="styles__inoh545"
+              style="--_1431nf60: 200px;"
+              tabindex="-1"
+            >
+              <div
+                class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+              >
+                Perihelion
+              </div>
+            </th>
+            <th
+              class="styles__inoh545"
+              style="--_1431nf60: 200px;"
+              tabindex="-1"
+            >
+              <div
+                class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+              >
+                Aphelion
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-mercury"
+                      class="styles__17da2jl6"
+                      id="mercury"
+                      name="radio-offer-list-mercury"
+                      type="radio"
+                      value="mercury"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Mercury
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              0.307AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              0.467AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-venus"
+                      class="styles__17da2jl6"
+                      id="venus"
+                      name="radio-offer-list-venus"
+                      type="radio"
+                      value="venus"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Venus
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              0.718AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              0.728AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-home-sweet-home"
+                      class="styles__17da2jl6"
+                      id="home-sweet-home"
+                      name="radio-offer-list-home-sweet-home"
+                      type="radio"
+                      value="home-sweet-home"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Earth
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              0.983AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              1.017AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-mars"
+                      class="styles__17da2jl6"
+                      id="mars"
+                      name="radio-offer-list-mars"
+                      type="radio"
+                      value="mars"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Mars
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              1.381AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              1.666AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-jupiter"
+                      class="styles__17da2jl6"
+                      id="jupiter"
+                      name="radio-offer-list-jupiter"
+                      type="radio"
+                      value="jupiter"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Jupiter
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              4.951AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              5.457AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-saturn"
+                      class="styles__17da2jl6"
+                      id="saturn"
+                      name="radio-offer-list-saturn"
+                      type="radio"
+                      value="saturn"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Saturn
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              9.041AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              10.124AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-uranus"
+                      class="styles__17da2jl6"
+                      id="uranus"
+                      name="radio-offer-list-uranus"
+                      type="radio"
+                      value="uranus"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Uranus
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              18.286AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              20.097AU
+            </td>
+          </tr>
+          <tr
+            class="styles__6c7s4u16 styles__inoh54b styles__inoh54a styles_sentiment_neutral__inoh54f"
+            data-highlight="false"
+            tabindex="-1"
+          >
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <div
+                class="styles__6c7s4u19"
+              >
+                <div
+                  class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+                >
+                  <div
+                    aria-disabled="false"
+                    class="styles__17da2jl2"
+                    data-checked="false"
+                    data-invalid="false"
+                  >
+                    <input
+                      aria-disabled="false"
+                      aria-label="select-id-neptune"
+                      class="styles__17da2jl6"
+                      id="id-neptune"
+                      name="radio-offer-list-id-neptune"
+                      type="radio"
+                      value="id-neptune"
+                    />
+                    <svg
+                      class="styles__17da2jl7"
+                      viewBox="0 0 24 24"
+                    >
+                      <title>
+                        radio
+                      </title>
+                      <g>
+                        <circle
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke-width="2"
+                        />
+                        <circle
+                          class="styles__17da2jl9"
+                          cx="12"
+                          cy="12"
+                          r="8"
+                        />
+                        <circle
+                          class="styles__17da2jl8"
+                          cx="12"
+                          cy="12"
+                          r="5"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td
+              class="styles__6c7s4u13 styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              <button
+                aria-label="expand"
+                class="styles__e1wcoe0 styles_disabled_true__e1wcoe2 styles_fullWidth_false__e1wcoe3 styles_sentiment_neutral__e1wcoe8 styles_size_small__e1wcoeg styles_variant_ghost__e1wcoej styles_undefined_compound_24__e1wcoe19"
+                data-testid="list-expand-button"
+                disabled=""
+                type="button"
+              >
+                <svg
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  width="16"
+                >
+                  <title>
+                    ArrowDownIcon
+                  </title>
+                  <path
+                    clip-rule="evenodd"
+                    d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06"
+                    fill-rule="evenodd"
+                  />
+                </svg>
+              </button>
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              Neptune
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              29.81AU
+            </td>
+            <td
+              class="styles__6c7s4u1b styles__inoh54k"
+              style="--_1431nf64: auto; --_1431nf66: auto; --_1431nf65: none; --_1431nf67: auto; --_1431nf68: none; --_1431nf69: auto;"
+            >
+              30.33AU
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`offerList > should work with selectable - checkbox 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ui/src/compositions/OfferList/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/OfferList/__tests__/index.test.tsx
@@ -1,13 +1,13 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { renderWithTheme, shouldMatchSnapshot } from '@utils/test'
+import { renderWithTheme } from '@utils/test'
 import { describe, expect, it, vi } from 'vitest'
 import { OfferList } from '..'
 import { columns, data } from './resources'
 
 describe('offerList', () => {
-  it('should work with default props', () =>
-    shouldMatchSnapshot(
+  it('should work with default props', () => {
+    const { asFragment } = renderWithTheme(
       <OfferList columns={columns}>
         {data.map(planet => (
           <OfferList.Row id={planet.id} key={planet.id} offerName={planet.id}>
@@ -17,10 +17,13 @@ describe('offerList', () => {
           </OfferList.Row>
         ))}
       </OfferList>,
-    ))
+    )
 
-  it('should work with sentiment', () =>
-    shouldMatchSnapshot(
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should work with sentiment', () => {
+    const { asFragment } = renderWithTheme(
       <OfferList columns={columns}>
         {data.map(planet => (
           <OfferList.Row id={planet.id} key={planet.id} offerName={planet.id}>
@@ -30,10 +33,13 @@ describe('offerList', () => {
           </OfferList.Row>
         ))}
       </OfferList>,
-    ))
+    )
 
-  it('should work with banner', () =>
-    shouldMatchSnapshot(
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should work with banner', () => {
+    const { asFragment } = renderWithTheme(
       <OfferList columns={columns} expandable>
         {data.map(planet => (
           <OfferList.Row
@@ -53,10 +59,12 @@ describe('offerList', () => {
           </OfferList.Row>
         ))}
       </OfferList>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('should work with banner open', () =>
-    shouldMatchSnapshot(
+  it('should work with banner open', () => {
+    const { asFragment } = renderWithTheme(
       <OfferList columns={columns} expandable>
         {data.map(planet => (
           <OfferList.Row
@@ -74,10 +82,13 @@ describe('offerList', () => {
           </OfferList.Row>
         ))}
       </OfferList>,
-    ))
+    )
 
-  it('should work with badge', () =>
-    shouldMatchSnapshot(
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should work with badge', () => {
+    const { asFragment } = renderWithTheme(
       <OfferList columns={columns} expandable>
         {data.map(planet => (
           <OfferList.Row
@@ -93,10 +104,13 @@ describe('offerList', () => {
           </OfferList.Row>
         ))}
       </OfferList>,
-    ))
+    )
 
-  it('should work loading', () =>
-    shouldMatchSnapshot(
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should work loading', () => {
+    const { asFragment } = renderWithTheme(
       <OfferList columns={columns} loading>
         {data.map(planet => (
           <OfferList.Row id={planet.id} key={planet.id} offerName={planet.id}>
@@ -106,7 +120,10 @@ describe('offerList', () => {
           </OfferList.Row>
         ))}
       </OfferList>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
   it('should work with selectable - radio', async () => {
     const onChange = vi.fn()
     const { asFragment } = renderWithTheme(
@@ -173,7 +190,7 @@ describe('offerList', () => {
       </OfferList>,
     )
 
-    const expandButton = screen.getAllByTestId('list-expand-button')[0]
+    const expandButton = screen.getAllByRole('button', { name: 'expand' })[0]
     await userEvent.click(expandButton)
 
     const expandText = screen.getByText('expandable content')
@@ -184,9 +201,27 @@ describe('offerList', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
+  it('should work with expandable false on a row', () => {
+    const { asFragment } = renderWithTheme(
+      <OfferList columns={columns} expandable>
+        {data.map(planet => (
+          <OfferList.Row expandable={false} id={planet.id} key={planet.id} offerName={planet.id}>
+            <OfferList.Cell>{planet.name}</OfferList.Cell>
+            <OfferList.Cell>{planet.perihelion}AU</OfferList.Cell>
+            <OfferList.Cell>{planet.aphelion}AU</OfferList.Cell>
+          </OfferList.Row>
+        ))}
+      </OfferList>,
+    )
+
+    const expandButton = screen.getAllByRole('button', { name: 'expand' })[0]
+    expect(expandButton).toBeDisabled()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
   it('should throw an error when using OfferList.Row outside OfferList', () => {
     expect(() =>
-      shouldMatchSnapshot(
+      renderWithTheme(
         <OfferList.Row id="cell" offerName="cell">
           <OfferList.Cell>a cell</OfferList.Cell>
         </OfferList.Row>,

--- a/packages/ui/src/compositions/OfferList/components/Row.tsx
+++ b/packages/ui/src/compositions/OfferList/components/Row.tsx
@@ -185,7 +185,7 @@ export const Row = ({
             <Button
               aria-label="expand"
               data-testid="list-expand-button"
-              disabled={(disabled ?? !expandable) || loading}
+              disabled={(disabled ?? !expandableContent) || loading}
               onClick={event => {
                 event.stopPropagation()
                 toggleRowExpand()


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
- `OfferList`: disabled expand button on a row when `expandable={false}`
- Update OfferList tests to use `renderWithTheme` instead of `shouldMatchSnapshot` (deprecated)