### PR TITLE
fix(FileInput): accept

### DIFF
--- a/.changeset/fast-boats-allow.md
+++ b/.changeset/fast-boats-allow.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`FileInput`: fix "accept" behavior issue with explicit types ('.mp3', '.png')

--- a/packages/ui/src/components/FileInput/__tests__/index.test.tsx
+++ b/packages/ui/src/components/FileInput/__tests__/index.test.tsx
@@ -374,7 +374,7 @@ describe('fileInput', () => {
 
   it('should add a file with drag and drop which when accept is defined and precise', () => {
     const onChangeFiles = vi.fn()
-    renderWithTheme(<FileInput accept="image/png, .mp3" aria-label="label" onChangeFiles={onChangeFiles} />)
+    renderWithTheme(<FileInput accept=".mp3, image/png" aria-label="label" onChangeFiles={onChangeFiles} />)
 
     const dropzone = screen.getByTestId('drag-container')
     const file = new File(['dnd'], 'dnd.png', { type: 'image/png' })

--- a/packages/ui/src/components/FileInput/helpers.ts
+++ b/packages/ui/src/components/FileInput/helpers.ts
@@ -48,8 +48,8 @@ export const fileIsAccepted = (file: File, accept?: string) => {
       }
     } else if (fileType === item) {
       return true
-    } else if (item.startsWith('.')) {
-      return fileName.toLocaleLowerCase().endsWith(item)
+    } else if (item.startsWith('.') && fileName.toLocaleLowerCase().endsWith(item)) {
+      return true
     }
   }
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`FileInput`: fix "accept" behavior issue with explicit types ('.mp3', '.png')