### PR TITLE
fix(OrderSummary): remove empty div

### DIFF
--- a/.changeset/dirty-boats-begin.md
+++ b/.changeset/dirty-boats-begin.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`OrderSummary`: remove empty div when a sub-category doesn't have details

--- a/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
@@ -152,9 +152,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -390,9 +387,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -438,9 +432,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -481,9 +472,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -524,9 +512,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -545,9 +530,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -588,9 +570,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -673,9 +652,6 @@ exports[`orderSummary > should work with additionalInfo 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1169,9 +1145,6 @@ exports[`orderSummary > should work with children 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1407,9 +1380,6 @@ exports[`orderSummary > should work with children 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1455,9 +1425,6 @@ exports[`orderSummary > should work with children 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1498,9 +1465,6 @@ exports[`orderSummary > should work with children 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1541,9 +1505,6 @@ exports[`orderSummary > should work with children 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -1562,9 +1523,6 @@ exports[`orderSummary > should work with children 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1605,9 +1563,6 @@ exports[`orderSummary > should work with children 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1690,9 +1645,6 @@ exports[`orderSummary > should work with children 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -1796,9 +1748,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2034,9 +1983,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2082,9 +2028,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2125,9 +2068,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2168,9 +2108,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -2189,9 +2126,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2232,9 +2166,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2317,9 +2248,6 @@ exports[`orderSummary > should work with default props 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2508,9 +2436,6 @@ exports[`orderSummary > should work with discount 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2699,9 +2624,6 @@ exports[`orderSummary > should work with discount in  % 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -2890,9 +2812,6 @@ exports[`orderSummary > should work with discount of 100% 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3090,9 +3009,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3328,9 +3244,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3376,9 +3289,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3419,9 +3329,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3462,9 +3369,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -3483,9 +3387,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3526,9 +3427,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3611,9 +3509,6 @@ exports[`orderSummary > should work with footer 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3803,9 +3698,6 @@ exports[`orderSummary > should work with fractionDigits 1`] = `
                   €5
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -3994,9 +3886,6 @@ exports[`orderSummary > should work with hide before price 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -4297,9 +4186,6 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -4313,9 +4199,6 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                   duration
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -4332,9 +4215,6 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                   €1.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -4519,9 +4399,6 @@ exports[`orderSummary > should work with price as a range 1`] = `
                   €200.00 - €300.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -4711,9 +4588,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -4949,9 +4823,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -4997,9 +4868,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5040,9 +4908,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5083,9 +4948,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -5104,9 +4966,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5147,9 +5006,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5232,9 +5088,6 @@ exports[`orderSummary > should work with price information 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5433,9 +5286,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5671,9 +5521,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5719,9 +5566,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5762,9 +5606,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5805,9 +5646,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -5826,9 +5664,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5869,9 +5704,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -5954,9 +5786,6 @@ exports[`orderSummary > should work with price information boolean 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6155,9 +5984,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6393,9 +6219,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6441,9 +6264,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6484,9 +6304,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6527,9 +6344,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -6548,9 +6362,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6591,9 +6402,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6676,9 +6484,6 @@ exports[`orderSummary > should work with totalPriceInfo 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -6881,9 +6686,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7119,9 +6921,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7167,9 +6966,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7210,9 +7006,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7253,9 +7046,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -7274,9 +7064,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7317,9 +7104,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7402,9 +7186,6 @@ exports[`orderSummary > should work with totalPriceInfo and totalPriceInfoPlacem
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7517,9 +7298,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7755,9 +7533,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   €10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7803,9 +7578,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   Included
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7846,9 +7618,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7889,9 +7658,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   €200.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
             <div
               class="styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.5rem_xxsmall__toi52u3p"
@@ -7910,9 +7676,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   €50.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -7953,9 +7716,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   €0.00000015 /request
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -8038,9 +7798,6 @@ exports[`orderSummary > should work without unitInput 1`] = `
                   </span>
                 </div>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -8827,9 +8584,6 @@ exports[`orderSummary > works with negative category price 1`] = `
                   €5.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>
@@ -8870,9 +8624,6 @@ exports[`orderSummary > works with negative category price 1`] = `
                   -€10.00
                 </span>
               </div>
-              <div
-                class="styles__11nvx2kc styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
-              />
             </div>
           </div>
         </div>

--- a/packages/ui/src/compositions/OrderSummary/components/SubCategory.tsx
+++ b/packages/ui/src/compositions/OrderSummary/components/SubCategory.tsx
@@ -55,20 +55,22 @@ export const SubCategory = ({ subCategory }: { subCategory: SubCategoryType }) =
       ) : null}
       <SubCategoryPrice subCategory={subCategory} />
     </Stack>
-    <Stack className={orderSummaryStyle.details} direction="column" gap={0.5}>
-      {subCategory.details?.map((detail, index) =>
-        detail ? (
-          <Text
-            as="span"
-            // oxlint-disable-next-line react/no-array-index-key
-            key={`${subCategory.title}-${index}`}
-            sentiment="neutral"
-            variant="bodySmall"
-          >
-            {detail}
-          </Text>
-        ) : null,
-      )}
-    </Stack>
+    {subCategory.details ? (
+      <Stack className={orderSummaryStyle.details} direction="column" gap={0.5}>
+        {subCategory.details.map((detail, index) =>
+          detail ? (
+            <Text
+              as="span"
+              // oxlint-disable-next-line react/no-array-index-key
+              key={`${subCategory.title}-${index}`}
+              sentiment="neutral"
+              variant="bodySmall"
+            >
+              {detail}
+            </Text>
+          ) : null,
+        )}
+      </Stack>
+    ) : null}
   </Stack>
 )


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?
`OrderSummary`: remove empty div when a sub-category doesn't have details