### PR TITLE
fix(number-input-field): nested type form

### DIFF
--- a/.changeset/sparkly-emus-fail.md
+++ b/.changeset/sparkly-emus-fail.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+Fix Nested field paths - Supports dot-notation paths like 'user.name'

--- a/packages/form/src/__tests__/types.test.ts
+++ b/packages/form/src/__tests__/types.test.ts
@@ -1,0 +1,57 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type { BaseFieldProps } from '../types'
+
+describe('types', () => {
+  describe('baseFieldProps', () => {
+    it('should infer correct name type for string field', () => {
+      type Props = BaseFieldProps<{ username: string }, 'username', string>
+      expectTypeOf<Props>().toHaveProperty('name').toEqualTypeOf<'username'>()
+      expectTypeOf<Props>().toHaveProperty('required').toEqualTypeOf<boolean | undefined>()
+      expectTypeOf<Props>().toHaveProperty('label').toEqualTypeOf<string | undefined>()
+      expectTypeOf<Props>().toHaveProperty('defaultValue').toEqualTypeOf<string | undefined>()
+    })
+
+    it('should infer correct name type for number field', () => {
+      type Props = BaseFieldProps<{ age: number }, 'age', number>
+      expectTypeOf<Props>().toHaveProperty('name').toEqualTypeOf<'age'>()
+      expectTypeOf<Props>().toHaveProperty('defaultValue').toEqualTypeOf<number | undefined>()
+    })
+
+    it('should infer correct name type for boolean field', () => {
+      type Props = BaseFieldProps<{ isActive: boolean }, 'isActive', boolean>
+      expectTypeOf<Props>().toHaveProperty('name').toEqualTypeOf<'isActive'>()
+      expectTypeOf<Props>().toHaveProperty('defaultValue').toEqualTypeOf<boolean | undefined>()
+    })
+
+    it('should accept onChange with correct value type', () => {
+      type Props = BaseFieldProps<{ count: number }, 'count', number>
+      expectTypeOf<Props>().toHaveProperty('onChange').toEqualTypeOf<((value?: number) => void) | undefined>()
+    })
+
+    it('should accept control and shouldUnregister from UseControllerProps', () => {
+      type FormValues = { username: string }
+      type Props = BaseFieldProps<FormValues, 'username', string>
+      expectTypeOf<Props>().toHaveProperty('control').toMatchTypeOf<object | undefined>()
+      expectTypeOf<Props>().toHaveProperty('shouldUnregister').toEqualTypeOf<boolean | undefined>()
+    })
+
+    it('should accept errorLabel property', () => {
+      type Props = BaseFieldProps<{ username: string }, 'username', string>
+      expectTypeOf<Props>().toHaveProperty('errorLabel').toEqualTypeOf<string | undefined>()
+    })
+
+    it('should work with nested field paths', () => {
+      type FormValues = { user: { name: string } }
+      type Props = BaseFieldProps<FormValues, 'user.name', string>
+      expectTypeOf<Props>().toHaveProperty('name').toEqualTypeOf<'user.name'>()
+      expectTypeOf<Props>().toHaveProperty('defaultValue').toEqualTypeOf<string | undefined>()
+    })
+
+    it('should work with array field values', () => {
+      type FormValues = { tags: string[] }
+      type Props = BaseFieldProps<FormValues, 'tags', string[]>
+      expectTypeOf<Props>().toHaveProperty('name').toEqualTypeOf<'tags'>()
+      expectTypeOf<Props>().toHaveProperty('defaultValue').toEqualTypeOf<string[] | undefined>()
+    })
+  })
+})

--- a/packages/form/src/components/NumberInputField/__tests__/types.test.tsx
+++ b/packages/form/src/components/NumberInputField/__tests__/types.test.tsx
@@ -1,3 +1,4 @@
+import type { Path } from 'react-hook-form'
 import { describe, expectTypeOf, it } from 'vitest'
 import type { NumberInputFieldProps } from '..'
 
@@ -11,28 +12,59 @@ describe('numberInputField', () => {
       requiredString: string
       optionalString: string | null
       undefinedString?: string
+      nested: {
+        string: string
+        number: number
+      }
     }
-    type FormKey = keyof FormData
-    type NameForm<T extends FormKey> = NumberInputFieldProps<FormData, T>['name']
+    type FormKey = Path<FormData>
+    type FieldFormName<T extends FormKey> = NumberInputFieldProps<FormData, T>['name']
+    type FieldFormValue<T extends FormKey> = NumberInputFieldProps<FormData, T>['value']
 
     it('should accept number field names', () => {
-      expectTypeOf<NameForm<'requiredNumber'>>().toEqualTypeOf<'requiredNumber'>()
-      expectTypeOf<NameForm<'optionalNumber'>>().toEqualTypeOf<'optionalNumber'>()
-      expectTypeOf<NameForm<'undefinedNumber'>>().toEqualTypeOf<'undefinedNumber'>()
-      expectTypeOf<NameForm<'undefinedOrNullNumber'>>().toEqualTypeOf<'undefinedOrNullNumber'>()
+      expectTypeOf<FieldFormName<'requiredNumber'>>().toEqualTypeOf<'requiredNumber'>()
+      expectTypeOf<FieldFormName<'optionalNumber'>>().toEqualTypeOf<'optionalNumber'>()
+      expectTypeOf<FieldFormName<'undefinedNumber'>>().toEqualTypeOf<'undefinedNumber'>()
+      expectTypeOf<FieldFormName<'undefinedOrNullNumber'>>().toEqualTypeOf<'undefinedOrNullNumber'>()
+      expectTypeOf<FieldFormName<'nested.number'>>().toEqualTypeOf<'nested.number'>()
+
+      // name is never if the type is not equal to the value: number in that case
+      expectTypeOf<FieldFormName<'nested.string'>>().toEqualTypeOf<never>()
+      expectTypeOf<FieldFormName<'nested'>>().toEqualTypeOf<never>()
     })
 
     it('should reject string field names', () => {
       // This will inform the user that the name doesn't have right type inside the form.
-      expectTypeOf<NameForm<'requiredString'>>().toEqualTypeOf<never>()
-      expectTypeOf<NameForm<'optionalString'>>().toEqualTypeOf<never>()
-      expectTypeOf<NameForm<'undefinedString'>>().toEqualTypeOf<never>()
+      expectTypeOf<FieldFormName<'requiredString'>>().toEqualTypeOf<never>()
+      expectTypeOf<FieldFormName<'optionalString'>>().toEqualTypeOf<never>()
+      expectTypeOf<FieldFormName<'undefinedString'>>().toEqualTypeOf<never>()
     })
 
     it('should have correct value type of NumberInput', () => {
-      expectTypeOf<NumberInputFieldProps<FormData, 'optionalNumber'>['value']>().toEqualTypeOf<
-        number | null | undefined
-      >()
+      type NestedValue = FieldFormValue<'nested.number'>
+      expectTypeOf<NestedValue>().toEqualTypeOf<number | null | undefined>()
+    })
+
+    it('should accept nested number field names with dot notation', () => {
+      // Test with a proper nested number type
+      type NestedFormData = {
+        dbConfig: {
+          port: number
+          host: string
+        }
+      }
+
+      type FormNestedKey = Path<NestedFormData>
+      type FieldNestedFormName<T extends FormNestedKey, S extends 'name' | 'value'> = NumberInputFieldProps<
+        NestedFormData,
+        T
+      >[S]
+
+      // Nested number field should be accepted
+      type Name = FieldNestedFormName<'dbConfig.port', 'name'>
+      type Value = FieldNestedFormName<'dbConfig.port', 'value'>
+      expectTypeOf<Name>().toEqualTypeOf<'dbConfig.port'>()
+      expectTypeOf<Value>().toEqualTypeOf<number | null | undefined>()
     })
   })
 })

--- a/packages/form/src/components/SelectableCardField/index.tsx
+++ b/packages/form/src/components/SelectableCardField/index.tsx
@@ -8,9 +8,9 @@ import type { BaseFieldProps } from '../../types'
 
 type SelectableCardFieldProps<TFieldValues extends FieldValues, TFieldName extends FieldPath<TFieldValues>> = Omit<
   BaseFieldProps<TFieldValues, TFieldName>,
-  'label'
+  'label' | 'value'
 > &
-  Omit<ComponentProps<typeof SelectableCard>, 'name' | 'onChange' | 'value'>
+  Omit<ComponentProps<typeof SelectableCard>, 'name' | 'onChange'>
 
 export const SelectableCardField = <
   TFieldValues extends FieldValues,
@@ -18,13 +18,13 @@ export const SelectableCardField = <
 >({
   name,
   control,
-  value,
   onChange,
   type,
   onFocus,
   onBlur,
   required,
   label,
+  value,
   shouldUnregister = false,
   validate,
   productIcon,
@@ -47,7 +47,7 @@ export const SelectableCardField = <
 
   const isChecked =
     (type === 'checkbox' || type === 'toggle') && Array.isArray(field.value) && value
-      ? (field.value ?? []).includes(value)
+      ? ((field.value ?? []) as (string | number)[]).includes(value)
       : field.value === value
 
   return (

--- a/packages/form/src/types.ts
+++ b/packages/form/src/types.ts
@@ -5,10 +5,10 @@ import type {
   FieldPath,
   FieldPathValue,
   FieldValues,
-  Path,
   PathValue,
   UseControllerProps,
   Validate,
+  NativeFieldValue,
 } from 'react-hook-form'
 
 /**
@@ -48,14 +48,19 @@ export type FormErrors = {
 export type BaseFieldProps<
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-  ValueType extends FieldValues[TFieldName] = FieldValues[TFieldName],
+  ValueType extends NativeFieldValue = FieldPathValue<TFieldValues, TFieldName>,
 > = {
-  name: TFieldValues[TFieldName] extends ValueType ? TFieldName : never
+  name: [ValueType] extends [never]
+    ? TFieldName
+    : FieldPathValue<TFieldValues, TFieldName> extends ValueType
+      ? TFieldName
+      : never
+
   required?: boolean
   validate?: Record<string, Validate<FieldPathValue<TFieldValues, TFieldName>, TFieldValues>>
-  defaultValue?: PathValue<TFieldValues, Path<TFieldValues>>
+  defaultValue?: ValueType
   label?: string
-  value?: PathValue<TFieldValues, Path<TFieldValues>>
+  value?: ValueType
   onChange?: (value?: PathValue<TFieldValues, TFieldName>) => void
   shouldUnregister?: UseControllerProps<TFieldValues, TFieldName>['shouldUnregister']
   control?: Control<TFieldValues>

--- a/packages/ui/src/components/NumberInput/__stories__/MinMax.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/MinMax.stories.tsx
@@ -4,7 +4,6 @@ import { NumberInput } from '..'
 
 export const Template: StoryFn<typeof NumberInput> = props => {
   const [value, setValue] = useState<number | null>(10)
-  console.debug(props.helper)
 
   return <NumberInput {...props} onChange={setValue} value={value} />
 }

--- a/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
@@ -271,7 +271,6 @@ describe('filters', () => {
   })
 
   it('should accept custom filter components', () => {
-    // oxlint-disable-next-line unicorn/consistent-function-scoping no-shadow
     const CustomFilter = ({ config }: FilterComponentProps) => <button type="button">{config.label}</button>
 
     renderWithTheme(


### PR DESCRIPTION
## Summary

## Type

- Enhancement


### Summarize concisely:

 Fix Nested field paths - Supports dot-notation paths like 'user.name'

Invalid name rejection - Ensures invalid field names result in never type (type error)

