### PR TITLE
fix: add step in numberInputField storybook

### DIFF
--- a/.changeset/lazy-corners-burn.md
+++ b/.changeset/lazy-corners-burn.md
@@ -1,5 +1,0 @@
----
-"@ultraviolet/form": patch
----
-
-Add step in numberInputField playground

--- a/.changeset/lazy-corners-burn.md
+++ b/.changeset/lazy-corners-burn.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Add step in numberInputField playground

--- a/packages/form/src/components/NumberInputField/__stories__/Playground.stories.tsx
+++ b/packages/form/src/components/NumberInputField/__stories__/Playground.stories.tsx
@@ -5,4 +5,5 @@ export const Playground = Template.bind({})
 Playground.args = {
   min: 10,
   name: 'value',
+  step: 1,
 }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

Add missing step props in NumberInputField storybook

#### What is expected?

Step should be visible in playground

#### The following changes were made:

(Describe what you did)

1.

2.

3.

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
