### PR TITLE
fix(SelectInput): item alignment with checkbox

### DIFF
--- a/.changeset/thirty-times-agree.md
+++ b/.changeset/thirty-times-agree.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`SelectInput`: fix checkbox alignment when no description (dropdown item)

--- a/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/Option.tsx
@@ -37,14 +37,18 @@ export const DisplayOption = ({
   if (descriptionDirection === 'row' && optionalInfoPlacement === 'left') {
     return (
       <Tooltip disableAnimation text={option.tooltip}>
-        <Stack data-testid={`option-stack-${option.value}`} direction="row" gap={0.5} justifyContent="left">
-          <Stack alignItems="flex-start" className={selectInputStyle.dropdownInfoContainer} direction="row" gap={0.5}>
-            {option.optionalInfo}
-            <Text as="span" className={selectInputStyle.dropdownInfoTextItem} placement="left" variant={textVariant}>
-              {option.label}
-            </Text>
-            {optionDescription}
-          </Stack>
+        <Stack
+          alignItems={optionDescription ? 'flex-start' : 'center'}
+          className={selectInputStyle.dropdownInfoContainer}
+          direction="row"
+          data-testid={`option-stack-${option.value}`}
+          gap={0.5}
+        >
+          {option.optionalInfo}
+          <Text as="span" className={selectInputStyle.dropdownInfoTextItem} placement="left" variant={textVariant}>
+            {option.label}
+          </Text>
+          {optionDescription}
         </Stack>
       </Tooltip>
     )
@@ -83,7 +87,6 @@ export const DisplayOption = ({
           className={selectInputStyle.optionalInfoPadding}
         >
           {option.optionalInfo}
-
           <Stack
             className={selectInputStyle.dropdownInfoContainer}
             data-testid={`option-stack-${option.value}`}

--- a/packages/ui/src/components/SelectInput/components/Dropdown/dropdown.css.ts
+++ b/packages/ui/src/components/SelectInput/components/Dropdown/dropdown.css.ts
@@ -90,6 +90,7 @@ export const dropdownItemBase = style([
   emptyStateGroupStyle,
   {
     backgroundColor: theme.colors.other.elevation.background.raised,
+    display: 'grid',
   },
 ])
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`SelectInput`: fix checkbox alignment when no description (dropdown item)


| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="143" height="64" alt="Capture d’écran 2026-06-24 à 16 28 27" src="https://github.com/user-attachments/assets/6a7230ce-558f-49ad-99a2-ce1d7b90d2ea" /> | <img width="196" height="60" alt="Capture d’écran 2026-06-24 à 16 28 16" src="https://github.com/user-attachments/assets/bfecded7-3eb6-4874-9e77-db796dc398ab" /> |
