### PR TITLE
fix(Plans): locales, props and cta height

### DIFF
--- a/.changeset/swift-symbols-check.md
+++ b/.changeset/swift-symbols-check.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Plans`: fix cta wrapper size to match recommended button size (40px) and correctly pass custom locales to header

--- a/.changeset/two-friends-arrive.md
+++ b/.changeset/two-friends-arrive.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/form": patch
+---
+
+`PlansField`: all props from `Plans` should be usable

--- a/packages/form/src/compositions/PlansField/index.tsx
+++ b/packages/form/src/compositions/PlansField/index.tsx
@@ -28,6 +28,7 @@ export const PlansField = <
 
   return (
     <Plans
+      {...props}
       fieldName={field.name}
       onChange={value => {
         field.onChange(value)
@@ -36,7 +37,6 @@ export const PlansField = <
         }
       }}
       value={field.value as string | undefined}
-      {...props}
     />
   )
 }

--- a/packages/form/src/compositions/PlansField/index.tsx
+++ b/packages/form/src/compositions/PlansField/index.tsx
@@ -7,21 +7,16 @@ import type { BaseFieldProps } from '../../types'
 type PlanFieldsProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = Pick<ComponentProps<typeof Plans>, 'features' | 'plans' | 'hideLabels' | 'onChange' | 'highlight'> &
-  Pick<BaseFieldProps<TFieldValues, TFieldName>, 'name' | 'control' | 'required'>
-
+> = BaseFieldProps<TFieldValues, TFieldName> & Omit<ComponentProps<typeof Plans>, 'value' | 'fieldName'>
 export const PlansField = <
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
   name,
   control,
-  features,
-  plans,
-  hideLabels,
-  highlight,
   onChange,
   required,
+  ...props
 }: PlanFieldsProps<TFieldValues, TFieldName>) => {
   const { field } = useController({
     control,
@@ -33,18 +28,15 @@ export const PlansField = <
 
   return (
     <Plans
-      features={features}
       fieldName={field.name}
-      hideLabels={hideLabels}
-      highlight={highlight}
       onChange={value => {
         field.onChange(value)
         if (onChange) {
           onChange(value)
         }
       }}
-      plans={plans}
       value={field.value as string | undefined}
+      {...props}
     />
   )
 }

--- a/packages/ui/src/compositions/Plans/PlanHeader.tsx
+++ b/packages/ui/src/compositions/Plans/PlanHeader.tsx
@@ -13,7 +13,7 @@ type PlanHeaderProps = {
   currentPlanValue?: string
   plan: PlanType<string>
   disabled: boolean
-  locales?: Record<keyof typeof PlansLocales, string>
+  locales: Record<keyof typeof PlansLocales, string>
 }
 
 export const PlanHeader = ({
@@ -23,7 +23,7 @@ export const PlanHeader = ({
   currentPlanValue,
   plan,
   disabled,
-  locales = PlansLocales,
+  locales,
 }: PlanHeaderProps) => (
   <>
     {fieldName && onChange && !disabled ? (

--- a/packages/ui/src/compositions/Plans/index.tsx
+++ b/packages/ui/src/compositions/Plans/index.tsx
@@ -109,6 +109,7 @@ export const Plans = <T extends string>({
                   onChange={onChange}
                   plan={plan}
                   setFocusedPlan={setFocusedPlan}
+                  locales={locales}
                 />
               </td>
             )

--- a/packages/ui/src/compositions/Plans/styles.css.ts
+++ b/packages/ui/src/compositions/Plans/styles.css.ts
@@ -153,8 +153,8 @@ const fullSizeSeparator = style({ width: '100%' })
 const currentWrapper = style({
   alignItems: 'center',
   display: 'flex',
-  /* Same as button */
-  height: theme.sizing[600],
+  /* Same as medium button, the recommended size for the cta button in the component */
+  height: theme.sizing[500],
 })
 
 export const plansStyle = {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:
- `Plans`: fix cta wrapper size to match recommended button size (40px) and correctly pass custom locales to header
- `PlansField`: all props from `Plans` should be usable