### PR TITLE
fix: missing default size + flaky test

### DIFF
--- a/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SearchInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -34,17 +34,17 @@ exports[`searchInput > renders correctly without children props 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  width="16"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzf uv_icons_1sbwqkz26"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
                 >
                   <title>
                     SearchIcon
                   </title>
                   <path
                     clip-rule="evenodd"
-                    d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
                     fill-rule="evenodd"
                   />
                 </svg>
@@ -101,17 +101,17 @@ exports[`searchInput > renders with disabled prop 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz2 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz1a"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  width="16"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz2 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzf uv_icons_1sbwqkz1a"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
                 >
                   <title>
                     SearchIcon
                   </title>
                   <path
                     clip-rule="evenodd"
-                    d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
                     fill-rule="evenodd"
                   />
                 </svg>
@@ -169,17 +169,17 @@ exports[`searchInput > renders with error prop 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  width="16"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzf uv_icons_1sbwqkz26"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
                 >
                   <title>
                     SearchIcon
                   </title>
                   <path
                     clip-rule="evenodd"
-                    d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
                     fill-rule="evenodd"
                   />
                 </svg>
@@ -263,17 +263,17 @@ exports[`searchInput > renders with shortcut prop > as array of string 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  width="16"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzf uv_icons_1sbwqkz26"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
                 >
                   <title>
                     SearchIcon
                   </title>
                   <path
                     clip-rule="evenodd"
-                    d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
                     fill-rule="evenodd"
                   />
                 </svg>
@@ -378,17 +378,17 @@ exports[`searchInput > renders with shortcut prop > as boolean 1`] = `
                 data-testid="search-icon"
               >
                 <svg
-                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzg uv_icons_1sbwqkz26"
-                  height="16"
-                  viewBox="0 0 16 16"
-                  width="16"
+                  class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz6 uv_icons_1sbwqkz9 uv_icons_1sbwqkzf uv_icons_1sbwqkz26"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  width="20"
                 >
                   <title>
                     SearchIcon
                   </title>
                   <path
                     clip-rule="evenodd"
-                    d="M9.965 11.026a5 5 0 1 1 1.06-1.06l2.755 2.754a.75.75 0 1 1-1.06 1.06zM10.5 7a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"
+                    d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11M2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9"
                     fill-rule="evenodd"
                   />
                 </svg>

--- a/packages/ui/src/components/SearchInput/index.tsx
+++ b/packages/ui/src/components/SearchInput/index.tsx
@@ -36,7 +36,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       label,
       labelDescription,
       loading,
-      size,
+      size = 'large',
       popupPlacement,
       threshold = 0,
       children,

--- a/packages/ui/src/compositions/RichTextInput/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/RichTextInput/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
 import { beforeAll, describe, expect, it, vi } from 'vitest'

--- a/packages/ui/src/compositions/RichTextInput/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/RichTextInput/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
@@ -26,15 +26,15 @@ describe('richTextInput', () => {
   it('should call onChange when typing', async () => {
     const onChange = vi.fn()
 
-    renderWithTheme(<RichTextInput aria-label="Test" onChange={onChange} value="test" />)
+    renderWithTheme(<RichTextInput aria-label="Test" onChange={onChange} />)
 
     const doc = screen.getByRole('textbox')
-    await waitFor(() => expect(doc.textContent).toBe('test'))
 
     await userEvent.click(doc)
-    await userEvent.type(doc, 'a')
+    await userEvent.type(doc, 'test')
 
-    expect(onChange).toHaveBeenCalledExactlyOnceWith('<p>testa</p>')
+    expect(onChange).toHaveBeenCalledTimes(4)
+    expect(onChange).toHaveBeenLastCalledWith('<p>test</p>')
   })
 
   it('should return empty string when cleared', async () => {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### The following changes were made:

- Add the default size `large` on the SearchInput in order to have a correct icon size
- another attempt to fix a flaky test on the RichTextInput

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | screenshot | screenshot |
| url  | screenshot | screenshot |
