### PR TITLE
docs: update a11y audit page

### DIFF
--- a/.oxlint/rules/storybook-a11y-partial.cjs
+++ b/.oxlint/rules/storybook-a11y-partial.cjs
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to check for a11y: partial in Storybook stories
+ * @fileoverview Rule to check for failed accessibility principles in Storybook stories
  */
 
 const STORYBOOK_A11Y_PARTIAL = {
@@ -7,7 +7,7 @@ const STORYBOOK_A11Y_PARTIAL = {
     name: 'a11y-partial',
     type: 'suggestion',
     docs: {
-      description: 'Report components with a11y: partial in index.stories.tsx files',
+      description: 'Report components with failed accessibility principles in index.stories.tsx files',
       category: 'Accessibility',
       recommended: false,
     },
@@ -15,7 +15,7 @@ const STORYBOOK_A11Y_PARTIAL = {
     schema: [],
     messages: {
       a11yPartialFound:
-        'Found a11y: partial for this component. Ensure accessibility improvements are tracked and documented.',
+        'Found a failed accessibility principle for this component. Ensure accessibility improvements are tracked and documented.',
     },
   },
 
@@ -30,9 +30,8 @@ const STORYBOOK_A11Y_PARTIAL = {
       Property(node) {
         if (
           node.key.type === 'Identifier' &&
-          node.key.name === 'a11yStatus' &&
-          node.value.type === 'Literal' &&
-          node.value.value === 'partial'
+          ['perceivable', 'operable', 'understandable', 'robust'].includes(node.key.name) &&
+          node.value.value === false
         ) {
           context.report({
             node,

--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -10,8 +10,6 @@ import '../../packages/themes/dist/themes.css'
 import type { ReactNode } from 'react'
 import { globalStyleStoryBook } from './globalStyle.css'
 
-type A11yLevel = 'partial' | 'compliant' | 'certified'
-
 type ExtraProps = {
   /**
    * When a component is deprecated we can set this property to true
@@ -33,16 +31,11 @@ type ExtraProps = {
    * This prop can be used to define if a component is being tested and not prod ready
    */
   experimental?: boolean
-  /**
-   * This prop can be used to define the accessibility compliance level
-   */
-  a11y?: boolean | A11yLevel
-  audit?: {
-    'keyboard-focus': boolean
-    'contrast-visuals': boolean
-    'semantics-screen-reader': boolean
-    'pointer-touch': boolean
-    'specific-patterns': boolean
+  a11yStatus?: {
+    perceivable: boolean
+    operable: boolean
+    understandable: boolean
+    robust: boolean
   }
 }
 
@@ -91,8 +84,7 @@ const DocsContainer = ({ children, context }: DocsContainerProps) => {
           <BaseContainer context={context}>
             {isValidElement<ExtraProps>(children)
               ? cloneElement(children, {
-                  a11y: parameters?.a11y,
-                  audit: parameters?.audit,
+                  a11yStatus: parameters?.a11yStatus,
                   deprecated: parameters?.deprecated,
                   deprecatedReason: parameters?.deprecatedReason,
                   experimental: isPlusLibrary ? true : parameters?.experimental,

--- a/packages/form/src/components/CheckboxField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/CheckboxField/__stories__/index.stories.tsx
@@ -64,13 +64,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A checkbox field',

--- a/packages/form/src/components/CheckboxGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/CheckboxGroupField/__stories__/index.stories.tsx
@@ -82,13 +82,6 @@ export default {
   },
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta<typeof CheckboxGroupField>
 

--- a/packages/form/src/components/DateInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/DateInputField/__stories__/index.stories.tsx
@@ -76,13 +76,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component:

--- a/packages/form/src/components/FileInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/FileInputField/__stories__/index.stories.tsx
@@ -85,13 +85,6 @@ export default {
   title: 'Form/Components/Fields/FileInputField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/Form/__stories__/index.stories.tsx
+++ b/packages/form/src/components/Form/__stories__/index.stories.tsx
@@ -5,13 +5,6 @@ export default {
   component: Form,
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'This is the main component that is needed to wrap your fields',

--- a/packages/form/src/components/KeyValueField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/KeyValueField/__stories__/index.stories.tsx
@@ -67,13 +67,6 @@ export default {
   title: 'Form/Components/Fields/KeyValueField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/NumberInputField/__stories__/index.stories.tsx
@@ -72,13 +72,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A NumberInput field',

--- a/packages/form/src/components/RadioField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/RadioField/__stories__/index.stories.tsx
@@ -70,13 +70,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A radio field',

--- a/packages/form/src/components/RadioGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/RadioGroupField/__stories__/index.stories.tsx
@@ -67,13 +67,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A group of radios field',

--- a/packages/form/src/components/SelectInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectInputField/__stories__/index.stories.tsx
@@ -66,13 +66,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A rich select field',

--- a/packages/form/src/components/SelectableCardField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectableCardField/__stories__/index.stories.tsx
@@ -66,13 +66,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A selectable card field',

--- a/packages/form/src/components/SelectableCardGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectableCardGroupField/__stories__/index.stories.tsx
@@ -69,13 +69,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A group of Selectable cards field',

--- a/packages/form/src/components/SelectableCardOptionGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__stories__/index.stories.tsx
@@ -70,13 +70,6 @@ export default {
   title: 'Form/Components/Fields/SelectableCardOptionGroupField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/SliderField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SliderField/__stories__/index.stories.tsx
@@ -78,13 +78,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A Slider field',

--- a/packages/form/src/components/Submit/__stories__/index.stories.tsx
+++ b/packages/form/src/components/Submit/__stories__/index.stories.tsx
@@ -5,13 +5,6 @@ export default {
   component: Submit,
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'Default submit button when no one is provided',

--- a/packages/form/src/components/SubmitErrorAlert/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SubmitErrorAlert/__stories__/index.stories.tsx
@@ -5,13 +5,6 @@ export default {
   component: SubmitErrorAlert,
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'This component is used to display error message after a form submission',

--- a/packages/form/src/components/SwitchButtonField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/SwitchButtonField/__stories__/index.stories.tsx
@@ -69,13 +69,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A SwitchButton field',

--- a/packages/form/src/components/TagInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TagInputField/__stories__/index.stories.tsx
@@ -69,13 +69,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A tags field',

--- a/packages/form/src/components/TextAreaField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextAreaField/__stories__/index.stories.tsx
@@ -68,13 +68,6 @@ export default {
   title: 'Form/Components/Fields/TextAreaField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TextInputField/__stories__/index.stories.tsx
@@ -70,13 +70,6 @@ export default {
   title: 'Form/Components/Fields/TextInputField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/TimeInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/TimeInputField/__stories__/index.stories.tsx
@@ -67,13 +67,6 @@ export default {
   title: 'Form/Components/Fields/TimeInputField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/ToggleField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/ToggleField/__stories__/index.stories.tsx
@@ -71,13 +71,6 @@ export default {
   ],
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
     docs: {
       description: {
         component: 'A switch field that act like a checkbox',

--- a/packages/form/src/components/ToggleGroupField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/ToggleGroupField/__stories__/index.stories.tsx
@@ -76,13 +76,6 @@ export default {
   },
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta<typeof ToggleGroupField>
 

--- a/packages/form/src/components/UnitInputField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/UnitInputField/__stories__/index.stories.tsx
@@ -67,13 +67,6 @@ export default {
   title: 'Form/Components/Fields/UnitInputField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/form/src/components/VerificationCodeField/__stories__/index.stories.tsx
+++ b/packages/form/src/components/VerificationCodeField/__stories__/index.stories.tsx
@@ -67,13 +67,6 @@ export default {
   title: 'Form/Components/Fields/VerificationCodeField',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
-    },
   },
 } as Meta
 

--- a/packages/ui/src/components/ActionBar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ActionBar/__stories__/index.stories.tsx
@@ -6,16 +6,11 @@ export default {
   title: 'UI/Overlay/ActionBar',
   tags: [],
   parameters: {
-    a11yStatus: 'partial',
-    a11y: {
-      test: 'error',
-    },
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } satisfies Meta<typeof ActionBar>

--- a/packages/ui/src/components/Alert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Alert/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Alert,
   title: 'UI/Feedback/Alert',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Avatar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Avatar/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Avatar,
   title: 'UI/Other/Avatar',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Badge/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Badge/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Badge,
   title: 'UI/Badges/Badge',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Badge>

--- a/packages/ui/src/components/Banner/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Banner/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Banner,
   title: 'UI/Other/Banner',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Banner>

--- a/packages/ui/src/components/BarChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/BarChart/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: BarChart,
   title: 'UI/Data Display/Chart/BarChart',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof BarChart>

--- a/packages/ui/src/components/BarStack/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/BarStack/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: BarStack,
   title: 'UI/Data Display/BarStack',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof BarStack>

--- a/packages/ui/src/components/Breadcrumbs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/index.stories.tsx
@@ -7,13 +7,11 @@ export default {
   subcomponents: { 'Breadcrumbs.Item': Item },
   title: 'UI/Navigation/Breadcrumbs',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Bullet/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Bullet/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Bullet,
   title: 'UI/Badges/Bullet',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Bullet>

--- a/packages/ui/src/components/Button/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Button/__stories__/index.stories.tsx
@@ -5,16 +5,11 @@ export default {
   component: Button,
   title: 'UI/Action/Button',
   parameters: {
-    a11y: {
-      statut: 'partial',
-      test: 'error',
-    },
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Button>

--- a/packages/ui/src/components/Card/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Card/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Card,
   title: 'UI/Layout/Card',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Carousel/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Carousel/__stories__/index.stories.tsx
@@ -6,13 +6,11 @@ export default {
   title: 'UI/Data Display/Carousel',
   subcomponents: { 'Carousel.Item': Carousel.Item },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Carousel>

--- a/packages/ui/src/components/Checkbox/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Checkbox/__stories__/index.stories.tsx
@@ -12,13 +12,11 @@ export default {
   ],
   title: 'UI/Data Entry/Checkbox',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Checkbox>

--- a/packages/ui/src/components/CheckboxGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/CheckboxGroup/__stories__/index.stories.tsx
@@ -17,13 +17,11 @@ export default {
     value: ['value-1'],
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof CheckboxGroup>

--- a/packages/ui/src/components/Chip/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Chip/__stories__/index.stories.tsx
@@ -15,13 +15,11 @@ export default {
   ],
   title: 'UI/Badges/Chip',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Chip>

--- a/packages/ui/src/components/CopyButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/CopyButton/__stories__/index.stories.tsx
@@ -13,13 +13,11 @@ export default {
   ],
   title: 'UI/Action/CopyButton',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof CopyButton>

--- a/packages/ui/src/components/DateInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/DateInput/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: DateInput,
   title: 'UI/Data Entry/DateInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Dialog/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Dialog/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Dialog,
   title: 'UI/Overlay/Dialog',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Dialog>

--- a/packages/ui/src/components/Drawer/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Drawer/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Drawer,
   title: 'UI/Overlay/Drawer',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Drawer>

--- a/packages/ui/src/components/EmptyState/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/EmptyState/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: EmptyState,
   title: 'UI/Data Display/EmptyState',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof EmptyState>

--- a/packages/ui/src/components/Expandable/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Expandable/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Expandable,
   title: 'UI/Action/Expandable',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/ExpandableCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ExpandableCard/__stories__/index.stories.tsx
@@ -8,13 +8,11 @@ export default {
     'ExpandableCard.Title': ExpandableCard.Title,
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/FileInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/FileInput/__stories__/index.stories.tsx
@@ -11,13 +11,11 @@ export default {
 
   title: 'UI/Data Entry/FileInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof FileInput>

--- a/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/GlobalAlert/__stories__/index.stories.tsx
@@ -6,13 +6,11 @@ export default {
   title: 'UI/Feedback/GlobalAlert',
   subcomponents: { 'GlobalAlert.Link': GlobalAlert.Link },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/InfiniteScroll/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/InfiniteScroll/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: InfiniteScroll,
   title: 'UI/Data Display/InfiniteScroll',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Key/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Key/__stories__/index.stories.tsx
@@ -13,13 +13,11 @@ export default {
   ],
   title: 'UI/Other/Key',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Key>

--- a/packages/ui/src/components/Label/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Label/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Label,
   title: 'UI/Typography/Label',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/LineChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/LineChart/__stories__/index.stories.tsx
@@ -6,12 +6,11 @@ export default {
   title: 'UI/Data Display/Chart/LineChart',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Link/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Link/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Link,
   title: 'UI/Action/Link',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/List/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/List/__stories__/index.stories.tsx
@@ -9,13 +9,11 @@ export default {
     'List.Cell': List.Cell,
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof List>

--- a/packages/ui/src/components/Loader/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Loader/__stories__/index.stories.tsx
@@ -13,13 +13,11 @@ export default {
     ),
   ],
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Menu/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Menu/__stories__/index.stories.tsx
@@ -11,13 +11,11 @@ export default {
     ),
   ],
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
 
     docs: {

--- a/packages/ui/src/components/Meter/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Meter/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Meter,
   title: 'UI/Feedback/Meter',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Meter>

--- a/packages/ui/src/components/Modal/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Modal/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Modal,
   title: 'UI/Overlay/Modal',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Modal>

--- a/packages/ui/src/components/Notice/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Notice/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Notice,
   title: 'UI/Feedback/Notice',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Notice>

--- a/packages/ui/src/components/Notification/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Notification/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: NotificationContainer,
   title: 'UI/Feedback/Notification',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof NotificationContainer>

--- a/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/index.stories.tsx
@@ -16,13 +16,11 @@ export default {
   ],
   title: 'UI/Data Entry/NumberInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof NumberInput>

--- a/packages/ui/src/components/Pagination/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Pagination/__stories__/index.stories.tsx
@@ -5,12 +5,11 @@ export default {
   title: 'UI/Navigation/Pagination',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 }

--- a/packages/ui/src/components/PasswordCheck/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PasswordCheck/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: PasswordCheck,
   title: 'UI/Feedback/PasswordCheck',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof PasswordCheck>

--- a/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/PieChart/__stories__/index.stories.tsx
@@ -6,12 +6,11 @@ export default {
   title: 'UI/Data Display/Chart/PieChart',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Popover/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Popover/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Popover,
   title: 'UI/Overlay/Popover',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Popover>

--- a/packages/ui/src/components/ProgressBar/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ProgressBar/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: ProgressBar,
   title: 'UI/Feedback/ProgressBar',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof ProgressBar>

--- a/packages/ui/src/components/Radio/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Radio/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Radio,
   title: 'UI/Data Entry/Radio',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Radio>

--- a/packages/ui/src/components/RadioGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/RadioGroup/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: RadioGroup,
   title: 'UI/Data Entry/RadioGroup',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof RadioGroup>

--- a/packages/ui/src/components/Row/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Row/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Row,
   title: 'UI/Layout/Row',
   parameters: {
-    a11y: 'compliant',
-    audit: {
-      'keyboard-focus': true,
-      'contrast-visuals': true,
-      'semantics-screen-reader': true,
-      'pointer-touch': true,
-      'specific-patterns': true,
+    a11yStatus: {
+      perceivable: true,
+      operable: true,
+      understandable: true,
+      robust: true,
     },
   },
 } as Meta<typeof Row>

--- a/packages/ui/src/components/SearchInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SearchInput/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: SearchInput,
   title: 'UI/Data Entry/SearchInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof SearchInput>

--- a/packages/ui/src/components/SelectInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectInput/__stories__/index.stories.tsx
@@ -13,13 +13,11 @@ export default {
 
   title: 'UI/Data Entry/SelectInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof SelectInput>

--- a/packages/ui/src/components/SelectableCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectableCard/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: SelectableCard,
   title: 'UI/Data Entry/SelectableCard',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof SelectableCard>

--- a/packages/ui/src/components/SelectableCardGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectableCardGroup/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: SelectableCardGroup,
   title: 'UI/Data Entry/SelectableCardGroup',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof SelectableCardGroup>

--- a/packages/ui/src/components/SelectableCardOptionGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SelectableCardOptionGroup/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: SelectableCardOptionGroup,
   title: 'UI/Data Entry/SelectableCardOptionGroup',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof SelectableCardOptionGroup>

--- a/packages/ui/src/components/Separator/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Separator/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Separator,
   title: 'UI/Layout/Separator',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Skeleton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Skeleton/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Skeleton,
   title: 'UI/Feedback/Skeleton',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Skeleton>

--- a/packages/ui/src/components/Slider/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Slider/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Slider,
   title: 'UI/Data Entry/Slider',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Slider>

--- a/packages/ui/src/components/Snippet/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Snippet/__stories__/index.stories.tsx
@@ -13,13 +13,11 @@ export default {
   ],
   title: 'UI/Data Display/Snippet',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Snippet>

--- a/packages/ui/src/components/Stack/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Stack/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Stack,
   title: 'UI/Layout/Stack',
   parameters: {
-    a11y: 'compliant',
-    audit: {
-      'keyboard-focus': true,
-      'contrast-visuals': true,
-      'semantics-screen-reader': true,
-      'pointer-touch': true,
-      'specific-patterns': true,
+    a11yStatus: {
+      perceivable: true,
+      operable: true,
+      understandable: true,
+      robust: true,
     },
   },
 } as Meta<typeof Stack>

--- a/packages/ui/src/components/Status/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Status/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Status,
   title: 'UI/Feedback/Status',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/StepList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/StepList/__stories__/index.stories.tsx
@@ -5,12 +5,11 @@ export default {
   component: StepList,
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/Stepper/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Stepper/__stories__/index.stories.tsx
@@ -9,13 +9,11 @@ export default {
   },
   title: 'UI/Navigation/Stepper',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/SwitchButton/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/SwitchButton/__stories__/index.stories.tsx
@@ -8,13 +8,11 @@ export default {
   },
   title: 'UI/Action/SwitchButton',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Table/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Table/__stories__/index.stories.tsx
@@ -6,13 +6,11 @@ export default {
   title: 'UI/Data Display/Table',
   subcomponents: { 'Table.Row': Table.Row, 'Table.Cell': Table.Cell },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Tabs/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tabs/__stories__/index.stories.tsx
@@ -6,13 +6,11 @@ export default {
   subcomponents: { 'Tabs.Tab': Tabs.Tab },
   title: 'UI/Navigation/Tabs',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Tabs>

--- a/packages/ui/src/components/Tag/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tag/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Tag,
   title: 'UI/Badges/Tag',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/TagInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TagInput/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: TagInput,
   title: 'UI/Data Entry/TagInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/TagList/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TagList/__stories__/index.stories.tsx
@@ -12,13 +12,11 @@ export default {
   ],
   title: 'UI/Data Display/TagList',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/Text/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Text/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Text,
   title: 'UI/Typography/Text',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/TextArea/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextArea/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: TextArea,
   title: 'UI/Data Entry/TextArea',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof TextArea>

--- a/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TextInput/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: TextInput,
   title: 'UI/Data Entry/TextInput',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof TextInput>

--- a/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TimeInput/__stories__/index.stories.tsx
@@ -6,13 +6,11 @@ export default {
   title: 'UI/Data Entry/TimeInput',
   decorators: [Story => <Story />],
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof TimeInput>

--- a/packages/ui/src/components/Toaster/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Toaster/__stories__/index.stories.tsx
@@ -10,12 +10,11 @@ export default {
   },
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 }

--- a/packages/ui/src/components/Toggle/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Toggle/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Toggle,
   title: 'UI/Data Entry/Toggle',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof Toggle>

--- a/packages/ui/src/components/ToggleGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/ToggleGroup/__stories__/index.stories.tsx
@@ -17,13 +17,11 @@ export default {
     value: ['weekly-save'],
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof ToggleGroup>

--- a/packages/ui/src/components/Tooltip/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/Tooltip/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Tooltip,
   title: 'UI/Overlay/Tooltip',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/TreeMapChart/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/TreeMapChart/__stories__/index.stories.tsx
@@ -6,12 +6,11 @@ export default {
   title: 'UI/Data Display/Chart/TreeMapChart',
   parameters: {
     a11y: false,
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/components/UnitInput/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/UnitInput/__stories__/index.stories.tsx
@@ -12,13 +12,11 @@ export default {
     ),
   ],
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta

--- a/packages/ui/src/components/VerificationCode/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/VerificationCode/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: VerificationCode,
   title: 'UI/Data Entry/VerificationCode',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
   },
 } as Meta<typeof VerificationCode>

--- a/packages/ui/src/compositions/CodeEditor/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/CodeEditor/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: CodeEditor,
   title: 'Compositions/CodeEditor',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/ContentCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/ContentCard/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: ContentCard,
   title: 'Compositions/ContentCard',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/ContentCardGroup/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/ContentCardGroup/__stories__/index.stories.tsx
@@ -6,13 +6,11 @@ export default {
   title: 'Compositions/ContentCardGroup',
   subcomponents: { 'ContentCardGroup.Card': ContentCardGroup.Card },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/Conversation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Conversation/__stories__/index.stories.tsx
@@ -11,13 +11,11 @@ export default {
   },
   title: 'Compositions/Conversation',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/CustomerSatisfaction/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/CustomerSatisfaction/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: CustomerSatisfaction,
   title: 'Compositions/CustomerSatisfaction',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/EstimateCost/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/EstimateCost/__stories__/index.stories.tsx
@@ -21,13 +21,11 @@ export default {
   },
   title: 'Compositions/EstimateCost',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/FAQ/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/FAQ/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: FAQ,
   title: 'Compositions/FAQ',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/InfoTable/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/InfoTable/__stories__/index.stories.tsx
@@ -11,13 +11,11 @@ export default {
     'InfoTable.CellWithCopyButton': InfoTable.CellWithCopyButton,
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Navigation/__stories__/index.stories.tsx
@@ -13,13 +13,11 @@ export default {
     'Navigation.ShowHide': Navigation.ShowHide,
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
     layout: 'fullscreen',

--- a/packages/ui/src/compositions/OfferList/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OfferList/__stories__/index.stories.tsx
@@ -10,13 +10,11 @@ export default {
     'OfferList.Cell': OfferList.Cell,
   },
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/OptionSelector/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OptionSelector/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: OptionSelector,
   title: 'Compositions/OptionSelector',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/OrderSummary/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/OrderSummary/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: OrderSummary,
   title: 'Compositions/OrderSummary',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/Plans/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/Plans/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: Plans,
   title: 'Compositions/Plans',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/packages/ui/src/compositions/SteppedListCard/__stories__/index.stories.tsx
+++ b/packages/ui/src/compositions/SteppedListCard/__stories__/index.stories.tsx
@@ -5,13 +5,11 @@ export default {
   component: SteppedListCard,
   title: 'Compositions/SteppedListCard',
   parameters: {
-    a11yStatus: 'partial',
-    audit: {
-      'keyboard-focus': false,
-      'contrast-visuals': false,
-      'semantics-screen-reader': false,
-      'pointer-touch': false,
-      'specific-patterns': false,
+    a11yStatus: {
+      perceivable: false,
+      operable: false,
+      understandable: false,
+      robust: false,
     },
     experimental: true,
   },

--- a/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
+++ b/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
@@ -1,13 +1,25 @@
 import { linkTo } from '@storybook/addon-links'
-import { CheckCircleOutlineIcon } from '@ultraviolet/icons/CheckCircleOutlineIcon'
+import { CheckCircleIcon } from '@ultraviolet/icons'
 import { CloseCircleOutlineIcon } from '@ultraviolet/icons/CloseCircleOutlineIcon'
-import { Button, Stack, Table, Text, Tooltip, ProgressBar } from '@ultraviolet/ui'
+import { Button, Stack, Table, Text, Tooltip, ProgressBar, Link } from '@ultraviolet/ui'
 import { useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import { findComponentState } from '../ComponentState/constants'
 import { storiesCompositionsModules, storiesComponentModules } from '../constants'
-import { AUDIT_CATEGORIES, A11Y_LEVELS, findA11yStatus, getComponentAuditCategories } from './constants'
-import type { A11yLevel, ComponentAuditStatus, AuditCategories, ComponentStoryParameters } from './constants'
+import {
+  A11Y_LEVELS,
+  findA11yLevel,
+  getComponentA11yStatus,
+  getComponentAuditCategories,
+  WCAG_PRINCIPLES,
+} from './constants'
+import type {
+  A11yLevel,
+  ComponentA11yStatus,
+  AuditCategories,
+  ComponentStoryParameters,
+  WcagPrinciple,
+} from './constants'
 
 type ComponentInfo = {
   title: string
@@ -19,11 +31,9 @@ type ComponentInfo = {
     description: ReactNode
   }
   a11yLevel: A11yLevel | null
-  audit: ComponentAuditStatus
+  a11yStatus: ComponentA11yStatus
   auditCategories: AuditCategories
 }
-
-const getComponentAudit = (parameters: ComponentStoryParameters): ComponentAuditStatus => parameters?.audit ?? {}
 
 const AccessibilityAudit = () => {
   const [modules, setModules] = useState<
@@ -63,41 +73,36 @@ const AccessibilityAudit = () => {
         }> => module.status === 'fulfilled',
       )
       .map(module => {
+        const parameters = module.value.default.parameters
         const destructuredName: string[] = module.value.default.title.split('/') ?? []
-
-        console.debug('destructuredName', destructuredName)
 
         const componentCategory = destructuredName.slice(1, -1).join('/')
         const componentName = destructuredName.at(-1) ?? 'Unknown'
-        const a11yStatus = findA11yStatus(module.value.default.parameters)
-        const auditCategories = getComponentAuditCategories(module.value.default.parameters)
-        const audit = getComponentAudit(module.value.default.parameters)
 
         return {
           title: module.value.default.title,
           name: componentName,
           category: componentCategory || 'Others',
-          state: findComponentState(module.value.default.parameters),
-          a11yLevel: a11yStatus?.level ?? null,
-          audit,
-          auditCategories,
+          state: findComponentState(parameters),
+          a11yLevel: findA11yLevel(parameters),
+          a11yStatus: getComponentA11yStatus(parameters),
+          auditCategories: getComponentAuditCategories(parameters),
         } satisfies ComponentInfo
       }) ?? []
 
-  const getCategoryCompletion = (categoryId: string) => {
+  const getPrincipleCompletion = (principle: WcagPrinciple) => {
     const total = componentsInfo.length
-    const completed = componentsInfo.filter(c => c.audit[categoryId]).length
+    const completed = componentsInfo.filter(c => c.a11yStatus[principle]).length
     return total > 0 ? Math.round((completed / total) * 100) : 0
   }
 
-  const getComponentsForCategory = (categoryId: string) => componentsInfo.filter(c => c.audit[categoryId])
+  const getComponentsForCategory = (categoryId: WcagPrinciple) => componentsInfo.filter(c => c.a11yStatus[categoryId])
 
   return (
     <Stack gap={5}>
       <Stack gap={2}>
         <Text as="p" variant="body">
-          Comprehensive accessibility audit checklist and tracking for all Ultraviolet components. Use this page to
-          track progress and understand accessibility requirements.
+          Accessibility audit tracking for all Ultraviolet components.
         </Text>
       </Stack>
 
@@ -107,10 +112,10 @@ const AccessibilityAudit = () => {
         </Text>
         <Stack gap={2} direction="row">
           {Object.entries(A11Y_LEVELS).map(([key, { icon, label, description }]) => (
-            <Stack key={key} gap={2} justifyContent="left">
-              <Stack direction="row" gap={2} alignItems="center">
+            <Stack key={key} gap={1} justifyContent="left">
+              <Stack direction="row" gap={1} alignItems="center">
                 {icon}
-                <Text as="h3" variant="headingSmall">
+                <Text as="h3" variant="headingSmall" style={{ margin: 0 }}>
                   {label}
                 </Text>
               </Stack>
@@ -120,28 +125,35 @@ const AccessibilityAudit = () => {
         </Stack>
       </Stack>
 
-      <Stack gap={3}>
+      <Stack gap={2}>
         <Text as="h2" variant="heading">
-          Audit Categories Overview
+          WCAG Principles
+        </Text>
+        <Text as="p" variant="body">
+          Based on the <Link href="https://www.w3.org/WAI/WCAG22/Understanding/">WCAG 2.2 documentation</Link>.
+        </Text>
+        <Text as="p" variant="body">
+          A component validates a principle if it has been audited and we found no violation of all rules within this
+          principle.
         </Text>
         <Table
           columns={[
-            { label: 'Category' },
+            { label: 'Principle' },
             { label: 'Progress', minWidth: '50%', width: '300px' },
             { label: 'Components' },
           ]}
           stripped
         >
           <Table.Body>
-            {AUDIT_CATEGORIES.map(category => {
-              const percentage = getCategoryCompletion(category.id)
-              const completedCount = getComponentsForCategory(category.id).length
+            {WCAG_PRINCIPLES.map(principle => {
+              const percentage = getPrincipleCompletion(principle)
+              const completedCount = getComponentsForCategory(principle).length
 
               return (
-                <Table.Row id={category.id} key={category.id}>
+                <Table.Row id={principle} key={principle}>
                   <Table.Cell>
-                    <Text as="span" variant="bodyStrong">
-                      {category.title}
+                    <Text as="span" variant="body">
+                      {principle[0].toUpperCase() + principle.slice(1)}
                     </Text>
                   </Table.Cell>
                   <Table.Cell align="left">
@@ -165,66 +177,6 @@ const AccessibilityAudit = () => {
         </Table>
       </Stack>
 
-      {/* Detailed Audit Checklist */}
-      <Stack gap={4}>
-        {AUDIT_CATEGORIES.map(category => (
-          <Stack gap={2} key={category.id}>
-            <Text as="h2" variant="heading">
-              {category.title}&nbsp;
-              <Text as="span" variant="bodySmall">
-                {getCategoryCompletion(category.id)}% complete
-              </Text>
-            </Text>
-
-            {category.description && (
-              <Text as="p" variant="body">
-                {category.description}
-              </Text>
-            )}
-
-            <Stack gap={3}>
-              {category.criteria.map(criterion => (
-                <Stack gap={2} key={criterion.name}>
-                  <Text as="p" variant="headingSmall">
-                    {criterion.name}
-                  </Text>
-                  <Text as="span" variant="bodySmall">
-                    {criterion.wcagLevel}
-                  </Text>
-                  <Text as="p" variant="body">
-                    {criterion.description}
-                  </Text>
-                  {criterion.aaaNote && (
-                    <Text as="p" variant="bodySmall">
-                      <Text as="span" variant="bodySmallStronger">
-                        Note AAA:{' '}
-                      </Text>
-                      {criterion.aaaNote}
-                    </Text>
-                  )}
-                  {criterion.examples && (
-                    <Stack gap={1}>
-                      <Text as="span" variant="bodySmallStronger">
-                        Examples:
-                      </Text>
-                      <ul>
-                        {criterion.examples.map(example => (
-                          <li key={example}>
-                            <Text as="span" variant="bodySmall">
-                              {example}
-                            </Text>
-                          </li>
-                        ))}
-                      </ul>
-                    </Stack>
-                  )}
-                </Stack>
-              ))}
-            </Stack>
-          </Stack>
-        ))}
-      </Stack>
-
       <Stack gap={3}>
         <Text as="h2" variant="heading">
           All Components
@@ -236,8 +188,8 @@ const AccessibilityAudit = () => {
           columns={[
             { label: 'Name' },
             { label: 'Category' },
-            { label: 'Accessibility' },
-            { label: 'Audit A11y Progress' },
+            { label: 'Accessibility Level' },
+            { label: 'Accessibility Progress' },
           ]}
           stripped
         >
@@ -256,7 +208,7 @@ const AccessibilityAudit = () => {
                 </Table.Cell>
                 <Table.Cell>
                   {component.a11yLevel ? (
-                    <Stack direction="row" gap={1} alignItems="center">
+                    <Stack direction="row" gap={0.5} alignItems="center">
                       {A11Y_LEVELS[component.a11yLevel].icon}
                       <Text as="span" variant="body">
                         {A11Y_LEVELS[component.a11yLevel].label}
@@ -274,7 +226,7 @@ const AccessibilityAudit = () => {
                       <Text as="span" key={category.id} variant="bodySmall">
                         <Tooltip text={category.id}>
                           {category.completed ? (
-                            <CheckCircleOutlineIcon size="medium" sentiment="success" />
+                            <CheckCircleIcon size="medium" sentiment="success" />
                           ) : (
                             <CloseCircleOutlineIcon size="medium" sentiment="danger" />
                           )}

--- a/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
+++ b/utils/stories/src/AccessibilityAudit/AccessibilityAudit.tsx
@@ -1,25 +1,14 @@
 import { linkTo } from '@storybook/addon-links'
-import { CheckCircleIcon } from '@ultraviolet/icons'
+import { CheckCircleIcon } from '@ultraviolet/icons/CheckCircleIcon'
 import { CloseCircleOutlineIcon } from '@ultraviolet/icons/CloseCircleOutlineIcon'
 import { Button, Stack, Table, Text, Tooltip, ProgressBar, Link } from '@ultraviolet/ui'
 import { useState, useEffect } from 'react'
 import type { ReactNode } from 'react'
 import { findComponentState } from '../ComponentState/constants'
 import { storiesCompositionsModules, storiesComponentModules } from '../constants'
-import {
-  A11Y_LEVELS,
-  findA11yLevel,
-  getComponentA11yStatus,
-  getComponentAuditCategories,
-  WCAG_PRINCIPLES,
-} from './constants'
-import type {
-  A11yLevel,
-  ComponentA11yStatus,
-  AuditCategories,
-  ComponentStoryParameters,
-  WcagPrinciple,
-} from './constants'
+import { A11Y_LEVELS, WCAG_PRINCIPLES } from './constants'
+import { findA11yLevel, getComponentA11yStatus, getComponentAuditCategories } from './helpers'
+import type { A11yLevel, ComponentA11yStatus, AuditCategories, ComponentStoryParameters, WcagPrinciple } from './types'
 
 type ComponentInfo = {
   title: string
@@ -146,14 +135,14 @@ const AccessibilityAudit = () => {
         >
           <Table.Body>
             {WCAG_PRINCIPLES.map(principle => {
-              const percentage = getPrincipleCompletion(principle)
-              const completedCount = getComponentsForCategory(principle).length
+              const percentage = getPrincipleCompletion(principle.name)
+              const completedCount = getComponentsForCategory(principle.name).length
 
               return (
-                <Table.Row id={principle} key={principle}>
+                <Table.Row id={principle.name} key={principle.name}>
                   <Table.Cell>
                     <Text as="span" variant="body">
-                      {principle[0].toUpperCase() + principle.slice(1)}
+                      {principle.label}
                     </Text>
                   </Table.Cell>
                   <Table.Cell align="left">
@@ -224,7 +213,7 @@ const AccessibilityAudit = () => {
                   <Stack direction="row" gap={1}>
                     {component.auditCategories.map(category => (
                       <Text as="span" key={category.id} variant="bodySmall">
-                        <Tooltip text={category.id}>
+                        <Tooltip text={category.label}>
                           {category.completed ? (
                             <CheckCircleIcon size="medium" sentiment="success" />
                           ) : (

--- a/utils/stories/src/AccessibilityAudit/constants.tsx
+++ b/utils/stories/src/AccessibilityAudit/constants.tsx
@@ -4,279 +4,18 @@ import type { ReactNode } from 'react'
 
 export type A11yLevel = 'partial' | 'compliant' | 'certified'
 
-export type A11yStatus = {
+export type A11yLevelInfo = {
   level: A11yLevel
   label: string
   icon: ReactNode
   description: ReactNode
 }
 
-export type AuditCriterion = {
-  name: string
-  wcagLevel: string
-  description: string
-  aaaNote?: string
-  examples?: string[]
-}
+export const WCAG_PRINCIPLES = ['perceivable', 'operable', 'understandable', 'robust'] as const
 
-export type AuditCategory = {
-  id: string
-  title: string
-  description?: string
-  criteria: AuditCriterion[]
-}
+export type WcagPrinciple = (typeof WCAG_PRINCIPLES)[number]
 
-export const AUDIT_CATEGORIES: AuditCategory[] = [
-  {
-    id: 'keyboard-focus',
-    title: '1. Keyboard & Focus Management',
-    description: 'Ensure all interactive elements are accessible via keyboard and focus is managed correctly.',
-    criteria: [
-      {
-        name: 'Keyboard Accessible',
-        wcagLevel: '2.1.1 - A',
-        description: 'All interactive elements can be triggered using Tab, Enter, or Space.',
-        examples: [
-          'Buttons respond to Enter/Space keys',
-          'Links respond to Enter key',
-          'Custom interactive elements have keyboard handlers',
-        ],
-      },
-      {
-        name: 'No Keyboard Trap',
-        wcagLevel: '2.1.2 - A',
-        description: 'Focus never gets stuck inside a component (e.g., Modals, Datepickers).',
-        examples: [
-          'Modal: Can close with Escape and focus returns to trigger',
-          'Datepicker: Can navigate with arrow keys and close',
-          'Dropdown: Can navigate options and close with Escape',
-        ],
-      },
-      {
-        name: 'Focus Order',
-        wcagLevel: '2.4.3 - A',
-        description: 'Tab order follows the visual and logical flow of the component.',
-        examples: [
-          'Tab order goes left-to-right, top-to-bottom',
-          'Focus order matches reading order',
-          'Interactive elements in logical sequence',
-        ],
-      },
-      {
-        name: 'Focus Visible',
-        wcagLevel: '2.4.7 - AA',
-        description: 'Highly visible focus indicator (outline) on all interactive elements.',
-        aaaNote: 'Focus indicator has a contrast ratio of at least 4.5:1 against the background (2.4.11 - AAA).',
-        examples: [
-          'Clear outline on focused buttons',
-          'Visible focus ring on input fields',
-          'Focus indicator visible in all themes (light/dark)',
-        ],
-      },
-      {
-        name: 'Focus Restoration',
-        wcagLevel: 'Best Practice',
-        description: 'Focus returns to the trigger element after closing overlays/menus.',
-        examples: [
-          'Modal closes → focus returns to trigger button',
-          'Dropdown closes → focus returns to dropdown button',
-          'Tooltip dismisses → focus returns to trigger',
-        ],
-      },
-    ],
-  },
-  {
-    id: 'contrast-visuals',
-    title: '2. Contrast & Visuals',
-    description: 'Ensure sufficient color contrast and that information is not conveyed by color alone.',
-    criteria: [
-      {
-        name: 'Text Contrast',
-        wcagLevel: '1.4.3 - AA',
-        description: 'Minimum 4.5:1 for normal text; 3:1 for large text (18pt or 14pt bold).',
-        aaaNote: 'Minimum 7:1 for normal text; 4.5:1 for large text (1.4.6 - AAA).',
-        examples: [
-          'Body text has 4.5:1 contrast ratio',
-          'Heading text meets contrast requirements',
-          'Placeholder text is sufficiently contrasted',
-        ],
-      },
-      {
-        name: 'Non-Text Contrast',
-        wcagLevel: '1.4.11 - AA',
-        description: 'Minimum 3:1 for UI components (borders, icons) and focus states.',
-        examples: [
-          'Input borders have 3:1 contrast',
-          'Icons have sufficient contrast against background',
-          'Focus indicators have 3:1 contrast',
-        ],
-      },
-      {
-        name: 'Use of Color',
-        wcagLevel: '1.4.1 - A',
-        description: 'Color is not the only way to convey info (e.g., error states use icons/text + color).',
-        examples: [
-          'Error fields have icon + red color + error message',
-          'Success states use checkmark + color + text',
-          'Required fields indicated by asterisk, not just color',
-        ],
-      },
-      {
-        name: 'Text Spacing',
-        wcagLevel: '1.4.12 - AA',
-        description: 'Component remains functional when line height/letter spacing is increased.',
-        examples: [
-          `Text doesn't overlap when line-height is 1.5x`,
-          `Content doesn't truncate when letter-spacing is increased`,
-          `Layout adapts to custom spacing settings`,
-        ],
-      },
-    ],
-  },
-  {
-    id: 'semantics-screen-reader',
-    title: '3. Semantics & Screen Reader (VoiceOver)',
-    description: 'Use proper semantic HTML and ARIA attributes to ensure screen reader compatibility.',
-    criteria: [
-      {
-        name: 'Name, Role, Value',
-        wcagLevel: '4.1.2 - A',
-        description: 'Every component has a valid ARIA role and a programmatic name (e.g., aria-label).',
-        examples: [
-          'Custom buttons have role="button" and accessible name',
-          'Icons have aria-label or aria-hidden="true"',
-          'Interactive regions have appropriate roles',
-        ],
-      },
-      {
-        name: 'Info & Relationships',
-        wcagLevel: '1.3.1 - A',
-        description: 'Proper HTML tags used (e.g., <ul> for lists, <button> for actions).',
-        examples: [
-          'Lists use <ul>/<ol> and <li> elements',
-          'Buttons use <button> not <div>',
-          'Headings use proper hierarchy (<h1> to <h6>)',
-        ],
-      },
-      {
-        name: 'Status Messages',
-        wcagLevel: '4.1.3 - AA',
-        description: 'Dynamic updates (success, loading, errors) use aria-live or role="status".',
-        examples: [
-          'Form submissions use aria-live for status updates',
-          'Loading states announce to screen readers',
-          'Error messages are announced automatically',
-        ],
-      },
-      {
-        name: 'State Transparency',
-        wcagLevel: 'Best Practice',
-        description: 'Attributes like aria-expanded, aria-selected, or aria-checked update correctly on interaction.',
-        examples: [
-          'Accordion: aria-expanded updates on toggle',
-          'Tabs: aria-selected updates on tab change',
-          'Checkboxes: aria-checked reflects current state',
-        ],
-      },
-    ],
-  },
-  {
-    id: 'pointer-touch',
-    title: '4. Pointer & Touch (Hardware)',
-    description: 'Ensure components work well with touch and pointer devices.',
-    criteria: [
-      {
-        name: 'Target Size',
-        wcagLevel: '2.5.8 - AA',
-        description: 'Minimum target area of 24x24 CSS pixels (WCAG 2.2).',
-        aaaNote: 'Minimum target area of 44x44 CSS pixels (2.5.5 - AAA).',
-        examples: [
-          'Buttons are at least 24x24 pixels',
-          'Icon buttons have sufficient clickable area',
-          'Links have adequate padding for touch',
-        ],
-      },
-      {
-        name: 'Pointer Cancellation',
-        wcagLevel: '2.5.2 - A',
-        description: 'Actions are triggered on the "Up" event (click), not the "Down" event, allowing users to abort.',
-        examples: [
-          'Click activates on mouseup, not mousedown',
-          'Touch actions complete on touchend',
-          'Users can move pointer away to cancel action',
-        ],
-      },
-      {
-        name: 'Label in Name',
-        wcagLevel: '2.5.3 - A',
-        description: 'For buttons with text, the accessible name must contain the visible text.',
-        examples: [
-          'Button "Submit" has accessible name containing "Submit"',
-          'Icon + text buttons include text in accessible name',
-          'aria-label matches or contains visible text',
-        ],
-      },
-    ],
-  },
-  {
-    id: 'specific-patterns',
-    title: '5. Specific Patterns',
-    description: 'Specific accessibility requirements for common UI patterns.',
-    criteria: [
-      {
-        name: 'Forms',
-        wcagLevel: '3.3.2 - A',
-        description: 'Every input has a visible <label> or an aria-labelledby association.',
-        examples: [
-          'Inputs have associated <label> elements',
-          'Labels are visible (not just placeholders)',
-          'aria-labelledby used for complex form structures',
-        ],
-      },
-      {
-        name: 'Error Identification',
-        wcagLevel: '3.3.1 - A',
-        description: 'Errors are clear and programmatically linked via aria-describedby.',
-        examples: [
-          'Error messages linked with aria-describedby',
-          'Invalid fields have aria-invalid="true"',
-          'Error summary provided for form-level errors',
-        ],
-      },
-      {
-        name: 'Tables',
-        wcagLevel: '1.3.1 - A',
-        description: 'Structural headers (<th>) are correctly associated with data cells (<td>).',
-        examples: [
-          'Table headers use <th> elements',
-          'scope attribute on headers (row/col)',
-          'Complex tables use aria-describedby for caption',
-        ],
-      },
-      {
-        name: 'Content on Hover/Focus',
-        wcagLevel: '1.4.13 - AA',
-        description:
-          'Tooltips or menus triggered by hover can be dismissed without moving the pointer and remain visible while the pointer is over the content.',
-        examples: [
-          'Tooltips dismissible with Escape key',
-          'Hover content stays visible when pointer moves over it',
-          'Dropdown menus remain open on hover',
-        ],
-      },
-    ],
-  },
-]
-
-export const A11Y_LEVELS: Record<
-  A11yLevel,
-  {
-    level: A11yLevel
-    label: string
-    icon: ReactNode
-    description: ReactNode
-  }
-> = {
+export const A11Y_LEVELS: Record<A11yLevel, A11yLevelInfo> = {
   partial: {
     level: 'partial',
     icon: <SettingsOutlineIcon size="medium" sentiment="danger" />,
@@ -294,7 +33,7 @@ export const A11Y_LEVELS: Record<
     label: 'Compliant',
     description: (
       <Text as="p" variant="body">
-        A11y Compliant means the component meets basic accessibility standards (WCAG 2.1 Level AA). The component has
+        A11y Compliant means the component meets basic accessibility standards (WCAG 2.2 Level AA). The component has
         been audited and validated for accessibility.
       </Text>
     ),
@@ -306,13 +45,13 @@ export const A11Y_LEVELS: Record<
     description: (
       <Text as="p" variant="body">
         A11y Certified means the component has been thoroughly tested and certified for accessibility compliance (WCAG
-        2.1 Level AAA). This is the highest level of accessibility validation.
+        2.2 Level AAA). This is the highest level of accessibility validation.
       </Text>
     ),
   },
 }
 
-export type ComponentAuditStatus = Record<string, boolean>
+export type ComponentA11yStatus = Record<WcagPrinciple, boolean>
 
 export type AuditCategories = {
   id: string
@@ -322,27 +61,30 @@ export type AuditCategories = {
 export type ComponentStoryParameters = {
   deprecated?: boolean
   experimental?: boolean
-  a11yStatus?: boolean | A11yLevel
-  audit?: ComponentAuditStatus
+  a11yStatus?: ComponentA11yStatus
+}
+
+export const getComponentA11yStatus = (parameters: ComponentStoryParameters): ComponentA11yStatus => {
+  if (!parameters?.a11yStatus) {
+    return Object.fromEntries(WCAG_PRINCIPLES.map(principle => [principle, false])) as ComponentA11yStatus
+  }
+
+  return parameters.a11yStatus
 }
 
 export const getComponentAuditCategories = (parameters: ComponentStoryParameters): AuditCategories => {
-  if (!parameters?.audit) {
-    return AUDIT_CATEGORIES.map(cat => ({ id: cat.id, completed: false }))
-  }
+  const a11yStatus = getComponentA11yStatus(parameters)
 
-  return AUDIT_CATEGORIES.map(cat => ({
-    id: cat.id,
-    completed: parameters.audit?.[cat.id] ?? false,
+  return WCAG_PRINCIPLES.map(principle => ({
+    id: principle,
+    completed: a11yStatus[principle] ?? false,
   }))
 }
 
-export const findA11yStatus = (parameters: { a11yStatus?: boolean | A11yLevel }) => {
+export const findA11yLevel = (parameters: { a11yStatus?: ComponentA11yStatus }): A11yLevel => {
   if (!parameters?.a11yStatus) {
-    return null
+    return 'partial'
   }
 
-  const a11yLevel = typeof parameters.a11yStatus === 'string' ? parameters.a11yStatus : 'compliant'
-
-  return A11Y_LEVELS[a11yLevel]
+  return WCAG_PRINCIPLES.every(principle => parameters.a11yStatus?.[principle] === true) ? 'compliant' : 'partial'
 }

--- a/utils/stories/src/AccessibilityAudit/constants.tsx
+++ b/utils/stories/src/AccessibilityAudit/constants.tsx
@@ -1,19 +1,13 @@
 import { SettingsOutlineIcon, ShieldCheckOutlineIcon, ProgressCheckIcon } from '@ultraviolet/icons'
 import { Text } from '@ultraviolet/ui'
-import type { ReactNode } from 'react'
+import type { A11yLevel, A11yLevelInfo } from './types'
 
-export type A11yLevel = 'partial' | 'compliant' | 'certified'
-
-export type A11yLevelInfo = {
-  level: A11yLevel
-  label: string
-  icon: ReactNode
-  description: ReactNode
-}
-
-export const WCAG_PRINCIPLES = ['perceivable', 'operable', 'understandable', 'robust'] as const
-
-export type WcagPrinciple = (typeof WCAG_PRINCIPLES)[number]
+export const WCAG_PRINCIPLES = [
+  { name: 'perceivable', label: 'Perceivable' },
+  { name: 'operable', label: 'Operable' },
+  { name: 'understandable', label: 'Understandable' },
+  { name: 'robust', label: 'Robust' },
+] as const
 
 export const A11Y_LEVELS: Record<A11yLevel, A11yLevelInfo> = {
   partial: {
@@ -49,42 +43,4 @@ export const A11Y_LEVELS: Record<A11yLevel, A11yLevelInfo> = {
       </Text>
     ),
   },
-}
-
-export type ComponentA11yStatus = Record<WcagPrinciple, boolean>
-
-export type AuditCategories = {
-  id: string
-  completed: boolean
-}[]
-
-export type ComponentStoryParameters = {
-  deprecated?: boolean
-  experimental?: boolean
-  a11yStatus?: ComponentA11yStatus
-}
-
-export const getComponentA11yStatus = (parameters: ComponentStoryParameters): ComponentA11yStatus => {
-  if (!parameters?.a11yStatus) {
-    return Object.fromEntries(WCAG_PRINCIPLES.map(principle => [principle, false])) as ComponentA11yStatus
-  }
-
-  return parameters.a11yStatus
-}
-
-export const getComponentAuditCategories = (parameters: ComponentStoryParameters): AuditCategories => {
-  const a11yStatus = getComponentA11yStatus(parameters)
-
-  return WCAG_PRINCIPLES.map(principle => ({
-    id: principle,
-    completed: a11yStatus[principle] ?? false,
-  }))
-}
-
-export const findA11yLevel = (parameters: { a11yStatus?: ComponentA11yStatus }): A11yLevel => {
-  if (!parameters?.a11yStatus) {
-    return 'partial'
-  }
-
-  return WCAG_PRINCIPLES.every(principle => parameters.a11yStatus?.[principle] === true) ? 'compliant' : 'partial'
 }

--- a/utils/stories/src/AccessibilityAudit/helpers.ts
+++ b/utils/stories/src/AccessibilityAudit/helpers.ts
@@ -1,0 +1,28 @@
+import { WCAG_PRINCIPLES } from './constants'
+import type { ComponentStoryParameters, ComponentA11yStatus, AuditCategories, A11yLevel } from './types'
+
+export const getComponentA11yStatus = (parameters: ComponentStoryParameters): ComponentA11yStatus => {
+  if (!parameters?.a11yStatus) {
+    return Object.fromEntries(WCAG_PRINCIPLES.map(principle => [principle.name, false])) as ComponentA11yStatus
+  }
+
+  return parameters.a11yStatus
+}
+
+export const getComponentAuditCategories = (parameters: ComponentStoryParameters): AuditCategories => {
+  const a11yStatus = getComponentA11yStatus(parameters)
+
+  return WCAG_PRINCIPLES.map(principle => ({
+    id: principle.name,
+    label: principle.label,
+    completed: a11yStatus[principle.name] ?? false,
+  }))
+}
+
+export const findA11yLevel = (parameters: { a11yStatus?: ComponentA11yStatus }): A11yLevel => {
+  if (!parameters?.a11yStatus) {
+    return 'partial'
+  }
+
+  return WCAG_PRINCIPLES.every(principle => parameters.a11yStatus?.[principle.name] === true) ? 'compliant' : 'partial'
+}

--- a/utils/stories/src/AccessibilityAudit/types.ts
+++ b/utils/stories/src/AccessibilityAudit/types.ts
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+import type { WCAG_PRINCIPLES } from './constants'
+
+export type A11yLevel = 'partial' | 'compliant' | 'certified'
+
+export type A11yLevelInfo = {
+  level: A11yLevel
+  label: string
+  icon: ReactNode
+  description: ReactNode
+}
+
+export type WcagPrinciple = (typeof WCAG_PRINCIPLES)[number]['name']
+
+export type ComponentA11yStatus = Record<WcagPrinciple, boolean>
+
+export type AuditCategories = {
+  id: string
+  label: string
+  completed: boolean
+}[]
+
+export type ComponentStoryParameters = {
+  deprecated?: boolean
+  experimental?: boolean
+  a11yStatus?: ComponentA11yStatus
+}


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

Update the Accessibility Audit page to use WCAG principles instead of custom categories.

#### What is expected?

Accessibility Audit page is consistent and understandable.

#### The following changes were made:

- update the stories parameters with WCAG principles
- update the Accessibility Audit page
