### PR TITLE
feat(selectable-card-group): add Label component

### DIFF
--- a/packages/form/src/components/SelectableCardGroupField/SelectableCardGroupField.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/SelectableCardGroupField.tsx
@@ -74,8 +74,10 @@ const SelectableCardGroupFieldComponent = <
 
 type SelectableCardGroupFieldType = typeof SelectableCardGroupFieldComponent & {
   Card: typeof SelectableCardGroup.Card
+  Label: typeof SelectableCardGroup.Label
 }
 
 export const SelectableCardGroupField: SelectableCardGroupFieldType = Object.assign(SelectableCardGroupFieldComponent, {
   Card: SelectableCardGroup.Card,
+  Label: SelectableCardGroup.Label,
 })

--- a/packages/form/src/components/SelectableCardGroupField/__stories__/WithLabel.stories.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/__stories__/WithLabel.stories.tsx
@@ -1,0 +1,40 @@
+import type { StoryFn } from '@storybook/react-vite'
+import type { ComponentProps } from 'react'
+import { SelectableCardGroupField } from '../..'
+
+export const WithLabel: StoryFn<ComponentProps<typeof SelectableCardGroupField>> = args => (
+  <SelectableCardGroupField {...args}>
+    <SelectableCardGroupField.Card
+      label={
+        <SelectableCardGroupField.Label
+          label="Option avec Badge"
+          labelDescription="Description de l'option"
+          badgeText="Nouveau"
+          badgeSentiment="primary"
+        />
+      }
+      value="value-1"
+    />
+    <SelectableCardGroupField.Card
+      label={
+        <SelectableCardGroupField.Label
+          label="Option avec Badge et Side Text"
+          badgeText="Populaire"
+          badgeSentiment="success"
+          sideText="5€"
+        />
+      }
+      value="value-2"
+    />
+    <SelectableCardGroupField.Card
+      label={<SelectableCardGroupField.Label label="Option simple" labelDescription="Sans badge" />}
+      value="value-3"
+    />
+  </SelectableCardGroupField>
+)
+
+WithLabel.args = {
+  legend: 'Sélectionnez une option',
+  name: 'withLabel',
+  type: 'radio',
+}

--- a/packages/ui/src/components/Badge/index.tsx
+++ b/packages/ui/src/components/Badge/index.tsx
@@ -8,7 +8,7 @@ import { TEXT_VARIANT } from './constant'
 import { badgeStyle } from './styles.css'
 import type { BadgeVariants } from './styles.css'
 
-type BadgeProps = {
+export type BadgeProps = {
   className?: string
   children: ReactNode
   'data-testid'?: string

--- a/packages/ui/src/components/SelectableCardGroup/Label.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/Label.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import type { BadgeProps } from '../Badge'
+import { Badge } from '../Badge'
+import { Stack } from '../Stack'
+import { Text } from '../Text'
+
+type SelectableCardGroupLabelProps = {
+  label: ReactNode
+  labelDescription?: ReactNode
+  badgeText?: ReactNode
+  badgeProminence?: BadgeProps['prominence']
+  badgeSentiment?: BadgeProps['sentiment']
+  badgeSize?: BadgeProps['size']
+  sideText?: ReactNode
+  disabled?: boolean
+}
+
+export const SelectableCardGroupLabel = ({
+  label,
+  labelDescription,
+  badgeText,
+  badgeProminence = 'default',
+  badgeSentiment = 'neutral',
+  badgeSize = 'medium',
+  sideText,
+  disabled = false,
+}: SelectableCardGroupLabelProps) => (
+  <Stack alignItems="center" direction="row" gap={1}>
+    <Stack alignItems="center" direction="row" gap={0.5}>
+      {label}
+      {labelDescription && typeof labelDescription === 'function' ? labelDescription : null}
+      {labelDescription && typeof labelDescription !== 'function' ? (
+        <Text as="span" disabled={disabled} variant="body">
+          {labelDescription}
+        </Text>
+      ) : null}
+      {badgeText ? (
+        <Badge disabled={disabled} prominence={badgeProminence} sentiment={badgeSentiment} size={badgeSize}>
+          {badgeText}
+        </Badge>
+      ) : null}
+    </Stack>
+    {sideText ? (
+      <Text as="span" disabled={disabled} sentiment="primary" variant="bodySmallStronger">
+        {sideText}
+      </Text>
+    ) : null}
+  </Stack>
+)

--- a/packages/ui/src/components/SelectableCardGroup/__stories__/WithLabel.stories.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/__stories__/WithLabel.stories.tsx
@@ -1,0 +1,48 @@
+import type { StoryFn } from '@storybook/react-vite'
+import { useState } from 'react'
+import { SelectableCardGroup } from '..'
+
+export const WithLabel: StoryFn<typeof SelectableCardGroup> = args => {
+  const [value, onChange] = useState('value-1')
+
+  return (
+    <SelectableCardGroup
+      {...args}
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) => onChange(event.currentTarget.value)}
+      value={value}
+    >
+      <SelectableCardGroup.Card
+        label={
+          <SelectableCardGroup.Label
+            label="Option avec Badge"
+            labelDescription="Description de l'option"
+            badgeText="Nouveau"
+            badgeSentiment="primary"
+          />
+        }
+        value="value-1"
+      />
+      <SelectableCardGroup.Card
+        label={
+          <SelectableCardGroup.Label
+            label="Option avec Badge et Side Text"
+            badgeText="Populaire"
+            badgeSentiment="success"
+            sideText="5€"
+          />
+        }
+        value="value-2"
+      />
+      <SelectableCardGroup.Card
+        label={<SelectableCardGroup.Label label="Option simple" labelDescription="Sans badge" />}
+        value="value-3"
+      />
+    </SelectableCardGroup>
+  )
+}
+
+WithLabel.args = {
+  legend: 'Sélectionnez une option',
+  name: 'with-label',
+  type: 'radio',
+}

--- a/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,239 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`selectableCardGroup > renders Label with function as labelDescription 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <div
+      class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
+    >
+      <fieldset
+        class="styles__7j58nd0"
+      >
+        <div
+          class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.75rem_xxsmall__toi52u5p"
+        >
+          <legend
+            class="styles_default__17td3g90 style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+          >
+            Label
+          </legend>
+          <div
+            class="styles__x6hyh50 styles_gap_1rem_xxsmall__x6hyh52p"
+            style="--_3mg8xe0: repeat(1, minmax(0, 1fr)); --_3mg8xe1: repeat(1, minmax(0, 1fr)); --_3mg8xe2: repeat(1, minmax(0, 1fr)); --_3mg8xe3: repeat(1, minmax(0, 1fr)); --_3mg8xe4: repeat(1, minmax(0, 1fr)); --_3mg8xe5: repeat(1, minmax(0, 1fr));"
+          >
+            <div
+              class="styles__475tnd0 styles_cursor_custom__475tnd1 styles_image_none__475tnd5 styles__475tnd6 styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+              data-checked="true"
+              data-disabled="false"
+              data-error="false"
+              data-type="radio"
+              role="button"
+              style="--_4k0ekn3: 1; --_18vc4d30: none; --_18vc4d31: inline; --_18vc4d32: 100%;"
+              tabindex="0"
+            >
+              <div
+                class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+              >
+                <div
+                  aria-disabled="false"
+                  class="styles__475tndd styles__17da2jl2"
+                  data-checked="true"
+                  data-invalid="false"
+                >
+                  <input
+                    aria-disabled="false"
+                    checked=""
+                    class="styles__17da2jl6"
+                    id="_r_2l_"
+                    name="radio"
+                    tabindex="-1"
+                    type="radio"
+                    value="value-1"
+                  />
+                  <svg
+                    class="styles__17da2jl7"
+                    viewBox="0 0 24 24"
+                  >
+                    <title>
+                      radio
+                    </title>
+                    <g>
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke-width="2"
+                      />
+                      <circle
+                        class="styles__17da2jl9"
+                        cx="12"
+                        cy="12"
+                        r="8"
+                      />
+                      <circle
+                        class="styles__17da2jl8"
+                        cx="12"
+                        cy="12"
+                        r="5"
+                      />
+                    </g>
+                  </svg>
+                  <label
+                    class="styles__17da2jl5 styles__17da2jl4"
+                    for="_r_2l_"
+                  >
+                    <div
+                      class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+                    >
+                      <div
+                        class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j"
+                      >
+                        Option
+                        <span
+                          class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
+                        >
+                          <span>
+                            Custom description
+                          </span>
+                        </span>
+                        <span
+                          class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_neutral__1yf71jy7 styles_size_medium__1yf71jye styles_undefined_compound_6__1yf71jyn style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                          style="--whiteSpace__qabug41: nowrap;"
+                        >
+                          Test
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`selectableCardGroup > renders Label with sideText 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <div
+      class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
+    >
+      <fieldset
+        class="styles__7j58nd0"
+      >
+        <div
+          class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.75rem_xxsmall__toi52u5p"
+        >
+          <legend
+            class="styles_default__17td3g90 style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+          >
+            Label
+          </legend>
+          <div
+            class="styles__x6hyh50 styles_gap_1rem_xxsmall__x6hyh52p"
+            style="--_3mg8xe0: repeat(1, minmax(0, 1fr)); --_3mg8xe1: repeat(1, minmax(0, 1fr)); --_3mg8xe2: repeat(1, minmax(0, 1fr)); --_3mg8xe3: repeat(1, minmax(0, 1fr)); --_3mg8xe4: repeat(1, minmax(0, 1fr)); --_3mg8xe5: repeat(1, minmax(0, 1fr));"
+          >
+            <div
+              class="styles__475tnd0 styles_cursor_custom__475tnd1 styles_image_none__475tnd5 styles__475tnd6 styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+              data-checked="true"
+              data-disabled="false"
+              data-error="false"
+              data-type="radio"
+              role="button"
+              style="--_4k0ekn3: 1; --_18vc4d30: none; --_18vc4d31: inline; --_18vc4d32: 100%;"
+              tabindex="0"
+            >
+              <div
+                class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+              >
+                <div
+                  aria-disabled="false"
+                  class="styles__475tndd styles__17da2jl2"
+                  data-checked="true"
+                  data-invalid="false"
+                >
+                  <input
+                    aria-disabled="false"
+                    checked=""
+                    class="styles__17da2jl6"
+                    id="_r_2d_"
+                    name="radio"
+                    tabindex="-1"
+                    type="radio"
+                    value="value-1"
+                  />
+                  <svg
+                    class="styles__17da2jl7"
+                    viewBox="0 0 24 24"
+                  >
+                    <title>
+                      radio
+                    </title>
+                    <g>
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke-width="2"
+                      />
+                      <circle
+                        class="styles__17da2jl9"
+                        cx="12"
+                        cy="12"
+                        r="8"
+                      />
+                      <circle
+                        class="styles__17da2jl8"
+                        cx="12"
+                        cy="12"
+                        r="5"
+                      />
+                    </g>
+                  </svg>
+                  <label
+                    class="styles__17da2jl5 styles__17da2jl4"
+                    for="_r_2d_"
+                  >
+                    <div
+                      class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+                    >
+                      <div
+                        class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j"
+                      >
+                        Option
+                        <span
+                          class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_neutral__1yf71jy7 styles_size_medium__1yf71jye styles_undefined_compound_6__1yf71jyn style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                          style="--whiteSpace__qabug41: nowrap;"
+                        >
+                          Populaire
+                        </span>
+                      </div>
+                      <span
+                        class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_primary__m4c9owc style_variant_bodySmallStronger__m4c9owm style_undefined_compound_0__m4c9ow1a style_undefined_compound_40__m4c9ow2e"
+                      >
+                        5€
+                      </span>
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`selectableCardGroup > renders correctly 1`] = `
 <DocumentFragment>
   <div
@@ -528,6 +762,122 @@ exports[`selectableCardGroup > renders correctly required and showTick 1`] = `
                       Checkbox 2
                     </label>
                   </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`selectableCardGroup > renders correctly with Label component and badge 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <div
+      class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
+    >
+      <fieldset
+        class="styles__7j58nd0"
+      >
+        <div
+          class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.75rem_xxsmall__toi52u5p"
+        >
+          <legend
+            class="styles_default__17td3g90 style__m4c9ow0 style_prominence_default__m4c9ow4 style_sentiment_neutral__m4c9owb style_variant_bodyStrong__m4c9own style_undefined_compound_0__m4c9ow1a style_undefined_compound_64__m4c9ow32"
+          >
+            Label
+          </legend>
+          <div
+            class="styles__x6hyh50 styles_gap_1rem_xxsmall__x6hyh52p"
+            style="--_3mg8xe0: repeat(1, minmax(0, 1fr)); --_3mg8xe1: repeat(1, minmax(0, 1fr)); --_3mg8xe2: repeat(1, minmax(0, 1fr)); --_3mg8xe3: repeat(1, minmax(0, 1fr)); --_3mg8xe4: repeat(1, minmax(0, 1fr)); --_3mg8xe5: repeat(1, minmax(0, 1fr));"
+          >
+            <div
+              class="styles__475tnd0 styles_cursor_custom__475tnd1 styles_image_none__475tnd5 styles__475tnd6 styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+              data-checked="true"
+              data-disabled="false"
+              data-error="false"
+              data-type="radio"
+              role="button"
+              style="--_4k0ekn3: 1; --_18vc4d30: none; --_18vc4d31: inline; --_18vc4d32: 100%;"
+              tabindex="0"
+            >
+              <div
+                class="styles__17da2jl0 styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
+              >
+                <div
+                  aria-disabled="false"
+                  class="styles__475tndd styles__17da2jl2"
+                  data-checked="true"
+                  data-invalid="false"
+                >
+                  <input
+                    aria-disabled="false"
+                    checked=""
+                    class="styles__17da2jl6"
+                    id="_r_25_"
+                    name="radio"
+                    tabindex="-1"
+                    type="radio"
+                    value="value-1"
+                  />
+                  <svg
+                    class="styles__17da2jl7"
+                    viewBox="0 0 24 24"
+                  >
+                    <title>
+                      radio
+                    </title>
+                    <g>
+                      <circle
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke-width="2"
+                      />
+                      <circle
+                        class="styles__17da2jl9"
+                        cx="12"
+                        cy="12"
+                        r="8"
+                      />
+                      <circle
+                        class="styles__17da2jl8"
+                        cx="12"
+                        cy="12"
+                        r="5"
+                      />
+                    </g>
+                  </svg>
+                  <label
+                    class="styles__17da2jl5 styles__17da2jl4"
+                    for="_r_25_"
+                  >
+                    <div
+                      class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.5rem_xxsmall__toi52u3p"
+                    >
+                      <div
+                        class="styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j"
+                      >
+                        Option avec Badge
+                        <span
+                          class="style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
+                        >
+                          Description
+                        </span>
+                        <span
+                          class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_primary__1yf71jy8 styles_size_medium__1yf71jye styles_undefined_compound_0__1yf71jyh style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
+                          style="--whiteSpace__qabug41: nowrap;"
+                        >
+                          Nouveau
+                        </span>
+                      </div>
+                    </div>
+                  </label>
                 </div>
               </div>
             </div>

--- a/packages/ui/src/components/SelectableCardGroup/__tests__/index.test.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/__tests__/index.test.tsx
@@ -1,19 +1,21 @@
-import { render } from '@testing-library/react'
-import { shouldMatchSnapshot } from '@utils/test'
+import { render, screen } from '@testing-library/react'
+import { renderWithTheme } from '@utils/test'
 import { describe, expect, it } from 'vitest'
 import { SelectableCardGroup } from '..'
 
 describe('selectableCardGroup', () => {
-  it('renders correctly', () =>
-    shouldMatchSnapshot(
+  it('renders correctly', () => {
+    const { asFragment } = renderWithTheme(
       <SelectableCardGroup legend="Label" name="checkbox" onChange={() => {}} type="checkbox" value={['value-1']}>
         <SelectableCardGroup.Card label="Checkbox 1" value="value-1" />
         <SelectableCardGroup.Card label="Checkbox 2" value="value-2" />
       </SelectableCardGroup>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('renders correctly with direction multiple columns', () =>
-    shouldMatchSnapshot(
+  it('renders correctly with direction multiple columns', () => {
+    const { asFragment } = renderWithTheme(
       <SelectableCardGroup
         columns={2}
         legend="Label"
@@ -25,10 +27,12 @@ describe('selectableCardGroup', () => {
         <SelectableCardGroup.Card label="Checkbox 1" value="value-1" />
         <SelectableCardGroup.Card label="Checkbox 2" value="value-2" />
       </SelectableCardGroup>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
-  it('renders correctly with helper content', () =>
-    shouldMatchSnapshot(
+  it('renders correctly with helper content', () => {
+    const { asFragment } = renderWithTheme(
       <SelectableCardGroup
         helper="Helper content"
         legend="Label"
@@ -40,9 +44,12 @@ describe('selectableCardGroup', () => {
         <SelectableCardGroup.Card label="Checkbox 1" value="value-1" />
         <SelectableCardGroup.Card label="Checkbox 2" value="value-2" />
       </SelectableCardGroup>,
-    ))
-  it('renders correctly required and showTick', () =>
-    shouldMatchSnapshot(
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders correctly required and showTick', () => {
+    const { asFragment } = renderWithTheme(
       <SelectableCardGroup
         legend="Label"
         name="checkbox"
@@ -55,9 +62,12 @@ describe('selectableCardGroup', () => {
         <SelectableCardGroup.Card label="Checkbox 1" value="value-1" />
         <SelectableCardGroup.Card label="Checkbox 2" value="value-2" />
       </SelectableCardGroup>,
-    ))
-  it('renders correctly with error content', () =>
-    shouldMatchSnapshot(
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders correctly with error content', () => {
+    const { asFragment } = renderWithTheme(
       <SelectableCardGroup
         error="Error content"
         legend="Label"
@@ -69,9 +79,12 @@ describe('selectableCardGroup', () => {
         <SelectableCardGroup.Card label="Checkbox 1" value="value-1" />
         <SelectableCardGroup.Card label="Checkbox 2" value="value-2" />
       </SelectableCardGroup>,
-    ))
-  it('renders correctly as a radio', () =>
-    shouldMatchSnapshot(
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders correctly as a radio', () => {
+    const { asFragment } = renderWithTheme(
       <SelectableCardGroup
         error="Error content"
         legend="Label"
@@ -83,11 +96,70 @@ describe('selectableCardGroup', () => {
         <SelectableCardGroup.Card label="Radio 1" value="value-1" />
         <SelectableCardGroup.Card label="Radio 2" value="value-2" />
       </SelectableCardGroup>,
-    ))
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
 
   it('throws if SelectableCardGroup.Card is used without SelectableCardGroup', () => {
     expect(() => render(<SelectableCardGroup.Card label="Checkbox 1" value="value-1" />)).toThrow(
       'SelectableCardGroup.Card can only be used inside a SelectableCardGroup',
     )
+  })
+
+  it('renders correctly with Label component and badge', () => {
+    const { asFragment } = renderWithTheme(
+      <SelectableCardGroup legend="Label" name="radio" onChange={() => {}} type="radio" value="value-1">
+        <SelectableCardGroup.Card
+          label={
+            <SelectableCardGroup.Label
+              label="Option avec Badge"
+              labelDescription="Description"
+              badgeText="Nouveau"
+              badgeSentiment="primary"
+            />
+          }
+          value="value-1"
+        />
+      </SelectableCardGroup>,
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders Label with sideText', () => {
+    const { asFragment } = renderWithTheme(
+      <SelectableCardGroup legend="Label" name="radio" onChange={() => {}} type="radio" value="value-1">
+        <SelectableCardGroup.Card
+          label={<SelectableCardGroup.Label label="Option" badgeText="Populaire" sideText="5€" />}
+          value="value-1"
+        />
+      </SelectableCardGroup>,
+    )
+
+    expect(screen.getByText('Option')).toBeInTheDocument()
+    expect(screen.getByText('Populaire')).toBeInTheDocument()
+    expect(screen.getByText('5€')).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders Label with function as labelDescription', () => {
+    const { asFragment } = renderWithTheme(
+      <SelectableCardGroup legend="Label" name="radio" onChange={() => {}} type="radio" value="value-1">
+        <SelectableCardGroup.Card
+          label={
+            <SelectableCardGroup.Label
+              label="Option"
+              labelDescription={<span>Custom description</span>}
+              badgeText="Test"
+            />
+          }
+          value="value-1"
+        />
+      </SelectableCardGroup>,
+    )
+
+    expect(screen.getByText('Option')).toBeInTheDocument()
+    expect(screen.getByText('Custom description')).toBeInTheDocument()
+    expect(screen.getByText('Test')).toBeInTheDocument()
+    expect(asFragment()).toMatchSnapshot()
   })
 })

--- a/packages/ui/src/components/SelectableCardGroup/index.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/index.tsx
@@ -9,6 +9,7 @@ import { Label } from '../Label'
 import { Row } from '../Row'
 import { Stack } from '../Stack'
 import { SelectableCardGroupContext } from './Context'
+import { SelectableCardGroupLabel } from './Label'
 import { CardSelectableCard } from './SingleCard'
 import { selectableCardGroupStyle } from './styles.css'
 
@@ -87,8 +88,10 @@ const SelectableCardGroupComponent = ({
 
 type SelectableCardOptionGroupType = typeof SelectableCardGroupComponent & {
   Card: typeof CardSelectableCard
+  Label: typeof SelectableCardGroupLabel
 }
 
 export const SelectableCardGroup: SelectableCardOptionGroupType = Object.assign(SelectableCardGroupComponent, {
   Card: CardSelectableCard,
+  Label: SelectableCardGroupLabel,
 })


### PR DESCRIPTION
## Summary

## Type

- Enhancement


### Summarize concisely:

#### What is expected?

Creates SelectableCardGroup.Label sub-component to simplify adding badges and side text to card labels.
- Adds SelectableCardGroup.Label with props: label, labelDescription, badgeText, badgeSentiment, badgeProminence, badgeSize, sideText, disabled
- Exports Label on both SelectableCardGroup (UI) and SelectableCardGroupField (Form)

