### PR TITLE
fix: remove `font-size: 16px` from the CSS normalize for accessibility

### DIFF
--- a/.changeset/thin-beds-pick.md
+++ b/.changeset/thin-beds-pick.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/themes": patch
+"@ultraviolet/ui": patch
+---
+
+Remove `font-size: 16px` from the CSS normalize for accessibility

--- a/packages/themes/src/vanilla/globalStyle.css
+++ b/packages/themes/src/vanilla/globalStyle.css
@@ -120,7 +120,6 @@ summary {
 }
 
 html {
-  font-size: 16px;
   line-height: 1.5;
   -webkit-tap-highlight-color: transparent;
   margin: 0;

--- a/packages/ui/src/utils/normalize.ts
+++ b/packages/ui/src/utils/normalize.ts
@@ -7,7 +7,6 @@ const normalize = () => `
   ${modernNormalize}
 
   html {
-    font-size: 16px;
     line-height: 1.5;
     -webkit-tap-highlight-color: transparent;
     margin: 0;


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

A font-size in pixel causes an accessibility issue, we want to fix that. 16px is the default value anyway

#### What is expected?

No visual change

#### The following changes were made:

remove font-size