### PR TITLE
test(RichTextInput): try to fix flaky test

### DIFF
--- a/packages/ui/src/compositions/RichTextInput/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/RichTextInput/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
@@ -29,11 +29,12 @@ describe('richTextInput', () => {
     renderWithTheme(<RichTextInput aria-label="Test" onChange={onChange} value="test" />)
 
     const doc = screen.getByRole('textbox')
+    await waitFor(() => expect(doc.textContent).toBe('test'))
+
     await userEvent.click(doc)
     await userEvent.type(doc, 'a')
 
-    expect(onChange).toHaveBeenCalled()
-    expect(onChange).toHaveBeenLastCalledWith('<p>testa</p>')
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('<p>testa</p>')
   })
 
   it('should return empty string when cleared', async () => {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

Attempt to fix a flaky test in `RichTextInput`. 

The test failed in very few PRs ([this one for instance](https://github.com/scaleway/ultraviolet/actions/runs/26745278312/job/78819559006)) and I couldn't reproduce the error locally so this is a blind fix.

<img width="657" height="384" alt="image" src="https://github.com/user-attachments/assets/656e7e49-d899-4ce1-9bf8-e9cdeab44e8d" />


#### The following changes were made:

Wait for the "test" string to be rendered before adding "a" to the value.
