### PR TITLE
docs: fix Storybook docgen

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -38,16 +38,6 @@ const main = defineMain({
     '../utils/stories/src/**/*.mdx',
     '../utils/stories/src/**/*.stories.tsx',
   ],
-
-  typescript: {
-    reactDocgen: 'react-docgen-typescript',
-    reactDocgenTypescriptOptions: {
-      compilerOptions: {
-        esModuleInterop: true,
-      },
-      shouldRemoveUndefinedFromOptional: true,
-    },
-  },
 })
 
 export default main

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -117,6 +117,7 @@ const parameters: Preview['parameters'] = {
   },
   controls: {
     exclude: 'data-flip-id',
+    expanded: true,
   },
   viewMode: 'docs',
   viewport: {


### PR DESCRIPTION
## Summary

## Type

- Documentation

### Summarize concisely:

#### What is expected?

Storybook playgrounds show relevant documentation for the components properties

**Still broken**:
- props defined with `XOR` (Button, Link, Breadcrumb...). Only those part are broken, the others props are fine
- props using a `ReceipeVariants` type from Vanilla Extract (Button, Badge, Alert...)
- other complex props types

#### The following changes were made:

- remove [react-docgen-typescript](https://github.com/styleguidist/react-docgen-typescript) which has no commit since more than 1 year and doesn't support typescript 7
- use the default [react-docgen](https://github.com/reactjs/react-docgen) which seems more maintained and seems to work fine

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| GlobalAlert  | <img width="1002" height="688" alt="image" src="https://github.com/user-attachments/assets/12d9247b-f0f9-4aaf-ac67-df96b7fbbb4e" /> | <img width="974" height="848" alt="image" src="https://github.com/user-attachments/assets/f898898d-c85a-46e5-8a6e-8bb50338981f" /> |
