### PR TITLE
feat(breadscrumb): add render props

### DIFF
--- a/.changeset/breadcrumbs-render-prop.md
+++ b/.changeset/breadcrumbs-render-prop.md
@@ -1,0 +1,25 @@
+---
+"@ultraviolet/ui": minor
+---
+
+`Breadcrumbs.Item`: add `render` prop to support custom link components (e.g., React Router `Link`, Next.js `Link`)
+
+### Added
+- `render` prop to `Breadcrumbs.Item` component for custom element rendering
+- Support for both element form (`render={<CustomLink />}`) and function form (`render={(props) => <CustomLink {...props} />}`)
+
+
+### Usage Example
+
+```tsx
+import Link from 'next/link'
+import { Breadcrumbs } from '@ultraviolet/ui'
+
+<Breadcrumbs>
+  <Breadcrumbs.Item render={(props) => <Link {...props} href="/"/ >}>Home</Breadcrumbs.Item>
+  <Breadcrumbs.Item render={(props) => <Link {...props} href="/products"/>}>Product</Breadcrumbs.Item>
+  <Breadcrumbs.Item>Current Page</Breadcrumbs.Item>
+</Breadcrumbs>
+```
+
+This change enables seamless integration with routing libraries while preserving Breadcrumbs styling and accessibility features.

--- a/packages/ui/src/components/Breadcrumbs/__stories__/RenderProp.stories.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__stories__/RenderProp.stories.tsx
@@ -1,0 +1,48 @@
+import type { StoryFn } from '@storybook/react-vite'
+import type { ComponentProps, PropsWithChildren } from 'react'
+import { Breadcrumbs } from '..'
+
+// Mock Next.js Link component for demonstration
+// In real usage, replace with: import Link from 'next/link'
+const NextLink = ({ href, children, ...props }: PropsWithChildren<{ href: string }>) => (
+  <a href={href} data-next-link="true" {...props}>
+    {children}
+  </a>
+)
+
+// Mock React Router Link component
+// In real usage, replace with: import { Link } from 'react-router-dom'
+const RouterLink = ({ to, children }: PropsWithChildren<{ to: string }>) => (
+  <a href={to} data-router-link="true">
+    {children}
+  </a>
+)
+
+export const RenderProp: StoryFn<ComponentProps<typeof Breadcrumbs>> = () => (
+  <Breadcrumbs>
+    <Breadcrumbs.Item to="/home">Home</Breadcrumbs.Item>
+    <Breadcrumbs.Item to="/products">Products</Breadcrumbs.Item>
+    <Breadcrumbs.Item render={<NextLink href="/products/123" />}>NextLink: /products/123</Breadcrumbs.Item>
+    <Breadcrumbs.Item
+      render={props => (
+        <RouterLink {...props} to="/products/123">
+          {props.children}
+          <span style={{ marginLeft: '4px' }}>🔗</span>
+        </RouterLink>
+      )}
+    >
+      RouterLink: /products/123
+    </Breadcrumbs.Item>
+
+    <Breadcrumbs.Item>Details</Breadcrumbs.Item>
+  </Breadcrumbs>
+)
+
+RenderProp.parameters = {
+  docs: {
+    description: {
+      story:
+        'Using the **element form** of the render prop. Props like `href`, `className`, and event handlers are automatically merged with your custom component.',
+    },
+  },
+}

--- a/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/__snapshots__/index.test.tsx.snap
@@ -210,3 +210,52 @@ exports[`breadcrumbs > renders correctly with minWidth and maxWidth 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`breadcrumbs > should render with custom render prop 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <nav
+      aria-label="breadcrumb"
+    >
+      <ol
+        class="styles__qxa0fl0"
+      >
+        <li
+          class="styles__1yxbbx44 styles__1yxbbx47"
+        >
+          <a
+            class="styles__1yxbbx42 styles__1dtqm9e0 styles_prominence_stronger__1dtqm9e5 styles_sentiment_info__1dtqm9e2 styles_oneLine_false__1dtqm9e8 styles_variant_bodySmallStrong__1dtqm9ea styles_type_standalone__1dtqm9ed styles_undefined_compound_6__1dtqm9ek styles__1dtqm9en"
+            data-variant="standalone"
+            href="/step1"
+          >
+            Step 1
+          </a>
+        </li>
+        <li
+          class="styles__1yxbbx44 styles__1yxbbx47"
+        >
+          <a
+            class="styles__1yxbbx42 styles__1dtqm9e0 styles_prominence_stronger__1dtqm9e5 styles_sentiment_info__1dtqm9e2 styles_oneLine_false__1dtqm9e8 styles_variant_bodySmallStrong__1dtqm9ea styles_type_standalone__1dtqm9ed styles_undefined_compound_6__1dtqm9ek styles__1dtqm9en"
+            data-custom-link="true"
+            data-variant="standalone"
+            href="/custom"
+          >
+            Custom Link
+          </a>
+        </li>
+        <li
+          class="styles__1yxbbx44 styles__1yxbbx47"
+        >
+          <div
+            class="styles__1yxbbx43 styles__1yxbbx46 style__m4c9ow0 style_prominence_default__m4c9ow4 style_variant_bodySmallStrong__m4c9owl style_undefined_compound_0__m4c9ow1a"
+          >
+            Step 3
+          </div>
+        </li>
+      </ol>
+    </nav>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/src/components/Breadcrumbs/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/index.test.tsx
@@ -85,7 +85,7 @@ describe('breadcrumbs', () => {
       </Breadcrumbs>,
     )
 
-    const customLink = screen.getByText('Custom Link').closest('a')
+    const customLink = screen.getByRole('link', { name: 'Custom Link' })
     expect(customLink).toHaveAttribute('data-custom-link', 'true')
     expect(customLink).toHaveAttribute('href', '/custom')
     expect(asFragment()).toMatchSnapshot()

--- a/packages/ui/src/components/Breadcrumbs/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Breadcrumbs/__tests__/index.test.tsx
@@ -1,12 +1,19 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { renderWithTheme, shouldMatchSnapshot } from '@utils/test'
+import { renderWithTheme } from '@utils/test'
+import { PropsWithChildren } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { Breadcrumbs } from '..'
 
+const CustomLink = ({ children, ...props }: PropsWithChildren<{ href: string }>) => (
+  <a data-custom-link="true" {...props}>
+    {children}
+  </a>
+)
+
 describe('breadcrumbs', () => {
-  it('renders correctly with default values', () =>
-    shouldMatchSnapshot(
+  it('renders correctly with default values', () => {
+    const { asFragment } = renderWithTheme(
       <Breadcrumbs>
         <Breadcrumbs.Item to="/step1">Step 1</Breadcrumbs.Item>
         <Breadcrumbs.Item to="/step1/step2">
@@ -14,10 +21,13 @@ describe('breadcrumbs', () => {
         </Breadcrumbs.Item>
         <Breadcrumbs.Item>Step 3</Breadcrumbs.Item>
       </Breadcrumbs>,
-    ))
+    )
 
-  it('renders correctly with minWidth and maxWidth', () =>
-    shouldMatchSnapshot(
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('renders correctly with minWidth and maxWidth', () => {
+    const { asFragment } = renderWithTheme(
       <Breadcrumbs>
         <Breadcrumbs.Item to="/step1">Step 1</Breadcrumbs.Item>
         <Breadcrumbs.Item maxWidth="200px" minWidth="100px" to="/step1/step2">
@@ -25,7 +35,10 @@ describe('breadcrumbs', () => {
         </Breadcrumbs.Item>
         <Breadcrumbs.Item>Step 3</Breadcrumbs.Item>
       </Breadcrumbs>,
-    ))
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
 
   it('click on middle item', async () => {
     const onClick = vi.fn()
@@ -61,5 +74,40 @@ describe('breadcrumbs', () => {
   it('renders correctly with invalid child', () => {
     const { asFragment } = renderWithTheme(<Breadcrumbs>Invalid child</Breadcrumbs>)
     expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should render with custom render prop', () => {
+    const { asFragment } = renderWithTheme(
+      <Breadcrumbs>
+        <Breadcrumbs.Item to="/step1">Step 1</Breadcrumbs.Item>
+        <Breadcrumbs.Item render={<CustomLink href="/custom" />}>Custom Link</Breadcrumbs.Item>
+        <Breadcrumbs.Item>Step 3</Breadcrumbs.Item>
+      </Breadcrumbs>,
+    )
+
+    const customLink = screen.getByText('Custom Link').closest('a')
+    expect(customLink).toHaveAttribute('data-custom-link', 'true')
+    expect(customLink).toHaveAttribute('href', '/custom')
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should render with render function prop', () => {
+    const { debug } = renderWithTheme(
+      <Breadcrumbs>
+        <Breadcrumbs.Item to="/step1">Step 1</Breadcrumbs.Item>
+        <Breadcrumbs.Item render={props => <CustomLink {...props} href="/function-custom" />}>
+          Function Render
+        </Breadcrumbs.Item>
+        <Breadcrumbs.Item>Step 3</Breadcrumbs.Item>
+      </Breadcrumbs>,
+    )
+
+    debug()
+
+    const step1Link = screen.getByRole('link', { name: 'Step 1' })
+    expect(step1Link).toHaveAttribute('href', '/step1')
+    const functionLink = screen.getByRole('link', { name: 'Function Render' })
+    expect(functionLink).toHaveAttribute('href', '/function-custom')
+    expect(functionLink).toHaveAttribute('data-custom-link', 'true')
   })
 })

--- a/packages/ui/src/components/Breadcrumbs/components/Item.tsx
+++ b/packages/ui/src/components/Breadcrumbs/components/Item.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cn } from '@ultraviolet/utils'
+import type { RenderProp } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { useMemo } from 'react'
 import type { KeyboardEvent, MouseEvent as ReactMouseEvent, ReactNode } from 'react'
@@ -13,17 +14,42 @@ import { maxWidthVar, minWidthVar } from './styles.css'
 type ItemProps = {
   children: ReactNode
   'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time'
-  /**
-   * Make the component act a `Link` tag
-   */
-  to?: string
   disabled?: boolean
   onClick?: (event: ReactMouseEvent<HTMLElement>) => void
   onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void
   className?: string
   maxWidth?: string
   minWidth?: string
-}
+  /**
+   * Custom element or render function to use instead of the default link/button.
+   * Useful for integrating with routing libraries (e.g., React Router, Next.js).
+   *
+   * Element form (props auto-merged):
+   * ```tsx
+   * <Breadcrumbs.Item render={<NextLink href="/about" />}>About</Breadcrumbs.Item>
+   * ```
+   *
+   * Function form (you control prop merging):
+   * ```tsx
+   * <Breadcrumbs.Item render={(props) => <NextLink {...props} href="/about" />}>
+   *   About
+   * </Breadcrumbs.Item>
+   * ```
+   */
+  render?: RenderProp
+} & XOR<
+  [
+    {
+      /**
+       * Make the component act a `Link` tag
+       */
+      to?: string
+    },
+    {
+      render: RenderProp
+    },
+  ]
+>
 
 export const Item = ({
   to,
@@ -35,30 +61,38 @@ export const Item = ({
   className,
   maxWidth,
   minWidth,
+  render,
 }: ItemProps) => {
   const renderedChildren = useMemo(() => {
-    if (to) {
+    if (to || render) {
       return (
         <Link
           className={breadcrumbsStyle.link}
-          href={to}
           onClick={onClick}
           onKeyDown={onKeyDown}
           prominence="stronger"
           size="small"
+          {...(render
+            ? {
+                render,
+              }
+            : {
+                href: to,
+              })}
         >
           {children}
         </Link>
       )
     }
 
-    if (onClick) {
+    if (onClick || render) {
       return (
         <Button
           className={breadcrumbsStyle.content}
           disabled={disabled}
           sentiment="neutral"
           size="small"
+          render={render}
           style={assignInlineVars({
             [minWidthVar]: minWidth?.toString(),
             [maxWidthVar]: maxWidth?.toString(),
@@ -79,7 +113,7 @@ export const Item = ({
         {children}
       </Text>
     )
-  }, [children, disabled, maxWidth, minWidth, onClick, to, onKeyDown])
+  }, [children, disabled, maxWidth, minWidth, onClick, to, onKeyDown, render])
 
   return (
     <li


### PR DESCRIPTION
## Summary

## Type
- Feature
- Enhancement


### Summarize concisely:

`Breadcrumbs.Item`: add `render` prop to support custom link components (e.g., React Router `Link`, Next.js `Link`)

### Added
- `render` prop to `Breadcrumbs.Item` component for custom element rendering
- Support for both element form (`render={<CustomLink />}`) and function form (`render={(props) => <CustomLink {...props} />}`)


### Usage Example

```tsx
import Link from 'next/link'
import { Breadcrumbs } from '@ultraviolet/ui'

<Breadcrumbs>
  <Breadcrumbs.Item render={(props) => <Link {...props} href="/"/ >}>Home</Breadcrumbs.Item>
  <Breadcrumbs.Item render={(props) => <Link {...props} href="/products"/>}>Product</Breadcrumbs.Item>
  <Breadcrumbs.Item>Current Page</Breadcrumbs.Item>
</Breadcrumbs>
```
This change enables seamless integration with routing libraries while preserving Breadcrumbs styling and accessibility features.