### PR TITLE
fix(devEngines): warn on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "packageManager": {
       "name": "pnpm",
       "version": "11.11.0",
-      "onFail": "download"
+      "onFail": "warn"
     },
     "runtime": {
       "name": "node",


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?

Cannot release using changeset action which use npm, and cannot bypass this setting with NPM_CONFIG or npmrc for now.

#### The following changes were made:

From error to warn
