### PR TITLE
feat: deprecate themes in ui

### DIFF
--- a/.changeset/honest-clouds-rule.md
+++ b/.changeset/honest-clouds-rule.md
@@ -1,0 +1,16 @@
+---
+"@ultraviolet/themes": patch
+"@ultraviolet/ui": patch
+---
+
+Deprecate `ThemeProvider`, `darkTheme`, `darkerTheme`, `theme`, and `useTheme` from @ultraviolet/ui. Use the equivalents from @ultraviolet/themes instead.
+
+⚠️⚠️ **Future breaking change** ⚠️⚠️  
+The `ThemeProvider` from `@ultraviolet/ui` automatically injects styles from `@ultraviolet/icons`.  
+The replacement `ThemeProvider` in `@ultraviolet/themes` does **not** include this side effect.
+
+When these exports are removed in the next major version, you must manually import the icon styles to avoid visual regressions:
+
+```js
+import '@ultraviolet/icons/styles'
+```

--- a/.storybook/storybookThemes.ts
+++ b/.storybook/storybookThemes.ts
@@ -1,5 +1,5 @@
+import { consoleDarkerTheme, consoleDarkTheme, consoleLightTheme } from '@ultraviolet/themes'
 import { create } from 'storybook/theming'
-import lightTheme, { darkerTheme, darkTheme } from '../packages/ui/src/theme'
 import logoDark from './assets/logo-dark.png'
 import logoLight from './assets/logo-light.png'
 import type lightBrandImage from './assets/scaleway-text-light.png'
@@ -11,7 +11,7 @@ enum Base {
 
 type GenerateStorybookThemeProps = {
   base: Base
-  theme: typeof darkTheme | typeof lightTheme | typeof darkerTheme
+  theme: typeof consoleDarkTheme | typeof consoleLightTheme | typeof consoleDarkerTheme
   brandUrl: string
   brandImage: typeof lightBrandImage
 }
@@ -57,19 +57,19 @@ export const light = generateStorybookTheme({
   base: Base.LIGHT,
   brandImage: logoLight,
   brandUrl: 'https://github.com/scaleway/ultraviolet',
-  theme: lightTheme,
+  theme: consoleLightTheme,
 })
 
 export const dark = generateStorybookTheme({
   base: Base.DARK,
   brandImage: logoDark,
   brandUrl: 'https://github.com/scaleway/ultraviolet',
-  theme: darkTheme,
+  theme: consoleDarkTheme,
 })
 
 export const darker = generateStorybookTheme({
   base: Base.DARK,
   brandImage: logoDark,
   brandUrl: 'https://github.com/scaleway/ultraviolet',
-  theme: darkerTheme,
+  theme: consoleDarkerTheme,
 })

--- a/examples/next/src/pages/_app.tsx
+++ b/examples/next/src/pages/_app.tsx
@@ -1,5 +1,5 @@
-import { consoleDarkTheme, consoleLightTheme, ThemeProvider } from '@ultraviolet/themes'
-import { extendTheme, Stack } from '@ultraviolet/ui'
+import { consoleDarkTheme, consoleLightTheme, extendTheme, ThemeProvider } from '@ultraviolet/themes'
+import { Stack } from '@ultraviolet/ui'
 import type { AppProps } from 'next/app'
 import { useCallback, useLayoutEffect, useState } from 'react'
 import type { PropsWithChildren } from 'react'

--- a/examples/next/src/pages/advanced/AdvancedUseCases.tsx
+++ b/examples/next/src/pages/advanced/AdvancedUseCases.tsx
@@ -2,8 +2,8 @@ import { Stack, Text } from '@ultraviolet/ui'
 import CopyBox from '../../components/CopyBoxCommand'
 import styles from '../../../styles/advanced.module.scss'
 
-const useCase1 = `import { theme as lightTheme, dark as darkTheme, Button, Text } from '@ultraviolet/ui'
-import { ThemeProvider } from '@ultraviolet/themes'
+const useCase1 = `import { theme as lightTheme, Button, Text } from '@ultraviolet/ui'
+import { ThemeProvider, consoleDarkTheme as darkTheme } from '@ultraviolet/themes'
 import React, { useCallback, useState } from 'react'
 
 const App = () => {

--- a/examples/next/src/pages/advanced/AdvancedUseCases.tsx
+++ b/examples/next/src/pages/advanced/AdvancedUseCases.tsx
@@ -2,8 +2,8 @@ import { Stack, Text } from '@ultraviolet/ui'
 import CopyBox from '../../components/CopyBoxCommand'
 import styles from '../../../styles/advanced.module.scss'
 
-const useCase1 = `import { theme as lightTheme, Button, Text } from '@ultraviolet/ui'
-import { ThemeProvider, consoleDarkTheme as darkTheme } from '@ultraviolet/themes'
+const useCase1 = `import { Button, Text } from '@ultraviolet/ui'
+import { ThemeProvider, consoleDarkTheme as darkTheme, consoleLightTheme as lightTheme } from '@ultraviolet/themes'
 import React, { useCallback, useState } from 'react'
 
 const App = () => {

--- a/examples/next/src/pages/advanced/GettingStarted.tsx
+++ b/examples/next/src/pages/advanced/GettingStarted.tsx
@@ -2,8 +2,8 @@ import { Snippet, Stack, Text } from '@ultraviolet/ui'
 import CopyBox from '../../components/CopyBoxCommand'
 import GithubAndDocumentationButtons from '../../components/GithubAndDocumentationButtons'
 
-const themeExample = `import { theme, Button } from "@ultraviolet/ui"
-import { ThemeProvider } from "@ultraviolet/themes"
+const themeExample = `import { Button } from "@ultraviolet/ui"
+import { ThemeProvider, consoleLightTheme } from "@ultraviolet/themes"
 
 const App = () => (
     <ThemeProvider theme={theme}>

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -1,5 +1,5 @@
-import { consoleDarkTheme, consoleLightTheme } from '@ultraviolet/themes'
-import { Alert, Button, Card, Row, Stack, Text, ThemeProvider, Badge, SelectableCardOptionGroup } from '@ultraviolet/ui'
+import { consoleDarkTheme, consoleLightTheme, ThemeProvider } from '@ultraviolet/themes'
+import { Alert, Button, Card, Row, Stack, Text, Badge, SelectableCardOptionGroup } from '@ultraviolet/ui'
 import { InfoTable } from '@ultraviolet/ui/compositions/InfoTable'
 import { useState } from 'react'
 import '@ultraviolet/ui/styles' // Import styles for the UI components

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -53,7 +53,8 @@
   },
   "dependencies": {
     "@vanilla-extract/css": "1.21.1",
-    "@vanilla-extract/dynamic": "2.1.5"
+    "@vanilla-extract/dynamic": "2.1.5",
+    "deepmerge": "4.3.1"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",

--- a/packages/themes/src/constants.ts
+++ b/packages/themes/src/constants.ts
@@ -16,3 +16,4 @@ export type ExtendedColor = Color | Monochrome
 export type TextVariant = keyof typeof typography
 export type TextStyleObject = typeof typography.body
 export const textVariants = Object.keys(typography) as TextVariant[]
+export type UltravioletUITheme = typeof lightTheme

--- a/packages/themes/src/extendTheme.ts
+++ b/packages/themes/src/extendTheme.ts
@@ -10,5 +10,5 @@ type RecursivePartial<T> = {
  * Will extend theme with new theme properties
  * @param {RecursivePartial<UltravioletUITheme>} extendedTheme the properties of a new theme you want to apply from baseTheme
  */
-export const extendTheme = (extendedTheme: RecursivePartial<UltravioletUITheme>) =>
+export const extendTheme = (extendedTheme: RecursivePartial<UltravioletUITheme>): UltravioletUITheme =>
   deepmerge(consoleLightTheme, extendedTheme) as UltravioletUITheme

--- a/packages/themes/src/extendTheme.ts
+++ b/packages/themes/src/extendTheme.ts
@@ -1,0 +1,15 @@
+import deepmerge from 'deepmerge'
+import { UltravioletUITheme } from './constants'
+import { consoleLightTheme } from './themes'
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>
+}
+
+/**
+ * Will extend theme with new theme properties
+ * @param {UltravioletUITheme} baseTheme the theme you want to extend from, by default it is set to light theme
+ * @param {RecursivePartial<UltravioletUITheme>} extendedTheme the properties of a new theme you want to apply from baseTheme
+ */
+export const extendTheme = (extendedTheme: RecursivePartial<UltravioletUITheme>) =>
+  deepmerge(consoleLightTheme, extendedTheme) as UltravioletUITheme

--- a/packages/themes/src/extendTheme.ts
+++ b/packages/themes/src/extendTheme.ts
@@ -1,5 +1,5 @@
 import deepmerge from 'deepmerge'
-import { UltravioletUITheme } from './constants'
+import type { UltravioletUITheme } from './constants'
 import { consoleLightTheme } from './themes'
 
 type RecursivePartial<T> = {

--- a/packages/themes/src/extendTheme.ts
+++ b/packages/themes/src/extendTheme.ts
@@ -8,7 +8,6 @@ type RecursivePartial<T> = {
 
 /**
  * Will extend theme with new theme properties
- * @param {UltravioletUITheme} baseTheme the theme you want to extend from, by default it is set to light theme
  * @param {RecursivePartial<UltravioletUITheme>} extendedTheme the properties of a new theme you want to apply from baseTheme
  */
 export const extendTheme = (extendedTheme: RecursivePartial<UltravioletUITheme>) =>

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -1,8 +1,9 @@
 import './vanilla/globalStyle.css'
 
-export type { ExtendedColor, TextStyleObject, TextVariant } from './constants'
+export type { ExtendedColor, TextStyleObject, TextVariant, UltravioletUITheme } from './constants'
 export { textVariants } from './constants'
 export { generateObjectStyleFromTheme, isColorMonochrome, isSize } from './helpers'
 export { ThemeProvider, useTheme } from './ThemeProvider'
 export * from './themes'
 export { theme } from './vanilla/themes.css'
+export { extendTheme } from './extendTheme'

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -37,8 +37,8 @@ For the library to work properly, you need to wrap your application with the `Th
 You will also need to import styles of components for them to have the correct styles.
 
 ```tsx
-import { ThemeProvider } from '@ultraviolet/themes'
-import { Button, theme } from '@ultraviolet/ui'
+import { ThemeProvider, consoleLightTheme as theme } from '@ultraviolet/themes'
+import { Button } from '@ultraviolet/ui'
 import '@ultraviolet/ui/styles'
 
 const App = () => (
@@ -63,7 +63,7 @@ If your app still uses `Emotion`, you can combine both theme providers:
 
 ```js
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react'
-import { consoleLightTheme, ThemeProvider as UVThemeProvider } from '@ultraviolet/ui'
+import { consoleLightTheme, ThemeProvider as UVThemeProvider } from '@ultraviolet/themes'
 
 const App = () => (
   <UVThemeProvider theme={consoleLightTheme}>

--- a/packages/ui/src/components/Row/index.tsx
+++ b/packages/ui/src/components/Row/index.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { consoleLightTheme } from '@ultraviolet/themes'
+import { consoleLightTheme, UltravioletUITheme } from '@ultraviolet/themes'
 import { cn } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import type { CSSProperties, ReactNode } from 'react'
-import type { UltravioletUITheme } from '../../theme'
 import { rowStyle, sprinkles } from './styles.css'
 import type { AlignItemsType, JustifyContentType } from './styles.css'
 import { paddings, templateColumn } from './variables.css'

--- a/packages/ui/src/components/Row/index.tsx
+++ b/packages/ui/src/components/Row/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { consoleLightTheme, UltravioletUITheme } from '@ultraviolet/themes'
+import { consoleLightTheme } from '@ultraviolet/themes'
+import type { UltravioletUITheme } from '@ultraviolet/themes'
 import { cn } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import type { CSSProperties, ReactNode } from 'react'

--- a/packages/ui/src/components/Snippet/index.tsx
+++ b/packages/ui/src/components/Snippet/index.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { ArrowDownIcon } from '@ultraviolet/icons/ArrowDownIcon'
+import { useTheme } from '@ultraviolet/themes'
 import { cn } from '@ultraviolet/utils'
 import type { ComponentProps, CSSProperties, ReactNode } from 'react'
 import { useId, useReducer } from 'react'
 import { hasHelperText } from '../../helpers/hasHelperText'
-import { useTheme } from '../../theme/ThemeProvider'
 import { CopyButton } from '../CopyButton'
 import { Description } from '../Description'
 import { Expandable } from '../Expandable'

--- a/packages/ui/src/components/Stack/index.tsx
+++ b/packages/ui/src/components/Stack/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { consoleLightTheme, UltravioletUITheme } from '@ultraviolet/themes'
+import { consoleLightTheme } from '@ultraviolet/themes'
+import type { UltravioletUITheme } from '@ultraviolet/themes'
 import { cn } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { forwardRef, useMemo } from 'react'

--- a/packages/ui/src/components/Stack/index.tsx
+++ b/packages/ui/src/components/Stack/index.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { consoleLightTheme } from '@ultraviolet/themes'
+import { consoleLightTheme, UltravioletUITheme } from '@ultraviolet/themes'
 import { cn } from '@ultraviolet/utils'
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import { forwardRef, useMemo } from 'react'
 import type { CSSProperties, ElementType, PropsWithChildren, ReactElement } from 'react'
-import type { UltravioletUITheme } from '../../theme'
 import type { PolymorphicComponentProps } from './types'
 import { sprinkles, stackStyle } from './styles.css'
 import type { AlignItemsType, JustifyContentType } from './styles.css'

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -32,7 +32,17 @@ type ThemeProviderProps = {
 /**
  * ThemeProvider will apply generated global CSS variables to the application in the `<head>`.
  * If no theme is provided, it will default to `lightTheme`.
- * @deprecated use ThemeProvider from \@ultraviolet/themes
+ * @deprecated use ThemeProvider from `@ultraviolet/themes`
+ *
+ * **Future breaking change**:
+ * The `ThemeProvider` from `@ultraviolet/ui` automatically injects styles from `@ultraviolet/icons`.
+ * The replacement `ThemeProvider` in `@ultraviolet/themes` does **not** include this side effect.
+ *
+ * When these exports are removed in the next major version, you must manually import the icon styles to avoid visual regressions:
+ *
+ * ```js
+ * import '@ultraviolet/icons/styles'
+ * ```
  */
 export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProviderProps) => {
   useLayoutEffect(() => {

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -32,6 +32,7 @@ type ThemeProviderProps = {
 /**
  * ThemeProvider will apply generated global CSS variables to the application in the `<head>`.
  * If no theme is provided, it will default to `lightTheme`.
+ * @deprecated use ThemeProvider from \@ultraviolet/themes
  */
 export const ThemeProvider = ({ children, theme = consoleLightTheme }: ThemeProviderProps) => {
   useLayoutEffect(() => {

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -4,6 +4,9 @@ import { ThemeProvider } from './ThemeProvider'
 
 export type ScreenSize = keyof typeof consoleLightTheme.breakpoints
 
+/**
+ * @deprecated use `UltravioletUITheme` from ultraviolet/themes instead
+ */
 type UltravioletUITheme = typeof consoleLightTheme
 
 const { colors, shadows, typography, space, radii, breakpoints } = consoleLightTheme
@@ -40,14 +43,32 @@ export {
   space,
   radii,
   breakpoints as screens,
+  /**
+   * @deprecated use `consoleDarkTheme` from ultraviolet/themes instead
+   */
   consoleDarkTheme as darkTheme,
+  /**
+   * @deprecated use `consoleDarkerTheme` from ultraviolet/themes instead
+   */
   consoleDarkerTheme as darkerTheme,
+  /**
+   * @deprecated use `extendTheme` from ultraviolet/themes instead
+   */
   extendTheme,
   SENTIMENTS,
   SENTIMENTS_WITHOUT_NEUTRAL,
   typography,
+  /**
+   * @deprecated use `ThemeProvider` from ultraviolet/themes instead
+   */
   ThemeProvider,
+  /**
+   * @deprecated use `useTheme` from ultraviolet/themes instead
+   */
   useTheme,
 }
 
+/**
+ * @deprecated use `consoleLightTheme` from ultraviolet/themes instead
+ */
 export default consoleLightTheme

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -17,7 +17,6 @@ type RecursivePartial<T> = {
 
 /**
  * Will extend theme with new theme properties
- * @param {UltravioletUITheme} baseTheme the theme you want to extend from, by default it is set to light theme
  * @param {RecursivePartial<UltravioletUITheme>} extendedTheme the properties of a new theme you want to apply from baseTheme
  */
 const extendTheme = (extendedTheme: RecursivePartial<UltravioletUITheme>) =>

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -5,7 +5,7 @@ import { ThemeProvider } from './ThemeProvider'
 export type ScreenSize = keyof typeof consoleLightTheme.breakpoints
 
 /**
- * @deprecated use `UltravioletUITheme` from ultraviolet/themes instead
+ * @deprecated use `UltravioletUITheme` from `@ultraviolet/themes` instead
  */
 type UltravioletUITheme = typeof consoleLightTheme
 
@@ -43,31 +43,31 @@ export {
   radii,
   breakpoints as screens,
   /**
-   * @deprecated use `consoleDarkTheme` from ultraviolet/themes instead
+   * @deprecated use `consoleDarkTheme` from `@ultraviolet/themes` instead
    */
   consoleDarkTheme as darkTheme,
   /**
-   * @deprecated use `consoleDarkerTheme` from ultraviolet/themes instead
+   * @deprecated use `consoleDarkerTheme` from `@ultraviolet/themes` instead
    */
   consoleDarkerTheme as darkerTheme,
   /**
-   * @deprecated use `extendTheme` from ultraviolet/themes instead
+   * @deprecated use `extendTheme` from `@ultraviolet/themes` instead
    */
   extendTheme,
   SENTIMENTS,
   SENTIMENTS_WITHOUT_NEUTRAL,
   typography,
   /**
-   * @deprecated use `ThemeProvider` from ultraviolet/themes instead
+   * @deprecated use `ThemeProvider` from `@ultraviolet/themes` instead
    */
   ThemeProvider,
   /**
-   * @deprecated use `useTheme` from ultraviolet/themes instead
+   * @deprecated use `useTheme` from `@ultraviolet/themes` instead
    */
   useTheme,
 }
 
 /**
- * @deprecated use `consoleLightTheme` from ultraviolet/themes instead
+ * @deprecated use `consoleLightTheme` from `@ultraviolet/themes` instead
  */
 export default consoleLightTheme

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,9 @@ importers:
       '@vanilla-extract/dynamic':
         specifier: 2.1.5
         version: 2.1.5
+      deepmerge:
+        specifier: 4.3.1
+        version: 4.3.1
     devDependencies:
       '@repo/config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

## Type

Deprecate `ThemeProvider`, `darkTheme`, `darkerTheme`, `theme`, and `useTheme` from @ultraviolet/ui. Use the equivalents from @ultraviolet/themes instead.

⚠️⚠️ **Future breaking change** ⚠️⚠️  
The `ThemeProvider` from `@ultraviolet/ui` automatically injects styles from `@ultraviolet/icons`.  
The replacement `ThemeProvider` in `@ultraviolet/themes` does **not** include this side effect.

When these exports are removed in the next major version, you must manually import the icon styles to avoid visual regressions:

```js
import '@ultraviolet/icons/styles'
```