### PR TITLE
fix(NumberInput): add background

### DIFF
--- a/.changeset/huge-files-vanish.md
+++ b/.changeset/huge-files-vanish.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`NumberInput`, `UnitInput`: add background

--- a/packages/form/src/components/NumberInputField/__stories__/Required.stories.tsx
+++ b/packages/form/src/components/NumberInputField/__stories__/Required.stories.tsx
@@ -1,15 +1,8 @@
 import type { StoryFn } from '@storybook/react-vite'
-import { Stack } from '@ultraviolet/ui'
 import type { ComponentProps } from 'react'
 import { NumberInputField } from '..'
-import { Submit } from '../../Submit'
 
-export const Required: StoryFn<ComponentProps<typeof NumberInputField>> = args => (
-  <Stack gap={1}>
-    <NumberInputField {...args} />
-    <Submit>Submit</Submit>
-  </Stack>
-)
+export const Required: StoryFn<ComponentProps<typeof NumberInputField>> = args => <NumberInputField {...args} />
 
 Required.args = {
   label: 'This field is required',

--- a/packages/form/src/components/NumberInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/NumberInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`numberInputField > should render correctly 1`] = `
       >
         <div>
           <div
-            class="uv_1ce7gb6j uv_1ce7gb6k uv_1ce7gb6n"
+            class="uv_1ce7gb6k uv_1ce7gb6l uv_1ce7gb6o"
             data-controls="true"
             data-disabled="false"
             data-error="false"
@@ -51,7 +51,7 @@ exports[`numberInputField > should render correctly 1`] = `
               style="--uv_3mg8xe0: 1fr auto; --uv_3mg8xe1: 1fr auto; --uv_3mg8xe2: 1fr auto; --uv_3mg8xe3: 1fr auto; --uv_3mg8xe4: 1fr auto; --uv_3mg8xe5: 1fr auto;"
             >
               <input
-                class="uv_1ce7gb6c uv_1ce7gb6f"
+                class="uv_1ce7gb6c uv_1ce7gb6e uv_1ce7gb6g"
                 id="_r_0_"
                 inputmode="decimal"
                 max="9007199254740991"
@@ -107,7 +107,7 @@ exports[`numberInputField > should render correctly disabled 1`] = `
       >
         <div>
           <div
-            class="uv_1ce7gb6j uv_1ce7gb6k uv_1ce7gb6o"
+            class="uv_1ce7gb6k uv_1ce7gb6l uv_1ce7gb6p"
             data-controls="true"
             data-disabled="true"
             data-error="false"
@@ -146,7 +146,7 @@ exports[`numberInputField > should render correctly disabled 1`] = `
             >
               <input
                 aria-label="Number Input"
-                class="uv_1ce7gb6c uv_1ce7gb6f"
+                class="uv_1ce7gb6c uv_1ce7gb6e uv_1ce7gb6g"
                 disabled=""
                 id="_r_5_"
                 inputmode="decimal"

--- a/packages/form/src/components/SliderField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/SliderField/__tests__/__snapshots__/index.test.tsx.snap
@@ -485,7 +485,7 @@ exports[`sliderField > should trigger events correctly 1`] = `
             >
               <div>
                 <div
-                  class="uv_1ce7gb6j uv_1ce7gb6m uv_1ce7gb6n"
+                  class="uv_1ce7gb6k uv_1ce7gb6n uv_1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -499,7 +499,7 @@ exports[`sliderField > should trigger events correctly 1`] = `
                   >
                     <input
                       aria-label="input"
-                      class="uv_1ce7gb6c uv_1ce7gb6d uv_1ce7gb6h uv_1ce7gb6i"
+                      class="uv_1ce7gb6c uv_1ce7gb6d uv_1ce7gb6i uv_1ce7gb6j"
                       data-testid="slider-input"
                       id="_r_15_"
                       inputmode="numeric"

--- a/packages/ui/src/components/NumberInput/__stories__/Unit.stories.tsx
+++ b/packages/ui/src/components/NumberInput/__stories__/Unit.stories.tsx
@@ -9,6 +9,7 @@ Unit.args = {
   name: 'number-input',
   onChange: () => {},
   unit: 'GB',
+  controls: true,
 }
 
 Unit.parameters = {

--- a/packages/ui/src/components/NumberInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/NumberInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`numberInput > should click on min button 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -47,7 +47,7 @@ exports[`numberInput > should click on min button 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_2l_"
               inputmode="numeric"
               max="100"
@@ -99,7 +99,7 @@ exports[`numberInput > should click on plus button with a step value 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -136,7 +136,7 @@ exports[`numberInput > should click on plus button with a step value 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_2q_"
               inputmode="numeric"
               max="100"
@@ -187,7 +187,7 @@ exports[`numberInput > should click on plus button with a step value and an in-b
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -224,7 +224,7 @@ exports[`numberInput > should click on plus button with a step value and an in-b
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_39_"
               inputmode="numeric"
               max="100"
@@ -275,7 +275,7 @@ exports[`numberInput > should focus input and modify value 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -312,7 +312,7 @@ exports[`numberInput > should focus input and modify value 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_2v_"
               inputmode="numeric"
               max="100"
@@ -364,7 +364,7 @@ exports[`numberInput > should focus input and modify value when value > max 1`] 
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -401,7 +401,7 @@ exports[`numberInput > should focus input and modify value when value > max 1`] 
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_34_"
               inputmode="numeric"
               max="5"
@@ -453,7 +453,7 @@ exports[`numberInput > should renders correctly 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -490,7 +490,7 @@ exports[`numberInput > should renders correctly 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_0_"
               inputmode="decimal"
               max="100"
@@ -540,7 +540,7 @@ exports[`numberInput > should renders correctly all sizes > with size large 1`] 
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -577,7 +577,7 @@ exports[`numberInput > should renders correctly all sizes > with size large 1`] 
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_1k_"
               inputmode="decimal"
               max="100"
@@ -627,7 +627,7 @@ exports[`numberInput > should renders correctly all sizes > with size large and 
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -664,7 +664,7 @@ exports[`numberInput > should renders correctly all sizes > with size large and 
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_hasUnit_true__1ce7gb6e styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_hasUnit_true__1ce7gb6f styles_size_large__1ce7gb6g"
               id="_r_23_"
               inputmode="decimal"
               max="100"
@@ -719,7 +719,7 @@ exports[`numberInput > should renders correctly all sizes > with size medium 1`]
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_medium__1ce7gb6l styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_medium__1ce7gb6m styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -756,7 +756,7 @@ exports[`numberInput > should renders correctly all sizes > with size medium 1`]
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_medium__1ce7gb6g"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_medium__1ce7gb6h"
               id="_r_1p_"
               inputmode="decimal"
               max="100"
@@ -806,7 +806,7 @@ exports[`numberInput > should renders correctly all sizes > with size medium and
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_medium__1ce7gb6l styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_medium__1ce7gb6m styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -843,7 +843,7 @@ exports[`numberInput > should renders correctly all sizes > with size medium and
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_hasUnit_true__1ce7gb6e styles_size_medium__1ce7gb6g"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_hasUnit_true__1ce7gb6f styles_size_medium__1ce7gb6h"
               id="_r_29_"
               inputmode="decimal"
               max="100"
@@ -898,7 +898,7 @@ exports[`numberInput > should renders correctly all sizes > with size small 1`] 
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -935,7 +935,7 @@ exports[`numberInput > should renders correctly all sizes > with size small 1`] 
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_small__1ce7gb6h"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_small__1ce7gb6i"
               id="_r_1u_"
               inputmode="decimal"
               max="100"
@@ -985,7 +985,7 @@ exports[`numberInput > should renders correctly all sizes > with size small and 
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1022,7 +1022,7 @@ exports[`numberInput > should renders correctly all sizes > with size small and 
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
               id="_r_2f_"
               inputmode="decimal"
               max="100"
@@ -1077,7 +1077,7 @@ exports[`numberInput > should renders correctly disabled 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_disabled__1ce7gb6o"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_disabled__1ce7gb6p"
           data-controls="true"
           data-disabled="true"
           data-error="false"
@@ -1115,7 +1115,7 @@ exports[`numberInput > should renders correctly disabled 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               disabled=""
               id="_r_5_"
               inputmode="decimal"
@@ -1167,7 +1167,7 @@ exports[`numberInput > should renders correctly max value 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1204,7 +1204,7 @@ exports[`numberInput > should renders correctly max value 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_1f_"
               inputmode="decimal"
               max="100"
@@ -1254,7 +1254,7 @@ exports[`numberInput > should renders correctly min value 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1291,7 +1291,7 @@ exports[`numberInput > should renders correctly min value 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_1a_"
               inputmode="decimal"
               max="100"
@@ -1341,7 +1341,7 @@ exports[`numberInput > should renders correctly with error 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_error__1ce7gb6p"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_error__1ce7gb6q"
           data-controls="true"
           data-disabled="false"
           data-error="true"
@@ -1379,7 +1379,7 @@ exports[`numberInput > should renders correctly with error 1`] = `
           >
             <input
               aria-describedby="_r_q_"
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_p_"
               inputmode="decimal"
               max="9007199254740991"
@@ -1442,7 +1442,7 @@ exports[`numberInput > should renders correctly with label 1`] = `
       </label>
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1479,7 +1479,7 @@ exports[`numberInput > should renders correctly with label 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_d_"
               inputmode="decimal"
               max="9007199254740991"
@@ -1540,7 +1540,7 @@ exports[`numberInput > should renders correctly with label description 1`] = `
       </div>
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1577,7 +1577,7 @@ exports[`numberInput > should renders correctly with label description 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_j_"
               inputmode="decimal"
               max="9007199254740991"
@@ -1627,7 +1627,7 @@ exports[`numberInput > should renders correctly with placeholder 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1664,7 +1664,7 @@ exports[`numberInput > should renders correctly with placeholder 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_15_"
               inputmode="decimal"
               max="9007199254740991"
@@ -1714,7 +1714,7 @@ exports[`numberInput > should renders correctly with success 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_success__1ce7gb6r"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_success__1ce7gb6s"
           data-controls="true"
           data-disabled="false"
           data-error="false"
@@ -1752,7 +1752,7 @@ exports[`numberInput > should renders correctly with success 1`] = `
           >
             <input
               aria-describedby="_r_10_"
-              class="styles__1ce7gb6c styles_size_large__1ce7gb6f"
+              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_large__1ce7gb6g"
               id="_r_v_"
               inputmode="decimal"
               max="9007199254740991"
@@ -1809,7 +1809,7 @@ exports[`numberInput > should renders correctly without controls 1`] = `
     >
       <div>
         <div
-          class="styles__1ce7gb6j styles_size_large__1ce7gb6k styles_state_default__1ce7gb6n"
+          class="styles__1ce7gb6k styles_size_large__1ce7gb6l styles_state_default__1ce7gb6o"
           data-controls="false"
           data-disabled="false"
           data-error="false"
@@ -1822,7 +1822,7 @@ exports[`numberInput > should renders correctly without controls 1`] = `
             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
           >
             <input
-              class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_large__1ce7gb6f styles_undefined_compound_0__1ce7gb6i"
+              class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_large__1ce7gb6g styles_undefined_compound_0__1ce7gb6j"
               id="_r_a_"
               inputmode="decimal"
               max="9007199254740991"

--- a/packages/ui/src/components/NumberInput/styles.css.ts
+++ b/packages/ui/src/components/NumberInput/styles.css.ts
@@ -95,6 +95,7 @@ const unit = recipe({
 
 const numberinput = recipe({
   base: {
+    background: 'none',
     borderWidth: 1,
     borderStyle: 'solid',
     borderColor: 'inherit',
@@ -205,8 +206,11 @@ const container = recipe({
       '&:has(input:out-of-range), &:has(:user-invalid:focus)': {
         boxShadow: theme.shadows.focusDanger,
       },
-      '&:has(input:out-of-range), &:has(:user-invalid)': {
+      '&:has(input:out-of-range:hover), &:has(:user-invalid:hover)': {
         borderColor: theme.colors.danger.borderHover,
+      },
+      '&:has(input:out-of-range), &:has(:user-invalid)': {
+        borderColor: theme.colors.danger.border,
       },
       '&[data-controls="false"]': {
         borderWidth: 0,

--- a/packages/ui/src/components/NumberInput/styles.css.ts
+++ b/packages/ui/src/components/NumberInput/styles.css.ts
@@ -39,7 +39,14 @@ const inputContainer = recipe({
 })
 
 const unit = recipe({
-  base: { alignItems: 'center', display: 'flex', padding: theme.space[1] },
+  base: {
+    alignItems: 'center',
+    display: 'flex',
+    padding: theme.space[1],
+    borderBlockWidth: 1,
+    borderColor: 'inherit',
+    borderBlockStyle: 'solid',
+  },
   defaultVariants: {
     disabled: false,
     readOnly: false,
@@ -79,6 +86,8 @@ const unit = recipe({
     controls: {
       false: {
         borderRadius: `0 ${theme.radii.default} ${theme.radii.default} 0`,
+        borderRightWidth: 1,
+        borderRightStyle: 'solid',
       },
     },
   },
@@ -86,8 +95,9 @@ const unit = recipe({
 
 const numberinput = recipe({
   base: {
-    background: 'none',
-    border: 'none',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'inherit',
     color: theme.colors.neutral.text,
     fontFamily: theme.typography.bodySmall.fontFamily,
     fontSize: theme.typography.bodySmall.fontSize,
@@ -140,11 +150,15 @@ const numberinput = recipe({
         textAlign: 'left',
         borderRadius: `${theme.radii.default} 0 0 ${theme.radii.default}`,
       },
+      true: {
+        borderInline: 'none',
+      },
     },
     hasUnit: {
       true: {
         padding: `${theme.space['1']} 0 ${theme.space['1']} ${theme.space['1']}`,
         textAlign: 'left',
+        borderRightWidth: 0,
       },
     },
     size: {
@@ -179,6 +193,7 @@ const container = recipe({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
+    background: theme.colors.neutral.background,
     selectors: {
       '&:focus-within': {
         borderColor: theme.colors.primary.borderHover,
@@ -187,9 +202,14 @@ const container = recipe({
       '&:hover': {
         border: `1px solid ${theme.colors.primary.borderHover}`,
       },
-      '&:has(input:out-of-range), &:has(input:invalid), &:has(:user-invalid)': {
-        borderColor: theme.colors.danger.borderHover,
+      '&:has(input:out-of-range), &:has(:user-invalid:focus)': {
         boxShadow: theme.shadows.focusDanger,
+      },
+      '&:has(input:out-of-range), &:has(:user-invalid)': {
+        borderColor: theme.colors.danger.borderHover,
+      },
+      '&[data-controls="false"]': {
+        borderWidth: 0,
       },
     },
   },

--- a/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
+++ b/packages/ui/src/components/SelectInput/components/SelectBar/selectBar.css.ts
@@ -79,7 +79,6 @@ export const selectBarBase = style({
   width: '100%',
   selectors: {
     [`.${unitInputStyle.unit} &`]: {
-      background: 'transparent',
       border: 'none !important',
     },
     [`${selectableCardOptionGroupStyle.optionSelectInput} &`]: {

--- a/packages/ui/src/components/Slider/__tests__/__snapshots__/doubleSlider.test.tsx.snap
+++ b/packages/ui/src/components/Slider/__tests__/__snapshots__/doubleSlider.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`double slider > handles correctly onChange double 1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -180,7 +180,7 @@ exports[`double slider > handles correctly onChange double 1`] = `
                   >
                     <input
                       aria-label="input-left"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-left"
                       id="_r_5n_"
                       inputmode="numeric"
@@ -200,7 +200,7 @@ exports[`double slider > handles correctly onChange double 1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -214,7 +214,7 @@ exports[`double slider > handles correctly onChange double 1`] = `
                   >
                     <input
                       aria-label="input-right"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-right"
                       id="_r_5q_"
                       inputmode="numeric"
@@ -304,7 +304,7 @@ exports[`double slider > handles correctly onChange with min and max double 1`] 
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -318,7 +318,7 @@ exports[`double slider > handles correctly onChange with min and max double 1`] 
                   >
                     <input
                       aria-label="input-left"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-left"
                       id="_r_62_"
                       inputmode="numeric"
@@ -338,7 +338,7 @@ exports[`double slider > handles correctly onChange with min and max double 1`] 
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -352,7 +352,7 @@ exports[`double slider > handles correctly onChange with min and max double 1`] 
                   >
                     <input
                       aria-label="input-right"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-right"
                       id="_r_65_"
                       inputmode="numeric"
@@ -667,7 +667,7 @@ exports[`double slider > renders correctly custom value with input  1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -681,7 +681,7 @@ exports[`double slider > renders correctly custom value with input  1`] = `
                   >
                     <input
                       aria-label="input-left"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-left"
                       id="_r_3k_"
                       inputmode="numeric"
@@ -701,7 +701,7 @@ exports[`double slider > renders correctly custom value with input  1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -715,7 +715,7 @@ exports[`double slider > renders correctly custom value with input  1`] = `
                   >
                     <input
                       aria-label="input-right"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-right"
                       id="_r_3n_"
                       inputmode="numeric"
@@ -925,7 +925,7 @@ exports[`double slider > renders correctly direction row double with input 1`] =
           >
             <div>
               <div
-                class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                 data-controls="false"
                 data-disabled="false"
                 data-error="false"
@@ -939,7 +939,7 @@ exports[`double slider > renders correctly direction row double with input 1`] =
                 >
                   <input
                     aria-label="input-left"
-                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                     data-testid="slider-input-left"
                     id="_r_14_"
                     inputmode="numeric"
@@ -1001,7 +1001,7 @@ exports[`double slider > renders correctly direction row double with input 1`] =
           >
             <div>
               <div
-                class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                 data-controls="false"
                 data-disabled="false"
                 data-error="false"
@@ -1015,7 +1015,7 @@ exports[`double slider > renders correctly direction row double with input 1`] =
                 >
                   <input
                     aria-label="input-right"
-                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                     data-testid="slider-input-right"
                     id="_r_1a_"
                     inputmode="numeric"
@@ -1478,7 +1478,7 @@ exports[`double slider > renders correctly double input 1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -1492,7 +1492,7 @@ exports[`double slider > renders correctly double input 1`] = `
                   >
                     <input
                       aria-label="input-left"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-left"
                       id="_r_28_"
                       inputmode="numeric"
@@ -1512,7 +1512,7 @@ exports[`double slider > renders correctly double input 1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="false"
                   data-disabled="false"
                   data-error="false"
@@ -1526,7 +1526,7 @@ exports[`double slider > renders correctly double input 1`] = `
                   >
                     <input
                       aria-label="input-right"
-                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                      class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                       data-testid="slider-input-right"
                       id="_r_2b_"
                       inputmode="numeric"

--- a/packages/ui/src/components/Slider/__tests__/__snapshots__/singleSlider.test.tsx.snap
+++ b/packages/ui/src/components/Slider/__tests__/__snapshots__/singleSlider.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`single slider > handles correctly onChange with min and max 1`] = `
           >
             <div>
               <div
-                class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                 data-controls="false"
                 data-disabled="false"
                 data-error="false"
@@ -34,7 +34,7 @@ exports[`single slider > handles correctly onChange with min and max 1`] = `
                 >
                   <input
                     aria-label="input"
-                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                     data-testid="slider-input"
                     id="_r_4s_"
                     inputmode="numeric"
@@ -557,7 +557,7 @@ exports[`single slider > renders correctly custom value with input  1`] = `
         >
           <div>
             <div
-              class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+              class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
               data-controls="false"
               data-disabled="false"
               data-error="false"
@@ -571,7 +571,7 @@ exports[`single slider > renders correctly custom value with input  1`] = `
               >
                 <input
                   aria-label="input"
-                  class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                  class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                   data-testid="slider-input"
                   id="_r_3o_"
                   inputmode="numeric"
@@ -765,7 +765,7 @@ exports[`single slider > renders correctly direction row with input 1`] = `
         >
           <div>
             <div
-              class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+              class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
               data-controls="false"
               data-disabled="false"
               data-error="false"
@@ -779,7 +779,7 @@ exports[`single slider > renders correctly direction row with input 1`] = `
               >
                 <input
                   aria-label="input"
-                  class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                  class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                   data-testid="slider-input"
                   id="_r_1d_"
                   inputmode="numeric"
@@ -1150,7 +1150,7 @@ exports[`single slider > renders correctly input 1`] = `
           >
             <div>
               <div
-                class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                 data-controls="false"
                 data-disabled="false"
                 data-error="false"
@@ -1164,7 +1164,7 @@ exports[`single slider > renders correctly input 1`] = `
                 >
                   <input
                     aria-label="input"
-                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6h styles_undefined_compound_0__1ce7gb6i"
+                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_size_small__1ce7gb6i styles_undefined_compound_0__1ce7gb6j"
                     data-testid="slider-input"
                     id="_r_2q_"
                     inputmode="numeric"
@@ -1597,7 +1597,7 @@ exports[`single slider > renders correctly suffix string input 1`] = `
           >
             <div>
               <div
-                class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                 data-controls="false"
                 data-disabled="false"
                 data-error="false"
@@ -1611,7 +1611,7 @@ exports[`single slider > renders correctly suffix string input 1`] = `
                 >
                   <input
                     aria-label="input"
-                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                    class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                     data-testid="slider-input"
                     id="_r_q_"
                     inputmode="numeric"

--- a/packages/ui/src/components/UnitInput/styles.css.ts
+++ b/packages/ui/src/components/UnitInput/styles.css.ts
@@ -43,6 +43,7 @@ const number = styleVariants({
 const unitInputNumberWrapperBase = style({
   border: `1px solid ${theme.colors.neutral.border}`,
   borderRadius: theme.radii.default,
+  background: theme.colors.neutral.background,
   selectors: {
     '&:focus-within': {
       borderColor: theme.colors.primary.borderHover,

--- a/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`estimateCost - NumberInput Item > render basic props 1`] = `
                     >
                       <div>
                         <div
-                          class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                          class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                           data-controls="true"
                           data-disabled="false"
                           data-error="false"
@@ -297,7 +297,7 @@ exports[`estimateCost - NumberInput Item > render basic props 1`] = `
                             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                           >
                             <input
-                              class="styles__1ce7gb6c styles_size_small__1ce7gb6h"
+                              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_small__1ce7gb6i"
                               id="_r_d_"
                               inputmode="decimal"
                               max="100"
@@ -651,7 +651,7 @@ exports[`estimateCost - NumberInput Item > render basic with overlay 1`] = `
                     >
                       <div>
                         <div
-                          class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                          class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                           data-controls="true"
                           data-disabled="false"
                           data-error="false"
@@ -688,7 +688,7 @@ exports[`estimateCost - NumberInput Item > render basic with overlay 1`] = `
                             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                           >
                             <input
-                              class="styles__1ce7gb6c styles_size_small__1ce7gb6h"
+                              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_small__1ce7gb6i"
                               id="_r_11_"
                               inputmode="decimal"
                               max="100"
@@ -1042,7 +1042,7 @@ exports[`estimateCost - NumberInput Item > render with getAmountValue 1`] = `
                     >
                       <div>
                         <div
-                          class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                          class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                           data-controls="true"
                           data-disabled="false"
                           data-error="false"
@@ -1079,7 +1079,7 @@ exports[`estimateCost - NumberInput Item > render with getAmountValue 1`] = `
                             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                           >
                             <input
-                              class="styles__1ce7gb6c styles_size_small__1ce7gb6h"
+                              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_small__1ce7gb6i"
                               id="_r_2b_"
                               inputmode="decimal"
                               max="100"
@@ -1438,7 +1438,7 @@ exports[`estimateCost - NumberInput Item > render with values 1`] = `
                     >
                       <div>
                         <div
-                          class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                          class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                           data-controls="true"
                           data-disabled="false"
                           data-error="false"
@@ -1475,7 +1475,7 @@ exports[`estimateCost - NumberInput Item > render with values 1`] = `
                             style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                           >
                             <input
-                              class="styles__1ce7gb6c styles_size_small__1ce7gb6h"
+                              class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_small__1ce7gb6i"
                               id="_r_1m_"
                               inputmode="decimal"
                               max="51"

--- a/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Unit.test.tsx.snap
+++ b/packages/ui/src/compositions/EstimateCost/__tests__/__snapshots__/Unit.test.tsx.snap
@@ -263,7 +263,7 @@ exports[`estimateCost - Unit Item > render basic props 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -276,7 +276,7 @@ exports[`estimateCost - Unit Item > render basic props 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_d_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -616,7 +616,7 @@ exports[`estimateCost - Unit Item > render basic props with monthly price 1`] = 
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -629,7 +629,7 @@ exports[`estimateCost - Unit Item > render basic props with monthly price 1`] = 
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_10_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -969,7 +969,7 @@ exports[`estimateCost - Unit Item > render basic props with overlay 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -982,7 +982,7 @@ exports[`estimateCost - Unit Item > render basic props with overlay 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_3t_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -1327,7 +1327,7 @@ exports[`estimateCost - Unit Item > render basic props with values 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -1340,7 +1340,7 @@ exports[`estimateCost - Unit Item > render basic props with values 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_1k_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -1691,7 +1691,7 @@ exports[`estimateCost - Unit Item > render basic props with values and no iterat
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -1704,7 +1704,7 @@ exports[`estimateCost - Unit Item > render basic props with values and no iterat
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_29_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -2094,7 +2094,7 @@ exports[`estimateCost - Unit Item > render test 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -2107,7 +2107,7 @@ exports[`estimateCost - Unit Item > render test 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_30_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -2187,7 +2187,7 @@ exports[`estimateCost - Unit Item > render test 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -2200,7 +2200,7 @@ exports[`estimateCost - Unit Item > render test 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_39_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -2546,7 +2546,7 @@ exports[`estimateCost - Unit Item > render with 0 amount 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -2559,7 +2559,7 @@ exports[`estimateCost - Unit Item > render with 0 amount 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_4g_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -2899,7 +2899,7 @@ exports[`estimateCost - Unit Item > render with 10 amount 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -2912,7 +2912,7 @@ exports[`estimateCost - Unit Item > render with 10 amount 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_53_"
                                 inputmode="decimal"
                                 max="9007199254740991"
@@ -3258,7 +3258,7 @@ exports[`estimateCost - Unit Item > render with getAmountValue 1`] = `
                       >
                         <div>
                           <div
-                            class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                            class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                             data-controls="false"
                             data-disabled="false"
                             data-error="false"
@@ -3271,7 +3271,7 @@ exports[`estimateCost - Unit Item > render with getAmountValue 1`] = `
                               style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                             >
                               <input
-                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                                class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                                 id="_r_6t_"
                                 inputmode="decimal"
                                 max="9007199254740991"

--- a/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/OrderSummary/__tests__/__snapshots__/index.test.tsx.snap
@@ -4044,7 +4044,7 @@ exports[`orderSummary > should work with numberInputs 1`] = `
             >
               <div>
                 <div
-                  class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                  class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                   data-controls="true"
                   data-disabled="false"
                   data-error="false"
@@ -4081,7 +4081,7 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                     style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                   >
                     <input
-                      class="styles__1ce7gb6c styles_size_small__1ce7gb6h"
+                      class="styles__1ce7gb6c styles_controls_true__1ce7gb6e styles_size_small__1ce7gb6i"
                       id="_r_jl_"
                       inputmode="decimal"
                       max="9007199254740991"
@@ -4156,7 +4156,7 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                 >
                   <div>
                     <div
-                      class="styles__1ce7gb6j styles_size_small__1ce7gb6m styles_state_default__1ce7gb6n"
+                      class="styles__1ce7gb6k styles_size_small__1ce7gb6n styles_state_default__1ce7gb6o"
                       data-controls="false"
                       data-disabled="false"
                       data-error="false"
@@ -4169,7 +4169,7 @@ exports[`orderSummary > should work with numberInputs 1`] = `
                         style="--_3mg8xe0: 1fr auto; --_3mg8xe1: 1fr auto; --_3mg8xe2: 1fr auto; --_3mg8xe3: 1fr auto; --_3mg8xe4: 1fr auto; --_3mg8xe5: 1fr auto;"
                       >
                         <input
-                          class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6e styles_size_small__1ce7gb6h"
+                          class="styles__1ce7gb6c styles_controls_false__1ce7gb6d styles_hasUnit_true__1ce7gb6f styles_size_small__1ce7gb6i"
                           id="_r_jt_"
                           inputmode="decimal"
                           max="9007199254740991"

--- a/packages/ui/src/compositions/OrderSummary/styles.css.ts
+++ b/packages/ui/src/compositions/OrderSummary/styles.css.ts
@@ -57,7 +57,6 @@ const nonScrollableContainer = recipe({
 })
 
 const numberInput = style({
-  backgroundColor: theme.colors.neutral.background,
   maxWidth: '12.5rem',
 })
 


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?
`NumberInput`, `UnitInput`: add background

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| UnitInput  | <img width="314" height="71" alt="Capture d’écran 2026-07-02 à 14 12 41" src="https://github.com/user-attachments/assets/67f73311-7a94-483f-ae45-9dff2040195f" />| <img width="314" height="71" alt="Capture d’écran 2026-07-02 à 14 12 56" src="https://github.com/user-attachments/assets/a583a550-1b98-4904-b813-4602681c2edc" />|
| NumberInput  | <img width="272" height="98" alt="Capture d’écran 2026-07-02 à 14 13 38" src="https://github.com/user-attachments/assets/b82c4e25-72c0-49dc-b1a9-c3e64dce37f8" />| <img width="272" height="98" alt="Capture d’écran 2026-07-02 à 14 13 22" src="https://github.com/user-attachments/assets/f2f01d55-daf5-4fd5-a5a5-0f6ca6eb1b94" />|
