### PR TITLE
fix(SelectInput): overflow placeholder

### DIFF
--- a/.changeset/lemon-bees-help.md
+++ b/.changeset/lemon-bees-help.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SelectInput`: fix placeholder overflow

--- a/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -432,6 +432,7 @@ exports[`selectInputField > should render correctly 1`] = `
             >
               <span
                 class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow1d uv_m4c9ow35"
+                style="--uv_qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -500,6 +501,7 @@ exports[`selectInputField > should render correctly disabled 1`] = `
             >
               <span
                 class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow1 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow25"
+                style="--uv_qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -568,6 +570,7 @@ exports[`selectInputField > should render correctly grouped 1`] = `
             >
               <span
                 class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow1d uv_m4c9ow35"
+                style="--uv_qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -636,6 +639,7 @@ exports[`selectInputField > should render correctly multiselect 1`] = `
             >
               <span
                 class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow1d uv_m4c9ow35"
+                style="--uv_qabug41: nowrap;"
               >
                 Select item
               </span>

--- a/packages/form/src/components/SelectableCardOptionGroupField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SelectableCardOptionGroupField/__tests__/__snapshots__/index.test.tsx.snap
@@ -306,6 +306,7 @@ exports[`selectableCardOptionGroupField > should render correctly 1`] = `
                           >
                             <span
                               class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owk uv_m4c9ow1d uv_m4c9ow35"
+                              style="--uv_qabug41: nowrap;"
                             >
                               Select item
                             </span>
@@ -460,6 +461,7 @@ exports[`selectableCardOptionGroupField > should render correctly 1`] = `
                           >
                             <span
                               class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owk uv_m4c9ow1d uv_m4c9ow35"
+                              style="--uv_qabug41: nowrap;"
                             >
                               Select item
                             </span>

--- a/packages/form/src/components/UnitInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/UnitInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -183,6 +183,7 @@ exports[`unitInputField > should render correctly 1`] = `
                 >
                   <span
                     class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow1d uv_m4c9ow35"
+                    style="--uv_qabug41: nowrap;"
                   >
                     Select item
                   </span>

--- a/packages/form/src/compositions/OptionSelectorField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/compositions/OptionSelectorField/__tests__/__snapshots__/index.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`optionSelectorField > should render correctly 1`] = `
               >
                 <span
                   class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow1d uv_m4c9ow35"
+                  style="--uv_qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -113,6 +114,7 @@ exports[`optionSelectorField > should render correctly 1`] = `
               >
                 <span
                   class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow1 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow25"
+                  style="--uv_qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -189,6 +191,7 @@ exports[`optionSelectorField > should render correctly disabled 1`] = `
               >
                 <span
                   class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow1 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow25"
+                  style="--uv_qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -259,6 +262,7 @@ exports[`optionSelectorField > should render correctly disabled 1`] = `
               >
                 <span
                   class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow1 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow25"
+                  style="--uv_qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -499,6 +503,7 @@ exports[`optionSelectorField > should trigger events 1`] = `
               >
                 <span
                   class="uv_r8qe44 uv_m4c9ow0 uv_m4c9ow7 uv_m4c9owb uv_m4c9owj uv_m4c9ow1d uv_m4c9ow35"
+                  style="--uv_qabug41: nowrap;"
                 >
                   Select item
                 </span>

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`selectInput > renders correctly 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               Select item
             </span>
@@ -100,6 +101,7 @@ exports[`selectInput > renders correctly disabled 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -162,6 +164,7 @@ exports[`selectInput > renders correctly grouped 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -605,6 +608,7 @@ exports[`selectInput > renders correctly loadMore 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -667,6 +671,7 @@ exports[`selectInput > renders correctly loading - grouped data 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -797,6 +802,7 @@ exports[`selectInput > renders correctly loading - ungrouped data 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -1999,6 +2005,7 @@ exports[`selectInput > renders correctly readOnly 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -2061,6 +2068,7 @@ exports[`selectInput > renders correctly required 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -2436,6 +2444,7 @@ exports[`selectInput > renders correctly small 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               Select item
             </span>
@@ -2570,6 +2579,7 @@ exports[`selectInput > renders correctly ungrouped 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -3381,6 +3391,7 @@ exports[`selectInput > renders correctly with dropdownAlign 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -3749,6 +3760,7 @@ exports[`selectInput > renders correctly with emptyState 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -3832,6 +3844,7 @@ exports[`selectInput > renders correctly with error 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -4732,6 +4745,7 @@ exports[`selectInput > renders correctly with group empty state 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -4960,6 +4974,7 @@ exports[`selectInput > renders correctly with group error 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -5541,6 +5556,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -6002,6 +6018,7 @@ exports[`selectInput > renders correctly with label on the bottom and optional i
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -6479,6 +6496,7 @@ exports[`selectInput > renders correctly with label on the right and optional in
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -6913,6 +6931,7 @@ exports[`selectInput > renders correctly with label on the right and optional in
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -7390,6 +7409,7 @@ exports[`selectInput > renders correctly with not searchable 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -7716,6 +7736,7 @@ exports[`selectInput > renders correctly with success 1`] = `
           >
             <span
               class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+              style="--whiteSpace__qabug41: nowrap;"
             >
               placeholder
             </span>
@@ -8119,6 +8140,7 @@ exports[`selectInput > renders correctly with tooltip 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>

--- a/packages/ui/src/components/SelectInput/components/SelectBar/SelectBar.tsx
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/SelectBar.tsx
@@ -232,6 +232,7 @@ const SelectBar = ({
             prominence="weak"
             sentiment="neutral"
             variant={textVariant}
+            whiteSpace="nowrap"
           >
             {placeholder}
           </Text>

--- a/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
@@ -30,6 +30,8 @@ export const selectbarState = styleVariants({
 export const placeholder = style({
   alignSelf: 'center',
   userSelect: 'none',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
 })
 
 function capitalizeFirstLetter(string: string) {

--- a/packages/ui/src/components/SelectableCardOptionGroup/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectableCardOptionGroup/__tests__/__snapshots__/index.test.tsx.snap
@@ -297,6 +297,7 @@ exports[`selectableCardOptionGroup > onChange and onChangeOption are being calle
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -451,6 +452,7 @@ exports[`selectableCardOptionGroup > onChange and onChangeOption are being calle
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -791,6 +793,7 @@ exports[`selectableCardOptionGroup > renders correctly 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -945,6 +948,7 @@ exports[`selectableCardOptionGroup > renders correctly 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -1280,6 +1284,7 @@ exports[`selectableCardOptionGroup > renders correctly 4 columns 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -1434,6 +1439,7 @@ exports[`selectableCardOptionGroup > renders correctly 4 columns 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -1771,6 +1777,7 @@ exports[`selectableCardOptionGroup > renders correctly with all options disabled
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_31__m4c9ow25"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -1926,6 +1933,7 @@ exports[`selectableCardOptionGroup > renders correctly with all options disabled
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_31__m4c9ow25"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -2249,6 +2257,7 @@ exports[`selectableCardOptionGroup > renders correctly with aria-label 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -2397,6 +2406,7 @@ exports[`selectableCardOptionGroup > renders correctly with aria-label 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -2747,6 +2757,7 @@ exports[`selectableCardOptionGroup > renders correctly with error as boolean 1`]
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -2916,6 +2927,7 @@ exports[`selectableCardOptionGroup > renders correctly with error as boolean 1`]
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -3282,6 +3294,7 @@ exports[`selectableCardOptionGroup > renders correctly with error message 1`] = 
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -3451,6 +3464,7 @@ exports[`selectableCardOptionGroup > renders correctly with error message 1`] = 
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -3809,6 +3823,7 @@ exports[`selectableCardOptionGroup > renders correctly with helper 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -3963,6 +3978,7 @@ exports[`selectableCardOptionGroup > renders correctly with helper 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -4305,6 +4321,7 @@ exports[`selectableCardOptionGroup > renders correctly with id 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -4459,6 +4476,7 @@ exports[`selectableCardOptionGroup > renders correctly with id 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -4788,6 +4806,7 @@ exports[`selectableCardOptionGroup > renders correctly with image as ReactNode 1
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -4939,6 +4958,7 @@ exports[`selectableCardOptionGroup > renders correctly with image as ReactNode 1
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -5274,6 +5294,7 @@ exports[`selectableCardOptionGroup > renders correctly with medium size 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -5428,6 +5449,7 @@ exports[`selectableCardOptionGroup > renders correctly with medium size 1`] = `
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -5764,6 +5786,7 @@ exports[`selectableCardOptionGroup > renders correctly with partial disabled 1`]
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_31__m4c9ow25"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>
@@ -5918,6 +5941,7 @@ exports[`selectableCardOptionGroup > renders correctly with partial disabled 1`]
                         >
                           <span
                             class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                            style="--whiteSpace__qabug41: nowrap;"
                           >
                             Select item
                           </span>

--- a/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/UnitInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`unitInput > renders click 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -249,6 +250,7 @@ exports[`unitInput > renders with default props 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -443,6 +445,7 @@ exports[`unitInput > renders with disabled and placeHolder 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -532,6 +535,7 @@ exports[`unitInput > renders with dropdownAlign center 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -638,6 +642,7 @@ exports[`unitInput > renders with error  and success 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -751,6 +756,7 @@ exports[`unitInput > renders with error 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -863,6 +869,7 @@ exports[`unitInput > renders with label and label information 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -959,6 +966,7 @@ exports[`unitInput > renders with label and no label information 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -1048,6 +1056,7 @@ exports[`unitInput > renders with min max 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -1151,6 +1160,7 @@ exports[`unitInput > renders with no label and label information 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -1240,6 +1250,7 @@ exports[`unitInput > renders with size large 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -1329,6 +1340,7 @@ exports[`unitInput > renders with size medioum 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -1418,6 +1430,7 @@ exports[`unitInput > renders with size small 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>
@@ -1524,6 +1537,7 @@ exports[`unitInput > renders with success 1`] = `
               >
                 <span
                   class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                  style="--whiteSpace__qabug41: nowrap;"
                 >
                   Select item
                 </span>

--- a/packages/ui/src/compositions/Filters/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/Filters/__tests__/__snapshots__/index.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`filters > should render main row with filters 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select status
               </span>
@@ -159,6 +160,7 @@ exports[`filters > should render main row with filters 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_bodySmall__m4c9owk style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select environment
               </span>

--- a/packages/ui/src/compositions/OptionSelector/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/OptionSelector/__tests__/__snapshots__/index.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`optionSelector > should work readonly 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -112,6 +113,7 @@ exports[`optionSelector > should work readonly 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -182,6 +184,7 @@ exports[`optionSelector > should work with default props 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -252,6 +255,7 @@ exports[`optionSelector > should work with default props 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -326,6 +330,7 @@ exports[`optionSelector > should work with direction vertical 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_3__m4c9ow1d style_undefined_compound_67__m4c9ow35"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -403,6 +408,7 @@ exports[`optionSelector > should work with direction vertical 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -473,6 +479,7 @@ exports[`optionSelector > should work with disabled 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>
@@ -543,6 +550,7 @@ exports[`optionSelector > should work with disabled 1`] = `
             >
               <span
                 class="selectBar__r8qe44 style__m4c9ow0 style_disabled_true__m4c9ow1 style_prominence_weak__m4c9ow7 style_sentiment_neutral__m4c9owb style_variant_body__m4c9owj style_undefined_compound_31__m4c9ow25"
+                style="--whiteSpace__qabug41: nowrap;"
               >
                 Select item
               </span>


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`SelectInput`: fix placeholder overflow

Before: 
<img width="388" height="136" alt="before" src="https://github.com/user-attachments/assets/02e70c3e-3ba4-424d-81e3-565252093596" />

After: 
<img width="424" height="132" alt="after" src="https://github.com/user-attachments/assets/c5c1f61b-0f00-40c6-bc78-edc44297a1d7" />
