### PR TITLE
feat(fonts): add root custom props for fallback

### DIFF
--- a/.changeset/upset-bushes-speak.md
+++ b/.changeset/upset-bushes-speak.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/fonts": patch
+---
+
+Add root custom props for fonts family fallbacks

--- a/packages/fonts/README.md
+++ b/packages/fonts/README.md
@@ -40,6 +40,21 @@ import '@ultraviolet/fonts/fonts-bundled.css'
 2. Edit `src/fonts.css` and add the font-face declaration following same directory order as you did locally but with S3 URL.
 3. Push your pull request, once merged your font will be uploaded on S3 and available for use.
 
+## How to use fallbacks fonts
+
+Available font custom props that expose fallbacks are `--font-inter`, `--font-jetbrains` and `--font-space-grotesk`
+
+You can map the pre-configured font tokens to your local semantic roles inside your application's global CSS file.
+
+```CSS
+/* Usage example */
+:root {
+   --font-body: var(--font-inter);
+   --font-heading: var(--font-space-grotesk);
+   --font-code: var(--font-jetbrains);
+}
+```
+
 ## Documentation
 
 Checkout our [documentation website](https://storybook.ultraviolet.scaleway.com/).

--- a/packages/fonts/src/fonts-bundled.css
+++ b/packages/fonts/src/fonts-bundled.css
@@ -26,3 +26,9 @@
   font-weight: 300 700;
   font-display: swap;
 }
+
+:root {
+  --font-inter: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-jetbrains: 'JetBrains', Consolas, Monaco, 'Andale Mono', monospace;
+  --font-space-grotesk: 'Space Grotesk', 'Century Gothic', Futura, sans-serif;
+}

--- a/packages/fonts/src/fonts-cdn.css
+++ b/packages/fonts/src/fonts-cdn.css
@@ -28,3 +28,9 @@
   font-weight: 300 700;
   font-display: swap;
 }
+
+:root {
+  --font-inter: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-jetbrains: 'JetBrains', Consolas, Monaco, 'Andale Mono', monospace;
+  --font-space-grotesk: 'Space Grotesk', 'Century Gothic', Futura, sans-serif;
+}


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarize concisely:

- Set fallback lists for the 3 fonts
- The fallback fonts were selected based on the following criteria:
    - Common fonts available on major operating systems  
    - Ranked in descending order of design similarity

#### What is expected?

- It should prevent FOUC effect when the default "Times" font blink at load time

#### The following changes were made:

1. Add root custom props in the 2 fonts .css files
2. Update README

