### PR TITLE
fix(Popup): arrow placement

### DIFF
--- a/.changeset/short-lamps-argue.md
+++ b/.changeset/short-lamps-argue.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Popup`: arrow should be centered with children container (when computed position is top or bottom)

--- a/packages/ui/src/components/Popup/helpers.ts
+++ b/packages/ui/src/components/Popup/helpers.ts
@@ -268,8 +268,13 @@ const placementBottom = (
   // To make sure the popup does not overflow (negative X position)
   const finalPositionX = isPopupPortalTargetBody ? Math.max(computedPositionX, 0) : computedPositionX
 
+  const childrenCenterInParent = overloadedChildrenLeft + childrenWidth / 2
+
+  // Center the arrow with the children (in popup coordinates)
+  const arrowLeft = childrenCenterInParent - finalPositionX
+
   return {
-    arrowLeft: isAligned ? childrenWidth / 2 : popupWidth / 2 - popupOverflow,
+    arrowLeft,
     arrowTop: -arrowWidth - 5,
     arrowTransform: '',
     placement: 'bottom',
@@ -415,8 +420,13 @@ const placementTop = (
   // To make sure the popup does not overflow (negative X position)
   const finalPositionX = isPopupPortalTargetBody ? Math.max(computedPositionX, 0) : computedPositionX
 
+  const childrenCenterInParent = overloadedChildrenLeft + childrenWidth / 2
+
+  // Center the arrow with the children (in popup coordinates)
+  const arrowLeft = childrenCenterInParent - finalPositionX
+
   return {
-    arrowLeft: isAligned ? childrenWidth / 2 : popupWidth / 2 - popupOverflow,
+    arrowLeft,
     arrowTop: popupHeight - 1,
     arrowTransform: '',
     placement: 'top',


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?
`Popup`: arrow should be centered with children container (when computed position is top or bottom)

Before:
<img width="132" height="130" alt="Capture d’écran 2026-06-08 à 11 52 48" src="https://github.com/user-attachments/assets/30632f7e-da4e-4d19-b326-0704bd6293d9" />

After: 
<img width="132" height="130" alt="Capture d’écran 2026-06-08 à 11 52 35" src="https://github.com/user-attachments/assets/97fbc0db-3ed9-4640-ada9-ae31874053c8" />
