### PR TITLE
fix: remove small description on inputs

### DIFF
--- a/.changeset/famous-worlds-bow.md
+++ b/.changeset/famous-worlds-bow.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+`Description`: inputs should not use small description as it is hard to read

--- a/packages/ui/src/components/FileInput/index.tsx
+++ b/packages/ui/src/components/FileInput/index.tsx
@@ -174,7 +174,7 @@ const FileInputBase = ({
   const computedChildren = typeof children === 'function' ? children(inputId, inputRef) : children
 
   const computedHelper = (
-    <Description error={error} helper={helper} id={ariaDescribedBy ?? helperId} size={size} disabled={disabled} />
+    <Description error={error} helper={helper} id={ariaDescribedBy ?? helperId} disabled={disabled} />
   )
 
   const input = (

--- a/packages/ui/src/components/NumberInput/index.tsx
+++ b/packages/ui/src/components/NumberInput/index.tsx
@@ -227,7 +227,6 @@ export const NumberInput = forwardRef(
           error={error}
           helper={helper}
           disabled={isDisabledOrReadOnly}
-          size={size}
           success={success}
           id={ariaDescribedBy ?? helperId}
         />

--- a/packages/ui/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/ui/src/components/PhoneInput/PhoneInput.tsx
@@ -220,7 +220,6 @@ export const PhoneInput: PhoneInputType = forwardRef(
           helper={helper}
           error={error}
           success={success}
-          size={size}
           disabled={disabled}
           id={ariaDescribedBy ?? helperId}
         />

--- a/packages/ui/src/components/SelectInput/index.tsx
+++ b/packages/ui/src/components/SelectInput/index.tsx
@@ -271,7 +271,6 @@ export const SelectInput = <IsMulti extends undefined | boolean>({
           error={error}
           success={success}
           helper={helper}
-          size={size}
           disabled={disabled}
           id={ariaDescribedBy ?? helperId}
           className={selectInputStyle.helper}

--- a/packages/ui/src/components/SelectableCardOptionGroup/SelectableCardOptionGroup.tsx
+++ b/packages/ui/src/components/SelectableCardOptionGroup/SelectableCardOptionGroup.tsx
@@ -95,7 +95,7 @@ const SelectableCardOptionGroupComponent = ({
             </Row>
           </Stack>
         </fieldset>
-        <Description id={ariaDescribedBy ?? helperId} error={error} helper={helper} disabled={disabled} size={size} />
+        <Description id={ariaDescribedBy ?? helperId} error={error} helper={helper} disabled={disabled} />
       </Stack>
     </SelectableCardOptionGroupContext.Provider>
   )

--- a/packages/ui/src/components/TagInput/index.tsx
+++ b/packages/ui/src/components/TagInput/index.tsx
@@ -268,7 +268,6 @@ export const TagInput = ({
         success={success}
         id={ariaDescribedBy ?? helperId}
         disabled={disabled || readOnly}
-        size={size}
       />
     </Stack>
   )

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -191,7 +191,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           helper={helper}
           error={error}
           success={success}
-          size={size}
           disabled={disabled}
           id={ariaDescribedBy ?? helperId}
         />

--- a/packages/ui/src/components/TimeInput/index.tsx
+++ b/packages/ui/src/components/TimeInput/index.tsx
@@ -428,7 +428,7 @@ export const TimeInput = ({
           />
         ) : null}
       </Stack>
-      <Description error={error} helper={helper} disabled={disabled} size={size} id={ariaDescribedBy ?? helperId} />
+      <Description error={error} helper={helper} disabled={disabled} id={ariaDescribedBy ?? helperId} />
     </Stack>
   )
 }

--- a/packages/ui/src/components/Toggle/index.tsx
+++ b/packages/ui/src/components/Toggle/index.tsx
@@ -108,13 +108,7 @@ export const Toggle = forwardRef(
                 ) : null}
               </Row>
             ) : null}
-            <Description
-              helper={helper}
-              error={error}
-              id={ariaDescribedBy ?? helperId}
-              disabled={disabled}
-              size={size}
-            />
+            <Description helper={helper} error={error} id={ariaDescribedBy ?? helperId} disabled={disabled} />
           </Stack>
           <div
             className={toggleStyle.toggle({

--- a/packages/ui/src/components/UnitInput/index.tsx
+++ b/packages/ui/src/components/UnitInput/index.tsx
@@ -202,7 +202,6 @@ export const UnitInput = ({
         error={error}
         success={success}
         disabled={disabled}
-        size={size}
         id={ariaDescribedBy ?? helperId}
       />
     </Stack>

--- a/packages/ui/src/compositions/OptionSelector/index.tsx
+++ b/packages/ui/src/compositions/OptionSelector/index.tsx
@@ -175,7 +175,6 @@ export const OptionSelector = ({
           error={firstSelector.error}
           helper={firstSelector.helper}
           id={firstSelectorHelperId}
-          size={size}
           disabled={firstSelector.disabled || disabled}
           className={optionSelectorStyle.errorFirstSelector}
         />
@@ -185,7 +184,6 @@ export const OptionSelector = ({
           error={secondSelector.error}
           helper={secondSelector.helper}
           id={secondSelectorHelperId}
-          size={size}
           disabled={secondSelector.disabled || disabled}
           className={optionSelectorStyle.errorSecondSelector}
         />


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?
`Description`: inputs should not use small description as it is hard to read
