### PR TITLE
fix(TextArea): padding and clear button

### DIFF
--- a/.changeset/fine-parts-search.md
+++ b/.changeset/fine-parts-search.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`TextArea`: fix padding right on content and disable clear button when input is read-only or disabled

--- a/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`textAreaField > should render correctly 1`] = `
             id="_r_0_"
             name="test"
             rows="3"
-            style="--uv_hlf4vn0: calc(1.5rem + 0px + 0px);"
+            style="--uv_hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
           />
           <div
             class="uv_hlf4vn2 uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u3p"
@@ -75,7 +75,7 @@ exports[`textAreaField > should render correctly generated 1`] = `
             id="_r_9_"
             name="test"
             rows="3"
-            style="--uv_hlf4vn0: calc(1.5rem + 300px + 0px); resize: vertical; height: auto; min-height: calc(1.5rem + nanpx);"
+            style="--uv_hlf4vn0: calc(0.5rem + 1.5rem + 0px + 0px + 0.25rem); resize: vertical; height: auto; min-height: calc(1.5rem + nanpx);"
           >
             This is an example
           </textarea>
@@ -142,7 +142,7 @@ exports[`textAreaField > should submit with onSubmitEnter prop 1`] = `
             id="_r_4_"
             name="test"
             rows="3"
-            style="--uv_hlf4vn0: calc(1.5rem + 0px + 0px); resize: vertical; height: auto; min-height: calc(1.5rem + nanpx);"
+            style="--uv_hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); resize: vertical; height: auto; min-height: calc(1.5rem + nanpx);"
           >
             This is an example
           </textarea>

--- a/packages/ui/src/components/TextArea/Icon.tsx
+++ b/packages/ui/src/components/TextArea/Icon.tsx
@@ -1,10 +1,9 @@
 import { AlertCircleIcon } from '@ultraviolet/icons/AlertCircleIcon'
 import { CheckCircleIcon } from '@ultraviolet/icons/CheckCircleIcon'
-import { STATE_ICON_SIZE } from './constant'
 
 export const SuccessErrorIcon = ({ success, error }: { success: boolean; error: boolean }) => (
   <>
-    {success && !error ? <CheckCircleIcon sentiment="success" size={STATE_ICON_SIZE} /> : null}
+    {success && !error ? <CheckCircleIcon sentiment="success" size="small" /> : null}
     {error ? <AlertCircleIcon sentiment="danger" /> : null}
   </>
 )

--- a/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`textArea > should render correctly when input  has a error sentiment 1`
           class="styles__hlf4vn3 styles_error_true__hlf4vn4"
           id="_r_14_"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + smallpx);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
         >
           test
         </textarea>
@@ -87,7 +87,7 @@ exports[`textArea > should render correctly when input has a success sentiment 1
           class="styles__hlf4vn3 styles_success_true__hlf4vn5"
           id="_r_v_"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + smallpx);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
         >
           test
         </textarea>
@@ -151,7 +151,7 @@ exports[`textArea > should render correctly when input is disabled 1`] = `
           disabled=""
           id="_r_d_"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
         >
           test
         </textarea>
@@ -187,7 +187,7 @@ exports[`textArea > should render correctly when input is readOnly 1`] = `
           id="_r_h_"
           readonly=""
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
         >
           test
         </textarea>
@@ -231,7 +231,7 @@ exports[`textArea > should render correctly when it is required 1`] = `
           class="styles__hlf4vn3"
           id="_r_l_"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
         >
           test
         </textarea>
@@ -266,7 +266,7 @@ exports[`textArea > should render correctly with basic props 1`] = `
           class="styles__hlf4vn3"
           id="_r_0_"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
         >
           test
         </textarea>
@@ -302,7 +302,7 @@ exports[`textArea > should render correctly with maxlength 1`] = `
           id="_r_q_"
           maxlength="3"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
         >
           test
         </textarea>
@@ -349,7 +349,7 @@ exports[`textArea > should render with AutoExpandMax 1`] = `
           class="styles__hlf4vn3 styles_error_true__hlf4vn4"
           id="_r_1e_"
           rows="3"
-          style="--hlf4vn0: calc(1.5rem + 0px + smallpx);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
         >
           test
         </textarea>
@@ -413,7 +413,7 @@ exports[`textArea > should render with AutoExpandMax and rows 1`] = `
           class="styles__hlf4vn3 styles_error_true__hlf4vn4"
           id="_r_1j_"
           rows="2"
-          style="--hlf4vn0: calc(1.5rem + 0px + smallpx);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
         >
           test
         </textarea>
@@ -477,7 +477,7 @@ exports[`textArea > should render with auto rows 1`] = `
           class="styles__hlf4vn3 styles_error_true__hlf4vn4"
           id="_r_19_"
           rows="1"
-          style="--hlf4vn0: calc(1.5rem + 0px + smallpx);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
         >
           test
         </textarea>

--- a/packages/ui/src/components/TextArea/constant.ts
+++ b/packages/ui/src/components/TextArea/constant.ts
@@ -1,1 +1,3 @@
-export const STATE_ICON_SIZE = 'small'
+// Sould be the same as the small size of the Icon component
+// See : packages/icons/src/components/Icon/constants.ts
+export const STATE_ICON_SIZE = '200'

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -7,7 +7,7 @@ import { forwardRef, useEffect, useId, useImperativeHandle, useRef } from 'react
 import type { CSSProperties, ReactNode, TextareaHTMLAttributes } from 'react'
 import { hasHelperText } from '../../helpers/hasHelperText'
 import { Button } from '../Button'
-import { SIZE_HEIGHT as ButtonSizeHeight } from '../Button/constants'
+import { SIZE_HEIGHT as buttonSizeHeight } from '../Button/constants'
 import { Label } from '../Label'
 import { Stack } from '../Stack'
 import { Tooltip } from '../Tooltip'
@@ -161,9 +161,14 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       requestAnimationFrame(updateHeight)
     }, [value, rows, theme, maxRows, textAreaRef.current?.value])
 
-    const notice = success || error || helper
+    const nonDefaultState = success || error
 
     const computedClearable = clearable && !!value
+    const defaultPadding = theme.space[1]
+    const spaceForClearButton = computedClearable ? theme.sizing[buttonSizeHeight.xsmall] : '0px'
+    const spaceForStateIcon = nonDefaultState ? theme.sizing[STATE_ICON_SIZE] : '0px'
+    const gapBetweenButtons = computedClearable && nonDefaultState ? theme.space['1'] : '0px'
+    const gapButtonsContent = computedClearable || nonDefaultState ? theme.space[0.5] : '0px'
 
     return (
       <Stack className={className} gap="0.5">
@@ -201,9 +206,9 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               rows={rows === 'auto' ? 1 : rows}
               style={{
                 ...assignInlineVars({
-                  [paddingRightVar]: `calc(${theme.space[computedClearable && (!!success || !!error) ? '4' : '3']} + ${
-                    computedClearable ? `${ButtonSizeHeight.xsmall}px` : '0px'
-                  } + ${!!success || !!error ? `${STATE_ICON_SIZE}px` : '0px'})`,
+                  [paddingRightVar]: `calc(${defaultPadding} + ${
+                    spaceForClearButton
+                  } + ${spaceForStateIcon} + ${gapBetweenButtons} + ${gapButtonsContent}) `,
                 }),
                 ...style,
               }}
@@ -220,6 +225,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
                   sentiment="neutral"
                   size="xsmall"
                   variant="ghost"
+                  disabled={disabled || readOnly}
                 >
                   <CloseIcon />
                 </Button>
@@ -228,7 +234,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             </Stack>
           </div>
         </Tooltip>
-        {notice || maxLength ? (
+        {nonDefaultState || helper || maxLength ? (
           <Notice
             disabled={disabled}
             error={error}


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`TextArea`: fix padding right on content and disable clear button when input is read-only or disabled