### PR TITLE
fix(SelectInput): alignments

### DIFF
--- a/.changeset/perky-ties-call.md
+++ b/.changeset/perky-ties-call.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SelectInput`: 
+- add a transparent border when disabled to avoid sizing differences between read-only, default, and disabled states
+- fix options alignment with checkbox and `OptionalInfo`

--- a/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-saturn"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -177,7 +177,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-uranus"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -203,7 +203,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-neptune"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -256,7 +256,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-mercury"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -282,7 +282,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-venus"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -340,7 +340,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-mars"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"

--- a/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-jupiter"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -151,7 +151,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-saturn"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -177,7 +177,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-uranus"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -203,7 +203,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-neptune"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -256,7 +256,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-mercury"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -282,7 +282,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-venus"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -308,7 +308,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-earth"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -340,7 +340,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-mars"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"
@@ -366,7 +366,7 @@ exports[`selectInputField > should display right value on grouped options 1`] = 
                           data-testid="option-stack-pluto"
                         >
                           <div
-                            class="uv_igqisuo uv_toi52u0 uv_toi52u2j uv_toi52u5j uv_toi52u77"
+                            class="uv_igqisuo uv_toi52u0 uv_toi52uv uv_toi52u2j uv_toi52u5j uv_toi52u77"
                           >
                             <span
                               class="uv_igqisun uv_m4c9ow0 uv_m4c9ow4 uv_m4c9owj uv_m4c9ow1a"

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -289,7 +289,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-jupiter"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -321,7 +321,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -347,7 +347,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -373,7 +373,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -436,7 +436,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -462,7 +462,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -488,7 +488,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-earth"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -520,7 +520,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -546,7 +546,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-pluto"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1144,7 +1144,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-jupiter"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1235,7 +1235,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-saturn"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1320,7 +1320,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-uranus"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1405,7 +1405,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-neptune"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1527,7 +1527,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-mercury"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1612,7 +1612,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-venus"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1697,7 +1697,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-earth"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1789,7 +1789,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-mars"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1875,7 +1875,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-pluto"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2168,7 +2168,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2194,7 +2194,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2220,7 +2220,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-earth"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2258,7 +2258,7 @@ exports[`selectInput > renders correctly required 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2285,7 +2285,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-jupiter"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2317,7 +2317,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2343,7 +2343,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2369,7 +2369,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2678,7 +2678,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2704,7 +2704,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2730,7 +2730,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-earth"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2768,7 +2768,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2795,7 +2795,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-jupiter"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2827,7 +2827,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2853,7 +2853,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2879,7 +2879,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3069,7 +3069,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-jupiter"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3101,7 +3101,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3127,7 +3127,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3153,7 +3153,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3216,7 +3216,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3242,7 +3242,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3268,7 +3268,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-earth"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3300,7 +3300,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3326,7 +3326,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-pluto"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3491,7 +3491,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3517,7 +3517,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3543,7 +3543,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-earth"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3581,7 +3581,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3608,7 +3608,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-jupiter"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3640,7 +3640,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3666,7 +3666,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3692,7 +3692,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3958,7 +3958,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3984,7 +3984,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4010,7 +4010,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-earth"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4048,7 +4048,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4075,7 +4075,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-jupiter"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4107,7 +4107,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4133,7 +4133,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4159,7 +4159,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4356,7 +4356,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-jupiter"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4388,7 +4388,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4414,7 +4414,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4440,7 +4440,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4503,7 +4503,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4529,7 +4529,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4555,7 +4555,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-earth"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4587,7 +4587,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4613,7 +4613,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-pluto"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4910,7 +4910,7 @@ exports[`selectInput > renders correctly with group empty state 1`] = `
                                 data-testid="option-stack-mars"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5138,7 +5138,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-mercury"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5223,7 +5223,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-venus"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5308,7 +5308,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-earth"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5400,7 +5400,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-mars"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5485,7 +5485,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-pluto"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5672,7 +5672,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
                       >
                         <span
                           class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_neutral__1yf71jy7 styles_size_medium__1yf71jye styles_undefined_compound_6__1yf71jyn style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
@@ -5710,7 +5710,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <div
                           class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
@@ -5736,7 +5736,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
                       >
                         <span
                           class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_neutral__1yf71jy7 styles_size_medium__1yf71jye styles_undefined_compound_6__1yf71jyn style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
@@ -5768,7 +5768,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <div
                           class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
@@ -5821,7 +5821,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
                       >
                         <span
                           class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_neutral__1yf71jy7 styles_size_medium__1yf71jye styles_undefined_compound_6__1yf71jyn style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
@@ -5853,7 +5853,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_left_xxsmall__toi52u6v"
                       >
                         <span
                           class="styles__1yf71jy0 styles_prominence_default__1yf71jy2 styles_sentiment_neutral__1yf71jy7 styles_size_medium__1yf71jye styles_undefined_compound_6__1yf71jyn style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_caption__m4c9owp style_undefined_compound_0__m4c9ow1a"
@@ -5885,7 +5885,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <div
                           class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
@@ -5917,7 +5917,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <div
                           class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
@@ -5943,7 +5943,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                       tabindex="0"
                     >
                       <div
-                        class="styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisur styles__toi52u0 styles_alignItems_normal_xxsmall__toi52u1 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <div
                           class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_column_xxsmall__toi52u2d styles_gap_0.25rem_xxsmall__toi52u5j"
@@ -6138,7 +6138,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-jupiter"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6180,7 +6180,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6206,7 +6206,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6242,7 +6242,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6295,7 +6295,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6331,7 +6331,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6367,7 +6367,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-earth"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6399,7 +6399,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6425,7 +6425,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-pluto"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7462,7 +7462,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7488,7 +7488,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7514,7 +7514,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-earth"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7552,7 +7552,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7579,7 +7579,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-jupiter"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7611,7 +7611,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7637,7 +7637,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7663,7 +7663,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7847,7 +7847,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7873,7 +7873,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7899,7 +7899,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-earth"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7937,7 +7937,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7964,7 +7964,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-jupiter"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7996,7 +7996,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -8022,7 +8022,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -8048,7 +8048,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -347,7 +347,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -373,7 +373,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -436,7 +436,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -462,7 +462,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -520,7 +520,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1235,7 +1235,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-saturn"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1320,7 +1320,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-uranus"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1405,7 +1405,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-neptune"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1527,7 +1527,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-mercury"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1612,7 +1612,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-venus"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -1789,7 +1789,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                                 data-testid="option-stack-mars"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2168,7 +2168,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2194,7 +2194,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2258,7 +2258,7 @@ exports[`selectInput > renders correctly required 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2317,7 +2317,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2343,7 +2343,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2369,7 +2369,7 @@ exports[`selectInput > renders correctly required 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2678,7 +2678,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2704,7 +2704,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2768,7 +2768,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2827,7 +2827,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2853,7 +2853,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -2879,7 +2879,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3101,7 +3101,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3127,7 +3127,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3153,7 +3153,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3216,7 +3216,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3242,7 +3242,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3300,7 +3300,7 @@ exports[`selectInput > renders correctly with default value 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3491,7 +3491,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3517,7 +3517,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3581,7 +3581,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3640,7 +3640,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3666,7 +3666,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3692,7 +3692,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3958,7 +3958,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -3984,7 +3984,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4048,7 +4048,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4107,7 +4107,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4133,7 +4133,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4159,7 +4159,7 @@ exports[`selectInput > renders correctly with error 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4388,7 +4388,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4414,7 +4414,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4440,7 +4440,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4503,7 +4503,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4529,7 +4529,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4587,7 +4587,7 @@ exports[`selectInput > renders correctly with footer 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -4910,7 +4910,7 @@ exports[`selectInput > renders correctly with group empty state 1`] = `
                                 data-testid="option-stack-mars"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5138,7 +5138,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-mercury"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5223,7 +5223,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-venus"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -5400,7 +5400,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
                                 data-testid="option-stack-mars"
                               >
                                 <div
-                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                                  class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                                 >
                                   <span
                                     class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6180,7 +6180,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-saturn"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6206,7 +6206,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-uranus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6242,7 +6242,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-neptune"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6295,7 +6295,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-mercury"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6331,7 +6331,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-venus"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -6399,7 +6399,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7462,7 +7462,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7488,7 +7488,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7552,7 +7552,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7611,7 +7611,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7637,7 +7637,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7663,7 +7663,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7847,7 +7847,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-mercury"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7873,7 +7873,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-venus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7937,7 +7937,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                         data-testid="option-stack-mars"
                       >
                         <div
-                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                          class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                         >
                           <span
                             class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -7996,7 +7996,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-saturn"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -8022,7 +8022,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-uranus"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"
@@ -8048,7 +8048,7 @@ exports[`selectInput > renders correctly with success 1`] = `
                       data-testid="option-stack-neptune"
                     >
                       <div
-                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                        class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                       >
                         <span
                           class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_body__m4c9owj style_undefined_compound_0__m4c9ow1a"

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Dropdown.tsx
@@ -33,6 +33,7 @@ export type DropdownProps = {
   groupError?: Record<string, ReactNode>
   groupEmptyState?: Record<string, ReactNode>
   addOption?: { text: string; onClick: (searchText: string) => void }
+  disabled?: boolean
 }
 
 const NON_SEARCHABLE_KEYS = [
@@ -116,6 +117,7 @@ export const Dropdown = ({
   groupError,
   groupEmptyState,
   addOption,
+  disabled,
 }: DropdownProps) => {
   const { setIsDropdownVisible, isDropdownVisible, onSearch, searchInput, options, displayedOptions, numberOfOptions } =
     useSelectInput()
@@ -291,7 +293,7 @@ export const Dropdown = ({
           {computedFooter}
         </Stack>
       }
-      visible={isDropdownVisible}
+      visible={!disabled && isDropdownVisible}
     >
       {children}
     </Popup>

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
@@ -38,7 +38,7 @@ export const DisplayOption = ({
     return (
       <Tooltip disableAnimation text={option.tooltip}>
         <Stack data-testid={`option-stack-${option.value}`} direction="row" gap={0.5} justifyContent="left">
-          <Stack alignItems="center" className={selectInputStyle.dropdownInfoContainer} direction="row" gap={0.5}>
+          <Stack alignItems="flex-start" className={selectInputStyle.dropdownInfoContainer} direction="row" gap={0.5}>
             {option.optionalInfo}
             <Text as="span" className={selectInputStyle.dropdownInfoTextItem} placement="left" variant={textVariant}>
               {option.label}
@@ -80,6 +80,7 @@ export const DisplayOption = ({
           direction="row"
           gap={0.5}
           justifyContent={option.optionalInfo ? 'left' : 'space-between'}
+          className={selectInputStyle.optionalInfoPadding}
         >
           {option.optionalInfo}
 
@@ -107,6 +108,7 @@ export const DisplayOption = ({
           direction="row"
           gap={0.5}
           justifyContent="space-between"
+          alignItems="flex-start"
         >
           <Text as="span" className={selectInputStyle.dropdownInfoTextItem} placement="left" variant={textVariant}>
             {option.label}

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
@@ -108,7 +108,7 @@ export const DisplayOption = ({
           direction="row"
           gap={0.5}
           justifyContent="space-between"
-          alignItems="flex-start"
+          alignItems={optionDescription ? 'flex-start' : 'center'}
         >
           <Text as="span" className={selectInputStyle.dropdownInfoTextItem} placement="left" variant={textVariant}>
             {option.label}

--- a/packages/ui/src/components/SelectInput/components/Dropdown/dropdown.css.ts
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/dropdown.css.ts
@@ -1,5 +1,5 @@
 import { theme } from '@ultraviolet/themes'
-import { createVar, style } from '@vanilla-extract/css'
+import { createVar, globalStyle, style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 
 const DROPDOWN_MAX_HEIGHT = 256
@@ -152,7 +152,7 @@ export const dropdownCheckbox = style({
   width: '100%',
   position: 'static',
   textAlign: 'left',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   pointerEvents: 'none',
 })
 
@@ -191,3 +191,9 @@ export const comboboxCreate = style([
     },
   },
 ])
+
+export const optionalInfoPadding = style({})
+
+globalStyle(`${optionalInfoPadding} > :first-child`, {
+  marginTop: theme.space['0.25'],
+})

--- a/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
@@ -65,6 +65,7 @@ export const selectBarBase = style({
   alignItems: 'center',
   background: theme.colors.neutral.background,
   borderRadius: theme.radii.default,
+  border: `1px solid transparent`,
   boxShadow: 'none',
   cursor: 'pointer',
   display: 'grid',

--- a/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
@@ -108,7 +108,7 @@ export const selectBar = recipe({
     {
       style: {
         selectors: {
-          "&:not([data-disabked='true'])": {
+          "&:not([data-disabled='true'])": {
             borderColor: theme.colors.primary.borderHover,
           },
         },
@@ -118,7 +118,7 @@ export const selectBar = recipe({
     {
       style: {
         selectors: {
-          "&:not([data-disabked='true'])": {
+          "&:not([data-disabled='true'])": {
             borderColor: theme.colors.success.borderHover,
           },
         },
@@ -128,7 +128,7 @@ export const selectBar = recipe({
     {
       style: {
         selectors: {
-          "&:not([data-disabked='true'])": {
+          "&:not([data-disabled='true'])": {
             borderColor: theme.colors.danger.borderHover,
           },
         },

--- a/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
@@ -107,31 +107,19 @@ export const selectBar = recipe({
   compoundVariants: [
     {
       style: {
-        selectors: {
-          "&:not([data-disabled='true'])": {
-            borderColor: theme.colors.primary.borderHover,
-          },
-        },
+        borderColor: theme.colors.primary.borderHover,
       },
       variants: { dropdownVisible: true, state: 'neutral' },
     },
     {
       style: {
-        selectors: {
-          "&:not([data-disabled='true'])": {
-            borderColor: theme.colors.success.borderHover,
-          },
-        },
+        borderColor: theme.colors.success.borderHover,
       },
       variants: { dropdownVisible: true, state: 'success' },
     },
     {
       style: {
-        selectors: {
-          "&:not([data-disabled='true'])": {
-            borderColor: theme.colors.danger.borderHover,
-          },
-        },
+        borderColor: theme.colors.danger.borderHover,
       },
       variants: { dropdownVisible: true, state: 'danger' },
     },

--- a/packages/ui/src/components/SelectInput/index.tsx
+++ b/packages/ui/src/components/SelectInput/index.tsx
@@ -224,6 +224,7 @@ export const SelectInput = <IsMulti extends undefined | boolean>({
       >
         <Dropdown
           addOption={addOption}
+          disabled={disabled}
           descriptionDirection={descriptionDirection}
           dropdownAlign={dropdownAlign}
           emptyState={emptyState}

--- a/packages/ui/src/components/SelectInput/styles.css.ts
+++ b/packages/ui/src/components/SelectInput/styles.css.ts
@@ -19,6 +19,7 @@ import {
   emptyStateGroupStyle,
   footer,
   searchBar,
+  optionalInfoPadding,
 } from './components/Dropdown/dropdown.css'
 import {
   multiselectStack,
@@ -66,4 +67,5 @@ export const selectInputStyle = {
   plusTag,
   multiselectStack,
   searchBar,
+  optionalInfoPadding,
 }

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`unitInput > renders click 1`] = `
                           data-testid="option-stack-kb"
                         >
                           <div
-                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                           >
                             <span
                               class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a"
@@ -143,7 +143,7 @@ exports[`unitInput > renders click 1`] = `
                           data-testid="option-stack-mb"
                         >
                           <div
-                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                           >
                             <span
                               class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a"
@@ -169,7 +169,7 @@ exports[`unitInput > renders click 1`] = `
                           data-testid="option-stack-gb"
                         >
                           <div
-                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_center_xxsmall__toi52ud styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                           >
                             <span
                               class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a"

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`unitInput > renders click 1`] = `
                           data-testid="option-stack-kb"
                         >
                           <div
-                            class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                           >
                             <span
                               class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a"
@@ -143,7 +143,7 @@ exports[`unitInput > renders click 1`] = `
                           data-testid="option-stack-mb"
                         >
                           <div
-                            class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                           >
                             <span
                               class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a"
@@ -169,7 +169,7 @@ exports[`unitInput > renders click 1`] = `
                           data-testid="option-stack-gb"
                         >
                           <div
-                            class="dropdown__igqisuo styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
+                            class="dropdown__igqisuo styles__toi52u0 styles_alignItems_flex-start_xxsmall__toi52uv styles_flexDirection_row_xxsmall__toi52u2j styles_gap_0.25rem_xxsmall__toi52u5j styles_justifyContent_space-between_xxsmall__toi52u77"
                           >
                             <span
                               class="dropdown__igqisun style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmall__m4c9owk style_undefined_compound_0__m4c9ow1a"


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?
`SelectInput`: 
	- add a transparent border when disabled to avoid sizing differences between read-only, default, and disabled states
	- fix options alignment with checkbox and `OptionalInfo`

Before (no border when disabled):

https://github.com/user-attachments/assets/792e42e2-291e-46dd-9ffc-552324ffacb3


After (border when disabled):

https://github.com/user-attachments/assets/f85c0988-625f-4455-9c9d-839deee0b907

