### PR TITLE
fix(MultiSelect): truncated Tags in size medium

### DIFF
--- a/.changeset/good-mice-hope.md
+++ b/.changeset/good-mice-hope.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`MultiSelect`: fix truncated Tags in size medium

--- a/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
@@ -186,7 +186,6 @@ export const selectBar = recipe({
 })
 
 const selectBarTagsBase = style({
-  height: 'max-content',
   maxWidth: maxWidthTag,
   minWidth: minWidthTag,
   width: 'fit-content',


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

Tags not truncated in the multiselect in size medium

#### The following changes were made:

fix the height of the tags (should be 24px and not 26px)

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="562" height="126" alt="image" src="https://github.com/user-attachments/assets/2243f2c1-6560-4c87-8836-ce05e81cda87" /> | <img width="568" height="123" alt="image" src="https://github.com/user-attachments/assets/b0574c8c-949a-4364-9d12-d383a1248636" /> |
