### PR TITLE
fix(TextInput): focus management

### DIFF
--- a/.changeset/wise-cloths-sort.md
+++ b/.changeset/wise-cloths-sort.md
@@ -1,0 +1,7 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`TextInput`:
+- replace React useState focus management with native CSS pseudo-selector
+- fix hover and focus styles with error and success states

--- a/packages/form/src/components/DateInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/DateInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,6 @@ exports[`dateInputField > should clear field 1`] = `
               class="uv_q3q8048 uv_q3q8045"
               data-disabled="false"
               data-error="false"
-              data-has-focus="false"
               data-readonly="false"
               data-success="false"
             >
@@ -509,7 +508,6 @@ exports[`dateInputField > should render correctly 1`] = `
               class="uv_q3q8048 uv_q3q8045"
               data-disabled="false"
               data-error="false"
-              data-has-focus="false"
               data-readonly="false"
               data-success="false"
             >
@@ -578,7 +576,6 @@ exports[`dateInputField > should render correctly disabled 1`] = `
               class="uv_q3q8048 uv_q3q8045"
               data-disabled="true"
               data-error="false"
-              data-has-focus="false"
               data-readonly="false"
               data-success="false"
             >
@@ -648,7 +645,6 @@ exports[`dateInputField > should test range 1`] = `
               class="uv_q3q8048 uv_q3q8045"
               data-disabled="false"
               data-error="false"
-              data-has-focus="false"
               data-readonly="false"
               data-success="false"
             >
@@ -719,7 +715,6 @@ exports[`dateInputField > should trigger events 1`] = `
               class="uv_q3q8048 uv_q3q8045"
               data-disabled="false"
               data-error="false"
-              data-has-focus="false"
               data-readonly="false"
               data-success="false"
             >

--- a/packages/form/src/components/Submit/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/Submit/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`submit > form is invalid 1`] = `
           class="uv_q3q8048 uv_q3q8045"
           data-disabled="false"
           data-error="false"
-          data-has-focus="false"
           data-readonly="false"
           data-success="false"
         >

--- a/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`textInputField > should render correctly 1`] = `
           class="uv_q3q8048 uv_q3q8045"
           data-disabled="false"
           data-error="false"
-          data-has-focus="false"
           data-readonly="false"
           data-success="false"
         >
@@ -73,7 +72,6 @@ exports[`textInputField > should render correctly generated 1`] = `
           class="uv_q3q8048 uv_q3q8045"
           data-disabled="false"
           data-error="false"
-          data-has-focus="false"
           data-readonly="false"
           data-success="false"
         >

--- a/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/DateInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`dateInput > render correctly with showMonthYearPicker 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -96,7 +95,6 @@ exports[`dateInput > render correctly with showMonthYearPicker with default date
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="true"
             data-readonly="false"
             data-success="false"
           >
@@ -323,7 +321,6 @@ exports[`dateInput > render correctly with showMonthYearPicker with excluded mon
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="true"
             data-readonly="false"
             data-success="false"
           >
@@ -552,7 +549,6 @@ exports[`dateInput > renders correctly custom format with range 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -623,7 +619,6 @@ exports[`dateInput > renders correctly disabled 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="true"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -693,7 +688,6 @@ exports[`dateInput > renders correctly error 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="true"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -789,7 +783,6 @@ exports[`dateInput > renders correctly error disabled 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="true"
             data-error="true"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -895,7 +888,6 @@ exports[`dateInput > renders correctly error disabled required 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="true"
             data-error="true"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -993,7 +985,6 @@ exports[`dateInput > renders correctly min-max 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -1071,7 +1062,6 @@ exports[`dateInput > renders correctly required 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -1141,7 +1131,6 @@ exports[`dateInput > renders correctly with a array of dates to exclude 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="true"
             data-readonly="false"
             data-success="false"
           >
@@ -1627,7 +1616,6 @@ exports[`dateInput > renders correctly with date-fns locale es 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="true"
             data-readonly="false"
             data-success="false"
           >
@@ -2108,7 +2096,6 @@ exports[`dateInput > renders correctly with date-fns locale fr 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="true"
             data-readonly="false"
             data-success="false"
           >
@@ -2589,7 +2576,6 @@ exports[`dateInput > renders correctly with date-fns locale ru 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="true"
             data-readonly="false"
             data-success="false"
           >
@@ -3070,7 +3056,6 @@ exports[`dateInput > renders correctly with default props 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >

--- a/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`searchInput > renders correctly without children props 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -88,7 +87,6 @@ exports[`searchInput > renders with disabled prop 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="true"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -156,7 +154,6 @@ exports[`searchInput > renders with error prop 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="true"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -250,7 +247,6 @@ exports[`searchInput > renders with shortcut prop > as array of string 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >
@@ -365,7 +361,6 @@ exports[`searchInput > renders with shortcut prop > as boolean 1`] = `
             class="styles__q3q8048 styles_large__q3q8045"
             data-disabled="false"
             data-error="false"
-            data-has-focus="false"
             data-readonly="false"
             data-success="false"
           >

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -206,7 +206,6 @@ exports[`selectInput > renders correctly grouped 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -1006,7 +1005,6 @@ exports[`selectInput > renders correctly multiselect 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -2107,7 +2105,6 @@ exports[`selectInput > renders correctly required 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -2617,7 +2614,6 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -2986,7 +2982,6 @@ exports[`selectInput > renders correctly with default value 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -3430,7 +3425,6 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -3897,7 +3891,6 @@ exports[`selectInput > renders correctly with error 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -4273,7 +4266,6 @@ exports[`selectInput > renders correctly with footer 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -5593,7 +5585,6 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -6055,7 +6046,6 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -6967,7 +6957,6 @@ exports[`selectInput > renders correctly with label on the right and optional in
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >
@@ -7786,7 +7775,6 @@ exports[`selectInput > renders correctly with success 1`] = `
                   class="styles__q3q8048 styles_medium__q3q8046"
                   data-disabled="false"
                   data-error="false"
-                  data-has-focus="true"
                   data-readonly="false"
                   data-success="false"
                 >

--- a/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`textInput > should render correctly when input  has a error sentiment 1
         class="styles__q3q8048 styles_large__q3q8045"
         data-disabled="false"
         data-error="true"
-        data-has-focus="false"
         data-readonly="false"
         data-success="false"
       >
@@ -81,7 +80,6 @@ exports[`textInput > should render correctly when input has a success sentiment 
         class="styles__q3q8048 styles_large__q3q8045"
         data-disabled="false"
         data-error="false"
-        data-has-focus="false"
         data-readonly="false"
         data-success="true"
       >
@@ -144,7 +142,6 @@ exports[`textInput > should render correctly when input is disabled 1`] = `
         class="styles__q3q8048 styles_large__q3q8045"
         data-disabled="true"
         data-error="false"
-        data-has-focus="false"
         data-readonly="false"
         data-success="false"
       >
@@ -181,7 +178,6 @@ exports[`textInput > should render correctly when input is readOnly 1`] = `
         class="styles__q3q8048 styles_large__q3q8045"
         data-disabled="false"
         data-error="false"
-        data-has-focus="false"
         data-readonly="true"
         data-success="false"
       >
@@ -218,7 +214,6 @@ exports[`textInput > should render correctly with basic props 1`] = `
         class="styles__q3q8048 styles_large__q3q8045"
         data-disabled="false"
         data-error="false"
-        data-has-focus="false"
         data-readonly="false"
         data-success="false"
       >

--- a/packages/ui/src/components/TextInput/index.tsx
+++ b/packages/ui/src/components/TextInput/index.tsx
@@ -70,7 +70,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   ) => {
     const localId = useId()
     const helperId = useId()
-    const [hasFocus, setHasFocus] = useState(false)
+
     const [localValue, setLocalValue] = useState(defaultValue)
     const inputRef = useRef<HTMLInputElement>(null)
     useImperativeHandle(ref, () => inputRef.current!)
@@ -108,7 +108,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             className={cn(textInputStyle.inputWrapper, textInputStyle.inputWrapperSizes[size])}
             data-disabled={disabled}
             data-error={!!error}
-            data-has-focus={hasFocus}
             data-readonly={readOnly}
             data-success={!!success}
           >
@@ -130,15 +129,9 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               maxLength={maxLength}
               minLength={minLength}
               name={name}
-              onBlur={event => {
-                setHasFocus(false)
-                onBlur?.(event)
-              }}
+              onBlur={onBlur}
               onChange={onChangeCallback}
-              onFocus={event => {
-                setHasFocus(true)
-                onFocus?.(event)
-              }}
+              onFocus={onFocus}
               onKeyDown={onKeyDown}
               onKeyUp={onKeyUp}
               placeholder={placeholder}

--- a/packages/ui/src/components/TextInput/styles.css.ts
+++ b/packages/ui/src/components/TextInput/styles.css.ts
@@ -72,14 +72,10 @@ const inputWrapper = style({
     '&:not([data-disabled="true"]):not([data-readonly="true"]):hover': {
       borderColor: theme.colors.primary.border,
     },
-    "&[data-disabled='true']": {
-      background: theme.colors.neutral.backgroundDisabled,
-      borderColor: theme.colors.neutral.borderDisabled,
-    },
     "&[data-error='true']": {
       borderColor: theme.colors.danger.border,
     },
-    "&[data-has-focus='true']": {
+    '&:focus-within': {
       border: `1px solid ${theme.colors.primary.border}`,
       boxShadow: theme.shadows.focusPrimary,
     },
@@ -89,6 +85,25 @@ const inputWrapper = style({
     },
     "&[data-success='true']": {
       borderColor: theme.colors.success.border,
+    },
+    "&[data-error='true']:focus-within": {
+      boxShadow: theme.shadows.focusDanger,
+      borderColor: theme.colors.danger.border,
+    },
+    "&[data-success='true']:focus-within": {
+      boxShadow: theme.shadows.focusSuccess,
+      borderColor: theme.colors.success.border,
+    },
+    '&:not([data-disabled="true"]):not([data-readonly="true"])[data-success="true"]:hover': {
+      borderColor: theme.colors.success.borderHover,
+    },
+    '&:not([data-disabled="true"]):not([data-readonly="true"])[data-error="true"]:hover': {
+      borderColor: theme.colors.danger.borderHover,
+    },
+
+    "&[data-disabled='true']": {
+      background: theme.colors.neutral.backgroundDisabled,
+      borderColor: theme.colors.neutral.borderDisabled,
     },
   },
   width: '100%',


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`TextInput`:
- replace React useState focus management with native CSS pseudo-selector
- fix hover and focus styles with error and success states

| |   Before   |      After |
| :---: | :--------: | ---------: |
| Success  | <img width="446" height="99" alt="Capture d’écran 2026-06-12 à 10 52 20" src="https://github.com/user-attachments/assets/4ce530ac-57b2-4e93-af8b-9737441937a6" /> | <img width="446" height="99" alt="Capture d’écran 2026-06-12 à 10 51 46" src="https://github.com/user-attachments/assets/fcea2d79-dc28-4666-9544-a30fe1d2faa0" /> |
| Error  | <img width="446" height="99" alt="Capture d’écran 2026-06-12 à 10 52 32" src="https://github.com/user-attachments/assets/6ff37860-ce8c-4b11-bdce-23ff64db6180" /> | <img width="446" height="99" alt="Capture d’écran 2026-06-12 à 10 51 56" src="https://github.com/user-attachments/assets/729dab47-ba0c-49da-9660-999de44555c0" /> |
