### PR TITLE
chore: add a11y-fix skill

### DIFF
--- a/.agents/skills/a11y-fix/REFERENCE.md
+++ b/.agents/skills/a11y-fix/REFERENCE.md
@@ -1,0 +1,145 @@
+# Common Accessibility Fix Patterns
+
+Reference patterns for the most frequent issues found by the a11y-audit skill. Always cross-check the fix against the ARIA Pattern and WCAG rule linked in the component's `A11y.mdx`.
+
+## 1. Missing role
+
+Add the semantic role the ARIA pattern requires, on the element that owns the behaviour.
+
+```tsx
+// Alert: announce dynamic insertion
+<div role="alert" ...>
+
+// Dialog / Modal
+<div role="dialog" aria-modal="true" aria-labelledby={titleId} ...>
+
+// Status / live region (non-urgent)
+<div role="status" ...>
+```
+
+## 2. Focus management on dismiss / close
+
+When an element is removed (alert dismissed, dialog closed, popover hidden), move focus deliberately — usually back to the trigger that opened it.
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement>(null)
+
+const handleClose = () => {
+  setOpen(false)
+  // restore focus to the trigger
+  triggerRef.current?.focus()
+}
+```
+
+If there is no logical trigger, move focus to a sensible parent (e.g. the main content region) rather than leaving it to fall to `document.body`.
+
+## 3. Labelling
+
+An interactive element needs an accessible name. Pick one, in order of preference:
+
+1. Visible text content (best)
+2. `aria-labelledby` pointing to the id of visible text
+3. visually hidden text content
+
+Try to avoid `aria-label` because it often gets overlooked in automatic browser translation and screen reader support is not as good as visually hidden content.
+
+```tsx
+<Button onClick={onClose}>
+  <span class="sr-only">close</span>
+  <CloseIcon>
+</Button>
+
+<div role="dialog" aria-labelledby={titleId}>
+  <h2 id={titleId}>Settings</h2>
+</div>
+```
+
+Use `aria-describedby` to associate helper / error text with an input.
+
+## 4. Tabindex management
+
+- Native controls (`button`, `a`, `input`) are already focusable — do **not** add `tabIndex`.
+- Custom interactive containers need `tabIndex={0}` (or `{-1}` when focus should only be set programmatically via `.focus()`).
+- Roving `tabIndex` for composite widgets (Menu, Tabs, Listbox): only the active child is `0`, siblings are `-1`.
+
+## 5. Announcing dynamic content
+
+Use `aria-live` regions for content that updates after load.
+
+- `role="alert"` (implicit `aria-live="assertive"`) — urgent errors / alerts
+- `role="status"` (implicit `aria-live="polite"`) — non-urgent status updates
+- `aria-live="polite"` on a container for progressive updates (e.g. search result counts)
+
+Avoid `aria-live="assertive"` unless the user must be interrupted.
+
+## 6. Hidden content
+
+- `aria-hidden="true"` on decorative / duplicated content (e.g. an icon-only button that already has `aria-label`).
+- `inert` on content outside a Dialog/Drawer while it is open (prevents focus from escaping and hides it from the AT).
+- Visually hide text that is only for screen readers with the visually-hidden utility (don't use `display: none`, which removes it from the a11y tree).
+
+## 7. Disabled vs aria-disabled
+
+- A native `<button disabled>` is removed from the a11y tree and not focusable.
+- If the user must still perceive the control (e.g. to show a tooltip explaining why it's disabled), keep it focusable with `aria-disabled="true"` and prevent the action in the handler instead.
+
+## a11y test template
+
+Tests live in `packages/ui/src/components/<Component>/__tests__/a11y.test.tsx`. Use the `a11y` tag so the suite can be filtered.
+
+### Axe-detectable issues
+
+```tsx
+import { renderWithTheme, expectNoViolations } from '@utils/test'
+import { describe, it } from 'vitest'
+import { Component } from '..'
+
+describe('component - A11y', { tags: ['a11y'] }, () => {
+  it('should not have violations with default props', async () => {
+    const { container } = renderWithTheme(<Component>label</Component>)
+    await expectNoViolations(container)
+  })
+})
+```
+
+### Theme-dependent contrast
+
+When contrast may vary across themes, iterate with `it.for`:
+
+```tsx
+import { consoleThemesMap } from '@ultraviolet/themes'
+import { renderWithTheme, expectNoViolations } from '@utils/test'
+import { describe, it } from 'vitest'
+import { Component } from '..'
+
+describe('component - A11y', { tags: ['a11y'] }, () => {
+  it.for([...consoleThemesMap.entries()])('should not have violations with (theme: %s)', async ([, currentTheme]) => {
+    const { container } = renderWithTheme(<Component>label</Component>, currentTheme)
+    await expectNoViolations(container)
+  })
+})
+```
+
+### Behaviour axe cannot catch (focus, keyboard)
+
+Use React Testing Library and `@testing-library/user-event` for issues like focus management or keyboard navigation:
+
+```tsx
+import { renderWithTheme } from '@utils/test'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import { Component } from '..'
+
+describe('component - A11y', { tags: ['a11y'] }, () => {
+  it('restores focus to the trigger after dismiss', async () => {
+    const user = userEvent.setup()
+    const { getByRole } = renderWithTheme(<Component />)
+
+    const trigger = getByRole('button')
+    await user.click(trigger)
+    await user.click(getByRole('button', { name: /close/i }))
+
+    expect(trigger).toHaveFocus()
+  })
+})
+```

--- a/.agents/skills/a11y-fix/SKILL.md
+++ b/.agents/skills/a11y-fix/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: a11y-fix
+description: Fix accessibility issues documented in a component's A11y.mdx audit file by editing the component source, then refresh the audit artifacts. Use when the user wants to resolve accessibility issues found by the a11y-audit skill, or mentions fixing a11y/ARIA/keyboard navigation/WCAG issues in a component.
+---
+
+# Accessibility Fix
+
+Resolve the accessibility issues documented in a component's `A11y.mdx` audit file by editing the component source, then refresh the audit artifacts so they reflect the new state.
+
+## Workflow
+
+### Step 1: Read the audit
+
+Locate `packages/ui/src/components/<Component>/__stories__/A11y.mdx` (or the path given by the user). If it does not exist, stop and tell the user to run the **a11y-audit** skill first.
+
+Extract from it:
+
+- The **Accessibility issues** section, grouped by Critical / High / Medium / Low
+- The **Rules** section (enforced by the component vs. to apply when using)
+- The **ARIA Pattern** link, if any
+
+### Step 2: Check dependencies
+
+Read the **Dependencies** section. If it lists other components that must be fixed first, present them to the user and ask whether to fix those before this one. If the user declines or there are none, continue.
+
+### Step 3: Read the component
+
+Read the component source to understand the current implementation and conventions:
+
+- `index.tsx` — component logic, ARIA attributes, keyboard handlers
+- `type.ts` — props
+- `styles.css.ts` — vanilla-extract styles (focus indicators, visibility)
+- Any hooks used by the component
+
+Follow existing conventions (vanilla-extract for styles, functional components, existing ARIA patterns in neighbour components).
+
+### Step 4: Plan and confirm
+
+List every issue from the audit, ordered Critical → High → Medium → Low. For each, state the intended fix and the file(s) affected. Present the plan to the user and confirm before editing.
+
+For common fix patterns and code snippets, see [REFERENCE.md](REFERENCE.md).
+
+### Step 5: Generate a11y test suite (TDD)
+
+Before implementing any fix, write an accessibility test suite that documents the expected **post-fix** behaviour. Tests will initially fail (confirming the issues exist) and pass once the fix is applied.
+
+Create `packages/ui/src/components/<Component>/__tests__/a11y.test.tsx` following the template in [REFERENCE.md](REFERENCE.md#a11y-test-template):
+
+- One `describe('<component> - A11y', { tags: ['a11y'] }, ...)` block.
+- For issues detectable by axe (missing role, contrast, labels, ARIA attributes), render the relevant variant and call `await expectNoViolations(container)`.
+- For issues axe cannot catch (focus management, keyboard navigation), use React Testing Library queries and `@testing-library/user-event` to assert the desired behaviour (e.g. `expect(trigger).toHaveFocus()` after dismiss, `expect(menu).toBeVisible()` after ArrowDown).
+- When color contrast is relevant, iterate themes with `it.for([...consoleThemesMap.entries()])('should not have violations with (theme: %s)', ...)`.
+- Only cover rules **Enforced by the component**. Skip **To apply when using the component** rules — those belong in consumer code.
+
+Run the suite with `pnpm test:unit -- <component-path>` and confirm the expected tests fail. Do not proceed to the fix until the suite accurately documents the issues.
+
+### Step 6: Apply fixes
+
+Implement fixes in criticality order. Prefer the smallest change that satisfies the WCAG rule referenced in the audit. Do not change the public API unless strictly necessary; if a prop must change or be added, flag it to the user first.
+
+### Step 7: Verify
+
+Run from the repo root:
+
+- Lint: `pnpm lint`
+- Typecheck: `pnpm typecheck`
+- Component tests: `pnpm test:unit -- <component-path>` (e.g. `packages/ui/src/components/Alert`)
+
+The a11y test suite generated in Step 5 should now pass. Fix any failures you introduced. If a pre-existing test needs updating to reflect the a11y fix, explain why to the user before updating it.
+
+### Step 8: Update audit artifacts
+
+1. **`A11y.mdx`** — for each resolved issue, mark it ✅ and move the detail under a **Resolved** subsection (keep the original note for traceability). Update the **Summary** lines (✅/⚠️/❌) to reflect the new state.
+2. **`index.stories.tsx`** — recompute the `a11yStatus` parameter:
+   - `perceivable`: `false` if any 1.x.x rule still fails, else `true`
+   - `operable`: `false` if any 2.x.x rule still fails, else `true`
+   - `understandable`: `false` if any 3.x.x rule still fails, else `true`
+   - `robust`: `false` if any 4.x.x rule still fails, else `true`
+
+### Step 9: Manual review
+
+Summarize which fixes were applied, then prompt the user to manually verify with a keyboard (Tab / Enter / Space / Escape) and, if possible, a screen reader.


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

Add `a11y-fix` skill to fix issues detected during the audit made with `a11y-audit` skill.

#### What is expected?

Skill is relevant and enables to quickly fix issues.

#### The following changes were made:

- add the skill
- add guidelines for common accessibility patterns

The skill was used on the Alert, see [related PR](https://github.com/scaleway/ultraviolet/pull/6583)