### PR TITLE
chore: update pnpm 11.11

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,9 +16,6 @@
     "**/__fixtures__/**",
     "**/examples/**"
   ],
-  "toolSettings": {
-    "nodeMaxMemory": 2900
-  },
   "prConcurrentLimit": 5,
   "reviewers": ["team:console"],
   "reviewersSampleSize": 2,

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "node": ">=20.x",
     "pnpm": ">=10.x"
   },
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.11.0",
   "manypkg": {
     "ignoredRules": [
       "INTERNAL_MISMATCH"


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

Attempt to fix the Renovate kernel-out-of-memory error following https://github.com/renovatebot/renovate/discussions/40942#discussioncomment-17634955

#### What is expected?

No functional change, hopefully Renovate will work better

#### The following changes were made:

- update pnpm@11.11
- remove the renovate config `toolSettings.nodeMaxMemory` because apparently it does not affect pnpm

