### PR TITLE
fix(PhoneInputField): source import

### DIFF
--- a/.changeset/two-drinks-ring.md
+++ b/.changeset/two-drinks-ring.md
@@ -1,5 +1,0 @@
----
-"@ultraviolet/form": patch
----
-
-`PhoneInputField`: fix field type imports to prevent `@ultraviolet/form` from importing itself

--- a/.changeset/two-drinks-ring.md
+++ b/.changeset/two-drinks-ring.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`PhoneInputField`: fix field type imports to prevent `@ultraviolet/form` from importing itself

--- a/packages/form/src/components/PhoneInputField/index.tsx
+++ b/packages/form/src/components/PhoneInputField/index.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { parsePhoneNumber } from '@scaleway/phonenumber'
-import type { BaseFieldProps, FieldPath, FieldValues } from '@ultraviolet/form'
 import { PhoneInput } from '@ultraviolet/ui'
 import type { ComponentProps } from 'react'
+import type { FieldPath, FieldValues } from 'react-hook-form'
 import { useController } from 'react-hook-form'
 import { useErrors } from '../../providers'
+import type { BaseFieldProps } from '../../types'
 
 type PhoneInputValue = NonNullable<ComponentProps<typeof PhoneInput>['value']>
 


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:
`PhoneInputField`: fix field type imports to prevent `@ultraviolet/form` from importing itself