### PR TITLE
fix(FileInputField): label and aria label

### DIFF
--- a/.changeset/many-cats-drop.md
+++ b/.changeset/many-cats-drop.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`FileInput`: fix label type

--- a/packages/form/src/components/FileInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/FileInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`fileInputField > should render correctly as an overlay 1`] = `
           data-testid="drag-container"
         >
           <input
+            aria-label="Test"
             class="uv_12cubgs9"
             id="_r_8_"
             name="Test"

--- a/packages/form/src/components/FileInputField/index.tsx
+++ b/packages/form/src/components/FileInputField/index.tsx
@@ -11,9 +11,15 @@ type FileInputFieldProps<TFieldValues extends FieldValues, TFieldName extends Fi
   TFieldValues,
   TFieldName
 > &
-  Omit<ComponentProps<typeof FileInput>, 'error' | 'name' | 'onChangeFiles' | 'label' | 'aria-label'> & {
-    label: string
-  }
+  Omit<ComponentProps<typeof FileInput>, 'error' | 'name' | 'onChangeFiles' | 'label' | 'aria-label'> &
+  XOR<
+    [
+      {
+        label: string
+      },
+      { 'aria-label': string },
+    ]
+  >
 
 /**
  * This component offers a form field based on Ultraviolet UI FileInput component
@@ -36,9 +42,12 @@ const FileInputFieldBase = <
   bottom,
   children,
   errorLabel,
+  'aria-label': ariaLabel,
   ...props
 }: FileInputFieldProps<TFieldValues, TFieldName>) => {
   const { getError } = useErrors()
+
+  const computedLabel = label ?? ariaLabel ?? name
 
   const {
     field,
@@ -52,12 +61,14 @@ const FileInputFieldBase = <
     shouldUnregister,
   })
 
+  const inputLabelProps = label ? { label } : { 'aria-label': ariaLabel ?? name }
+
   if (variant === 'overlay' && children) {
     return (
       <FileInput
         {...props}
-        error={getError({ label: errorLabel ?? label }, error)}
-        label={label}
+        error={getError({ label: errorLabel ?? computedLabel }, error)}
+        aria-label={computedLabel}
         onChangeFiles={files => {
           field.onChange(files)
           onChange?.(files as PathValue<TFieldValues, Path<TFieldValues>>)
@@ -75,8 +86,7 @@ const FileInputFieldBase = <
     <FileInput
       {...props}
       bottom={bottom}
-      error={getError({ label }, error)}
-      label={label}
+      error={getError({ label: errorLabel ?? computedLabel }, error)}
       onChangeFiles={files => {
         field.onChange(files)
         onChange?.(files as PathValue<TFieldValues, Path<TFieldValues>>)
@@ -85,6 +95,7 @@ const FileInputFieldBase = <
       size={size}
       title={title}
       variant="dropzone"
+      {...inputLabelProps}
     >
       {typeof children === 'function' ? (inputId, inputRef) => children(inputId, inputRef) : children}
     </FileInput>

--- a/packages/ui/src/components/FileInput/types.ts
+++ b/packages/ui/src/components/FileInput/types.ts
@@ -14,7 +14,14 @@ export type ErrorType = { fileName?: string; error: string }
  */
 export type MimeType = 'application' | 'audio' | 'example' | 'font' | 'image' | 'model' | 'text' | 'video'
 
-type LabelType = { label: string; 'aria-label'?: never } | { label?: never; 'aria-label': string }
+type LabelType = XOR<
+  [
+    {
+      label: string
+    },
+    { 'aria-label': string },
+  ]
+>
 
 /**
  * Add the dropzone inside any content: when hovering, replace the content with the dropzone overlay


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?

`FileInput`: fix label type (`label` was mandatory even with aria-label and for overlay variant which do not display the label)