### PR TITLE
fix(SearchInput): fix icon size, padding and color

### DIFF
--- a/.changeset/dry-nails-arrive.md
+++ b/.changeset/dry-nails-arrive.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SearchInput`: fix icon size, padding and color

--- a/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`searchInput > renders correctly without children props 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz1i"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
                   height="16"
                   viewBox="0 0 16 16"
                   width="16"
@@ -101,7 +101,7 @@ exports[`searchInput > renders with disabled prop 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz2 uv_icons_1sbwqkz3 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkzm"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz2 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz1a"
                   height="16"
                   viewBox="0 0 16 16"
                   width="16"
@@ -169,7 +169,7 @@ exports[`searchInput > renders with error prop 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz1i"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
                   height="16"
                   viewBox="0 0 16 16"
                   width="16"
@@ -263,7 +263,7 @@ exports[`searchInput > renders with shortcut prop > as array of string 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz1i"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
                   height="16"
                   viewBox="0 0 16 16"
                   width="16"
@@ -378,7 +378,7 @@ exports[`searchInput > renders with shortcut prop > as boolean 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz1i"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
                   height="16"
                   viewBox="0 0 16 16"
                   width="16"

--- a/packages/ui/src/components/SearchInput/index.tsx
+++ b/packages/ui/src/components/SearchInput/index.tsx
@@ -272,7 +272,12 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
                 data-testid={`search-icon${dataTestId ? `-${dataTestId}` : ''}`}
                 onClick={() => innerSearchInputRef.current?.focus()}
               >
-                <SearchIcon disabled={disabled} sentiment="neutral" />
+                <SearchIcon
+                  disabled={disabled}
+                  size={size === 'large' ? 'medium' : 'small'}
+                  sentiment="neutral"
+                  prominence="weak"
+                />
               </Stack>
             }
             readOnly={readOnly}

--- a/packages/ui/src/components/TextInput/styles.css.ts
+++ b/packages/ui/src/components/TextInput/styles.css.ts
@@ -12,9 +12,15 @@ const basicPrefix = style({
   height: '100%',
 
   selectors: {
-    '&[data-size="small"]': { padding: theme.space['1'] },
+    '&[data-size="small"]': {
+      padding: theme.space['1'],
+    },
     [`${searchInputStyle.searchInput} &`]: {
       border: 'none',
+      padding: `0 ${theme.space[1]} 0 ${theme.space[2]}`,
+    },
+    [`${searchInputStyle.searchInput} &[data-size="small"]`]: {
+      paddingLeft: theme.space[1.5],
     },
   },
 })


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

Component matches the design

#### The following changes were made:

Fix styles

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| large  | <img width="461" height="132" alt="image" src="https://github.com/user-attachments/assets/69d148da-7419-4664-9973-dddbf1094391" /> | <img width="461" height="132" alt="image" src="https://github.com/user-attachments/assets/2c51e516-82e9-4e1a-bbca-2590d3d3209e" /> |
| medium | <img width="461" height="132" alt="image" src="https://github.com/user-attachments/assets/3055588b-ec68-4b6f-bc39-494e82ca7c55" /> | <img width="461" height="132" alt="image" src="https://github.com/user-attachments/assets/ae8ed292-000f-4e55-a2d5-1347c7b630b6" /> |
| small | <img width="461" height="132" alt="image" src="https://github.com/user-attachments/assets/927a66d7-e920-4773-ac8b-61aaa1fea7de" /> |  <img width="461" height="132" alt="image" src="https://github.com/user-attachments/assets/bb3a15b5-c46d-4483-b76a-8b5947fb582f" /> |
