### PR TITLE
chore: set maximum memory for pnpm on Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,9 @@
     "**/__tests__/**",
     "**/__fixtures__/**"
   ],
+  "toolSettings": {
+    "nodeMaxMemory": 2900
+  },
   "prConcurrentLimit": 10,
   "reviewers": ["team:console"],
   "reviewersSampleSize": 2,


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

Renovate is out of memory because of pnpm install

#### What is expected?

Renovate works

#### The following changes were made:

Set a max memory for node according to [Renovate docs](https://docs.renovatebot.com/mend-hosted/faq/#im-hitting-a-timeout-kernel-out-of-memory-limit-with-a-pnpmyarn-project)