### PR TITLE
fix(TextArea): fix automatic resize when rows="auto"

### DIFF
--- a/.changeset/lovely-stamps-battle.md
+++ b/.changeset/lovely-stamps-battle.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`TextArea`: fix automatic resize when rows="auto"

--- a/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TextAreaField/__tests__/__snapshots__/index.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`textAreaField > should render correctly 1`] = `
             id="_r_0_"
             name="test"
             rows="3"
-            style="--uv_hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+            style="--uv_hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
           />
           <div
             class="uv_hlf4vn2 uv_toi52u0 uv_toi52ud uv_toi52u2j uv_toi52u3p"
@@ -75,7 +75,7 @@ exports[`textAreaField > should render correctly generated 1`] = `
             id="_r_9_"
             name="test"
             rows="3"
-            style="--uv_hlf4vn0: calc(0.5rem + 1.5rem + 0px + 0px + 0.25rem); resize: vertical; height: auto; min-height: calc(1.5rem + nanpx);"
+            style="--uv_hlf4vn0: calc(0.5rem + 1.5rem + 0px + 0px + 0.25rem); min-block-size: calc(2px + 48px + 1.5rem);"
           >
             This is an example
           </textarea>
@@ -142,7 +142,7 @@ exports[`textAreaField > should submit with onSubmitEnter prop 1`] = `
             id="_r_4_"
             name="test"
             rows="3"
-            style="--uv_hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); resize: vertical; height: auto; min-height: calc(1.5rem + nanpx);"
+            style="--uv_hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
           >
             This is an example
           </textarea>

--- a/packages/form/src/components/TextAreaField/__tests__/index.test.tsx
+++ b/packages/form/src/components/TextAreaField/__tests__/index.test.tsx
@@ -1,11 +1,21 @@
 import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { mockFormErrors, renderWithForm } from '@utils/test'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import { TextAreaField } from '..'
 import { Submit } from '../..'
 
 describe('textAreaField', () => {
+  let spyGetComputedStyle: Mock
+
+  beforeEach(() => {
+    const mockTextareaStyle = { lineHeight: '16px' } as CSSStyleDeclaration
+    spyGetComputedStyle = vi.spyOn(window, 'getComputedStyle').mockReturnValue(mockTextareaStyle)
+  })
+  afterEach(() => {
+    spyGetComputedStyle.mockRestore()
+  })
+
   it('should render correctly', () => {
     const { asFragment } = renderWithForm(<TextAreaField label="Test" name="test" />)
     expect(asFragment()).toMatchSnapshot()

--- a/packages/ui/src/components/TextArea/__stories__/AutomaticRows.stories.tsx
+++ b/packages/ui/src/components/TextArea/__stories__/AutomaticRows.stories.tsx
@@ -52,7 +52,7 @@ AutomaticRows.parameters = {
   docs: {
     description: {
       story:
-        'You can set a number of rows to display in the input, which will change its height. You can set rows="auto" and the textarea will automatically adjust its height based on the content. Use prop `maxRows` so that textArea automatically adjusts its height based on the content until it reaches maxRows (upper bound). When both `maxRows` and `row` are defined, they will respectively be used as an upper bound and a lower bound in the number of rows to display.',
+        'You can set a number of rows to display in the textarea, which will set its initial height. With `rows="auto"`, the textarea will dynamically adjust its height based on the content and update it when typing.\n\nThe textarea is always resizable using the native handle. A maximum height can be set using the prop `maxRows`, and the minimum height is given by the prop `rows` (which defaults to 2 when `rows="auto"`)',
     },
   },
 }

--- a/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TextArea/__tests__/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`textArea > renders correctly with size large 1`] = `
           class="styles__hlf4vn3 styles_size_large__hlf4vn8"
           id="_r_2p_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -57,7 +57,7 @@ exports[`textArea > renders correctly with size medium 1`] = `
           class="styles__hlf4vn3 styles_size_medium__hlf4vn7"
           id="_r_2l_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -92,7 +92,7 @@ exports[`textArea > renders correctly with size small 1`] = `
           class="styles__hlf4vn3 styles_size_small__hlf4vn6"
           id="_r_2h_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -128,7 +128,7 @@ exports[`textArea > should render correctly when input  has a error sentiment 1`
           class="styles__hlf4vn3 styles_error_true__hlf4vn4 styles_size_large__hlf4vn8"
           id="_r_14_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -192,7 +192,7 @@ exports[`textArea > should render correctly when input has a success sentiment 1
           class="styles__hlf4vn3 styles_success_true__hlf4vn5 styles_size_large__hlf4vn8"
           id="_r_v_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -256,7 +256,7 @@ exports[`textArea > should render correctly when input is disabled 1`] = `
           disabled=""
           id="_r_d_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -292,7 +292,7 @@ exports[`textArea > should render correctly when input is readOnly 1`] = `
           id="_r_h_"
           readonly=""
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -336,7 +336,7 @@ exports[`textArea > should render correctly when it is required 1`] = `
           class="styles__hlf4vn3 styles_size_large__hlf4vn8"
           id="_r_l_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -371,7 +371,7 @@ exports[`textArea > should render correctly with basic props 1`] = `
           class="styles__hlf4vn3 styles_size_large__hlf4vn8"
           id="_r_0_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -407,7 +407,7 @@ exports[`textArea > should render correctly with maxlength 1`] = `
           id="_r_q_"
           maxlength="3"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 0px + 0px + 0px); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -454,7 +454,7 @@ exports[`textArea > should render with AutoExpandMax 1`] = `
           class="styles__hlf4vn3 styles_error_true__hlf4vn4 styles_size_large__hlf4vn8"
           id="_r_1e_"
           rows="3"
-          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem); max-block-size: calc(2px + 48px + 1.5rem); min-block-size: calc(2px + 48px + 1.5rem);"
         >
           test
         </textarea>
@@ -518,7 +518,7 @@ exports[`textArea > should render with AutoExpandMax and rows 1`] = `
           class="styles__hlf4vn3 styles_error_true__hlf4vn4 styles_size_large__hlf4vn8"
           id="_r_1j_"
           rows="2"
-          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem); max-block-size: calc(2px + 48px + 1.5rem); min-block-size: calc(2px + 32px + 1.5rem);"
         >
           test
         </textarea>
@@ -581,8 +581,8 @@ exports[`textArea > should render with auto rows 1`] = `
           aria-invalid="true"
           class="styles__hlf4vn3 styles_error_true__hlf4vn4 styles_size_large__hlf4vn8"
           id="_r_19_"
-          rows="1"
-          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem);"
+          rows="2"
+          style="--hlf4vn0: calc(0.5rem + 0px + 1rem + 0px + 0.25rem); height: calc(2px); min-block-size: calc(2px + 32px + 1.5rem);"
         >
           test
         </textarea>

--- a/packages/ui/src/components/TextArea/__tests__/index.test.tsx
+++ b/packages/ui/src/components/TextArea/__tests__/index.test.tsx
@@ -1,10 +1,20 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import { TextArea } from '..'
 
 describe('textArea', () => {
+  let spyGetComputedStyle: Mock
+
+  beforeEach(() => {
+    const mockTextareaStyle = { lineHeight: '16px' } as CSSStyleDeclaration
+    spyGetComputedStyle = vi.spyOn(window, 'getComputedStyle').mockReturnValue(mockTextareaStyle)
+  })
+  afterEach(() => {
+    spyGetComputedStyle.mockRestore()
+  })
+
   it('should render correctly with basic props', () => {
     const { asFragment } = renderWithTheme(<TextArea label="Test" onChange={() => {}} value="test" />)
 

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -58,7 +58,7 @@ type TextAreaProps = {
    */
   helper?: ReactNode
   /**
-   * Number of rows to display. If 'auto', the textarea will grow with the content and won't be resizable
+   * Number of rows to display. If 'auto', the textarea will grow with the content
    */
   rows?: number | 'auto'
   /**
@@ -77,6 +77,9 @@ type TextAreaProps = {
   style?: CSSProperties
 } & LabelProps &
   Pick<TextareaHTMLAttributes<HTMLTextAreaElement>, 'onFocus' | 'onBlur' | 'onKeyDown' | 'aria-describedby'>
+
+const BORDERS_WIDTH = '2px'
+const AUTO_ROWS = 2
 
 /**
  * This component offers an extended textarea HTML
@@ -124,44 +127,46 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const textAreaRef = useRef<HTMLTextAreaElement>(null)
     useImperativeHandle(ref, () => textAreaRef.current!)
 
+    // native automatic resize
+    useEffect(() => {
+      if (textAreaRef.current && window.CSS && CSS.supports('field-sizing', 'content')) {
+        textAreaRef.current.style.fieldSizing = rows === 'auto' ? 'content' : 'fixed'
+      }
+    }, [rows])
+
+    // fallback for older browsers
     useEffect(() => {
       const textArea = textAreaRef.current
-      const padding = theme.space['1.5']
+      if (!textArea || rows !== 'auto') {
+        return
+      }
+
+      const userResized = textArea.style.height.match(/^\d+px$/)
+      const hasNativeAutoResize = textArea.style.fieldSizing === 'content'
+      if (userResized || hasNativeAutoResize) {
+        return
+      }
+
+      textArea.style.height = `calc(${textArea.scrollHeight}px + ${BORDERS_WIDTH})`
+    }, [value, rows])
+
+    // Set min and max heights
+    useEffect(() => {
+      const textArea = textAreaRef.current
       if (!textArea) {
         return
       }
 
-      const updateHeight = () => {
-        if (textArea && rows === 'auto' && !maxRows) {
-          textArea.style.height = 'auto'
-          textArea.style.resize = 'none'
-          textArea.style.height = `${textArea.scrollHeight + 2}px`
-        } else {
-          textArea.style.resize = 'vertical'
-        }
+      const padding = theme.space['1.5']
+      const lineHeight = Number.parseFloat(getComputedStyle(textArea).lineHeight)
 
-        if (textArea && (maxRows || typeof rows === 'number')) {
-          const lineHeight = Number.parseFloat(getComputedStyle(textArea).lineHeight)
-
-          if (maxRows) {
-            textArea.style.height = 'auto'
-            const maxHeight = maxRows * lineHeight
-
-            textArea.style.height = `${textArea.scrollHeight + 2}px`
-            textArea.style.maxHeight = `calc(${maxHeight}px + 2*${padding})`
-          } else if (typeof rows === 'number') {
-            textArea.style.height = 'auto'
-          }
-
-          if (typeof rows === 'number') {
-            const minHeight = rows * lineHeight
-            textArea.style.minHeight = `calc(${minHeight}px + 2*${padding})`
-          }
-        }
+      if (maxRows) {
+        textArea.style.maxBlockSize = `calc(${maxRows * lineHeight}px + 2*${padding} + ${BORDERS_WIDTH})`
       }
 
-      requestAnimationFrame(updateHeight)
-    }, [value, rows, theme, maxRows, textAreaRef.current?.value])
+      const minRows = rows === 'auto' ? AUTO_ROWS : rows
+      textArea.style.minBlockSize = `calc(${minRows * lineHeight}px + 2*${padding} + ${BORDERS_WIDTH})`
+    }, [maxRows, rows, theme.space])
 
     const nonDefaultState = success || error
 
@@ -206,7 +211,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               placeholder={placeholder}
               readOnly={!!readOnly}
               ref={textAreaRef}
-              rows={rows === 'auto' ? 1 : rows}
+              rows={rows === 'auto' ? AUTO_ROWS : rows}
               style={{
                 ...assignInlineVars({
                   [paddingRightVar]: `calc(${defaultPadding} + ${

--- a/packages/ui/src/components/TextArea/styles.css.ts
+++ b/packages/ui/src/components/TextArea/styles.css.ts
@@ -70,15 +70,12 @@ const textArea = recipe({
     size: {
       small: {
         fontSize: theme.typography.bodySmall.fontSize,
-        minHeight: theme.sizing[700],
       },
       medium: {
         fontSize: theme.typography.bodySmall.fontSize,
-        minHeight: theme.sizing[800],
       },
       large: {
         fontSize: theme.typography.body.fontSize,
-        minHeight: theme.sizing[900],
       },
     },
   },

--- a/utils/test/src/vitest/setup.ts
+++ b/utils/test/src/vitest/setup.ts
@@ -42,6 +42,7 @@ export const setup = () => {
 
     window.ResizeObserver = vi.fn().mockImplementation(MockResize)
     window.matchMedia = vi.fn().mockImplementation(MockMatchMedia)
+    window.CSS.supports = vi.fn().mockReturnValue(false)
 
     if (!globalThis.navigator.clipboard) {
       // @ts-expect-error mock clipboard API


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

Textarea can be resized and keep its size and scroll position when typing in it.

#### The following changes were made:

- use the new CSS property field-sizing in supported browsers
- use a fallback with a less good behavior on older browsers (the textarea won't shrink back because it causes scroll issues)

#### To check the fallback behavior
- open Firefox
- go to about:config
- search for "field-sizing"
- disable `layout.css.field-sizing.enabled` using the arrow on the right