### PR TITLE
fix: improve guards for selectable card field components

### DIFF
--- a/.changeset/violet-lines-design.md
+++ b/.changeset/violet-lines-design.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+fix: improve guards on selectable card field components

--- a/packages/form/src/components/SelectableCardField/index.tsx
+++ b/packages/form/src/components/SelectableCardField/index.tsx
@@ -47,7 +47,7 @@ export const SelectableCardField = <
 
   const isChecked =
     (type === 'checkbox' || type === 'toggle') && Array.isArray(field.value) && value
-      ? (field.value ?? []).includes(value)
+      ? field.value.includes(value)
       : field.value === value
 
   return (
@@ -64,7 +64,7 @@ export const SelectableCardField = <
       }}
       onChange={event => {
         if (type === 'checkbox' || type === 'toggle') {
-          const fieldValue = (field.value ?? []) as string[]
+          const fieldValue = Array.isArray(field.value) ? field.value as string[] : []
           if (fieldValue?.includes(event.currentTarget.value)) {
             field.onChange(fieldValue?.filter(currentValue => currentValue !== event.currentTarget.value))
           } else {

--- a/packages/form/src/components/SelectableCardGroupField/SelectableCardGroupField.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/SelectableCardGroupField.tsx
@@ -54,7 +54,7 @@ const SelectableCardGroupFieldComponent = <
       name={name}
       onChange={event => {
         if (type === 'checkbox') {
-          const fieldValue = (field.value ?? []) as string[]
+          const fieldValue = Array.isArray(field.value) ? field.value as string[] : []
           if (fieldValue?.includes(event.currentTarget.value)) {
             field.onChange(fieldValue?.filter(currentValue => currentValue !== event.currentTarget.value))
           } else {


### PR DESCRIPTION
## Summary

Improve guards on the selectable card fields components.


## Type

- Enhancement

### Summarize concisely:

In some cases guards weren't strong enough to ensure correct calls.

#### What is expected?

Guards should be stronger and not use truthy values

#### The following changes were made:

Edited the guards from xxx ?? [] to Array.isArray and a ternary to remove truthy values that are not an array from the test.
