### PR TITLE
refactor: breaking: change NumberInputField isInteger handling

### DIFF
--- a/.changeset/empty-rings-relate.md
+++ b/.changeset/empty-rings-relate.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+breaking: change NumberInputField isInteger error handling

--- a/examples/next/src/constants.ts
+++ b/examples/next/src/constants.ts
@@ -3,15 +3,13 @@ export const APP_MAX_WIDTH = 1140
 
 export const EMAIL_REGEX = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i
 export const mockErrors: FormErrors = {
-  isInteger: ({ isInteger }) => {
-    if (typeof isInteger === 'number') {
-      if (Number.isInteger(isInteger)) {
-        return 'This field should be a decimal number'
+  isInteger: ({ isInteger, isNumber }) => {
+    if (isNumber) {
+      if (isInteger) {
+        return 'This field should be a whole number'
       }
-
-      return 'This field should be a whole number'
+      return 'This field should be a decimal number'
     }
-
     return 'This field should be a number'
   },
   max: ({ max }) => `This field is too high (maximum is : ${max})`,

--- a/packages/form/src/components/NumberInputField/index.tsx
+++ b/packages/form/src/components/NumberInputField/index.tsx
@@ -58,7 +58,8 @@ export const NumberInputField = <
       aria-label={ariaLabel}
       error={getError(
         {
-          isInteger: step,
+          isNumber: !Number.isNaN(field.value),
+          isInteger: Number.isInteger(step),
           label: errorLabel ?? label ?? ariaLabel ?? name,
           max,
           min,

--- a/packages/form/src/mocks/mockErrors.ts
+++ b/packages/form/src/mocks/mockErrors.ts
@@ -3,15 +3,13 @@ import type { FormErrors } from '../types'
 export const emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/iu
 
 export const mockErrors: FormErrors = {
-  isInteger: ({ isInteger }) => {
-    if (typeof isInteger === 'number') {
-      if (Number.isInteger(isInteger)) {
-        return 'This field should be a decimal number'
+  isInteger: ({ isInteger, isNumber }) => {
+    if (isNumber) {
+      if (isInteger) {
+        return 'This field should be a whole number'
       }
-
-      return 'This field should be a whole number'
+      return 'This field should be a decimal number'
     }
-
     return 'This field should be a number'
   },
   max: ({ max }) => `This field is too high (maximum is : ${max})`,

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -12,7 +12,8 @@ import type {
 } from 'react-hook-form'
 
 export type MetaField = {
-  isInteger?: number | string
+  isNumber?: boolean
+  isInteger?: boolean
   min?: number | string
   max?: number | string
   minLength?: number

--- a/utils/test/src/vitest/helpers/index.tsx
+++ b/utils/test/src/vitest/helpers/index.tsx
@@ -19,13 +19,12 @@ export const ComponentWrapper = ({
 )
 
 export const mockFormErrors: FormErrors = {
-  isInteger: ({ isInteger }) => {
-    if (typeof isInteger === 'number') {
-      if (Number.isInteger(isInteger)) {
-        return 'This field should be a decimal number'
+  isInteger: ({ isInteger, isNumber }) => {
+    if (isNumber) {
+      if (isInteger) {
+        return 'This field should be a whole number'
       }
-
-      return 'This field should be a whole number'
+      return 'This field should be a decimal number'
     }
 
     return 'This field should be a number'

--- a/utils/test/src/vitest/mockFormErrors.ts
+++ b/utils/test/src/vitest/mockFormErrors.ts
@@ -1,13 +1,12 @@
 import type { FormErrors } from '../../../../packages/form/src'
 
 export const mockFormErrors: FormErrors = {
-  isInteger: ({ isInteger }) => {
-    if (typeof isInteger === 'number') {
-      if (Number.isInteger(isInteger)) {
-        return 'This field should be a decimal number'
+  isInteger: ({ isInteger, isNumber }) => {
+    if (isNumber) {
+      if (isInteger) {
+        return 'This field should be a whole number'
       }
-
-      return 'This field should be a whole number'
+      return 'This field should be a decimal number'
     }
 
     return 'This field should be a number'


### PR DESCRIPTION
## Summary

## Type

- Refactor

### Summarize concisely:

Change NumberInputField isInteger error handling to pass boolean instead of step that does not handle every cases

#### What is expected?

this is a breaking change, project using this library and using NumberInputField's isInteger form error function will have to update their codebase to use isInteger as boolean and isNumber as boolean

