### PR TITLE
feat(Filters): add a DateRange filter type using the DateInput component

### DIFF
--- a/.changeset/clever-pots-do.md
+++ b/.changeset/clever-pots-do.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+`Filters`: add a DateRange filter type using the DateInput component

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "storybook": "10.4.6",
     "storybook-addon-tag-badges": "3.1.0",
     "svgo": "4.0.1",
-    "timekeeper": "2.3.1",
     "turbo": "2.10.4",
     "typescript": "7.0.1-rc",
     "vite": "catalog:",

--- a/packages/ui/src/components/DateInput/__tests__/index.test.tsx
+++ b/packages/ui/src/components/DateInput/__tests__/index.test.tsx
@@ -2,7 +2,6 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
 import { es, fr, ru } from 'date-fns/locale'
-import tk from 'timekeeper'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { DateInput } from '..'
 
@@ -11,11 +10,11 @@ const YEAR = /1995/iu
 
 describe('dateInput', () => {
   beforeAll(() => {
-    tk.freeze(new Date(1_609_503_120_000))
+    vi.useFakeTimers({ now: new Date(1_609_503_120_000), toFake: ['Date'] })
   })
 
   afterAll(() => {
-    tk.reset()
+    vi.useRealTimers()
   })
 
   it('renders correctly with default props', () => {

--- a/packages/ui/src/compositions/Filters/__stories__/Context.stories.tsx
+++ b/packages/ui/src/compositions/Filters/__stories__/Context.stories.tsx
@@ -35,7 +35,6 @@ export const Context: StoryFn = () => {
       <Stack direction="row" gap="4">
         <div>
           <strong>Submitted values</strong>
-          <p>Updated when changing a filter in the main row or when submitting in the Drawer.</p>
           <Snippet initiallyExpanded>{JSON.stringify(filterValues, null, 2)}</Snippet>
         </div>
       </Stack>

--- a/packages/ui/src/compositions/Filters/__stories__/Dates.stories.tsx
+++ b/packages/ui/src/compositions/Filters/__stories__/Dates.stories.tsx
@@ -52,6 +52,7 @@ const config: FilterConfig<FilterValues>[] = [
     type: 'dateRange',
     name: 'dates',
     label: 'Date Range',
+    placeholder: 'DD/MM/YYYY - DD/MM/YYYY',
   },
 ]
 

--- a/packages/ui/src/compositions/Filters/__stories__/Dates.stories.tsx
+++ b/packages/ui/src/compositions/Filters/__stories__/Dates.stories.tsx
@@ -1,18 +1,23 @@
 import type { StoryFn } from '@storybook/react-vite'
+import { useState } from 'react'
+import { Stack, Snippet } from '../../../components'
 import type { FiltersProps } from '../Filters'
 import { Filters } from '../Filters'
 import type { FilterConfig } from '../types'
 
 type FilterValues = {
-  dates: {
+  datetimes: {
     preset: string
     startAt: Date | null
     endAt: Date | null
   }
-  name: string
+  dates: {
+    startAt: Date | null
+    endAt: Date | null
+  }
 }
 
-const dateFormat = new Intl.DateTimeFormat('en-US', {
+const datetimeFormat = new Intl.DateTimeFormat('en-US', {
   timeStyle: 'medium',
   dateStyle: 'short',
 })
@@ -20,10 +25,9 @@ const dateFormat = new Intl.DateTimeFormat('en-US', {
 const config: FilterConfig<FilterValues>[] = [
   {
     type: 'datetimeRange',
-    name: 'dates',
-    label: 'Dates',
-    dateFormatter: date => dateFormat.format(date),
-    dateInputLocale: 'fr',
+    name: 'datetimes',
+    label: 'DateTime Range',
+    dateFormatter: date => datetimeFormat.format(date),
     maxDate: new Date(),
     minDate: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
     relativePresets: [
@@ -45,15 +49,31 @@ const config: FilterConfig<FilterValues>[] = [
     },
   },
   {
-    type: 'search',
-    name: 'name',
-    hideInDrawer: true,
-    label: 'Name',
-    placeholder: 'Type to search...',
+    type: 'dateRange',
+    name: 'dates',
+    label: 'Date Range',
   },
 ]
 
-export const Dates: StoryFn<FiltersProps<FilterValues>> = props => <Filters {...props} />
+export const Dates: StoryFn<FiltersProps<FilterValues>> = props => {
+  const [submittedValues, setSubmittedValues] = useState({ ...props.defaultValues, ...props.initialValues })
+
+  return (
+    <Stack gap="4">
+      <Filters onSubmit={setSubmittedValues} {...props} />
+      <Stack direction="row" wrap gap="4">
+        <div>
+          <strong>Submitted values</strong>
+          <Snippet initiallyExpanded>{JSON.stringify(submittedValues, null, 2)}</Snippet>
+        </div>
+      </Stack>
+    </Stack>
+  )
+}
+
+const today = new Date()
+today.setHours(0, 0, 0, 0)
+const oneWeekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
 
 Dates.args = {
   config,
@@ -61,12 +81,21 @@ Dates.args = {
     templateColumns: 'repeat(auto-fit, minmax(min(32ch, 100%), 1fr))',
   },
   defaultValues: {
-    dates: {
+    datetimes: {
       preset: 'last_30days',
       startAt: null,
       endAt: null,
     },
-    name: 'John Doe',
+    dates: {
+      startAt: null,
+      endAt: null,
+    },
+  },
+  initialValues: {
+    dates: {
+      startAt: oneWeekAgo,
+      endAt: today,
+    },
   },
   labels: {
     clearAll: 'Clear all',

--- a/packages/ui/src/compositions/Filters/__stories__/demo.config.ts
+++ b/packages/ui/src/compositions/Filters/__stories__/demo.config.ts
@@ -68,6 +68,7 @@ export const demoFilters: FilterConfig<FilterValues>[] = [
     type: 'dateRange',
     name: 'dates',
     label: 'Dates',
+    placeholder: 'DD/MM/YYYY - DD/MM/YYYY',
   },
   {
     type: 'slider',

--- a/packages/ui/src/compositions/Filters/__stories__/demo.config.ts
+++ b/packages/ui/src/compositions/Filters/__stories__/demo.config.ts
@@ -7,6 +7,10 @@ export type FilterValues = {
   price: [number, number]
   ram: [number, number]
   gpu: string
+  dates: {
+    startAt: Date | null
+    endAt: Date | null
+  }
 }
 
 export const demoDefaultValues: FilterValues = {
@@ -16,6 +20,10 @@ export const demoDefaultValues: FilterValues = {
   price: [0, 1000],
   ram: [0, 64],
   gpu: '',
+  dates: {
+    startAt: null,
+    endAt: null,
+  },
 }
 
 export const demoFilters: FilterConfig<FilterValues>[] = [
@@ -55,6 +63,11 @@ export const demoFilters: FilterConfig<FilterValues>[] = [
         searchable: true,
       },
     ],
+  },
+  {
+    type: 'dateRange',
+    name: 'dates',
+    label: 'Dates',
   },
   {
     type: 'slider',

--- a/packages/ui/src/compositions/Filters/__tests__/dateRange.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/dateRange.test.tsx
@@ -1,0 +1,119 @@
+import { screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { renderWithTheme } from '@utils/test'
+import tk from 'timekeeper'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { Filters } from '..'
+import type { FilterConfig } from '../types'
+
+type FilterValues = {
+  dates: {
+    startAt: Date | null
+    endAt: Date | null
+  }
+}
+
+const defaultValues: FilterValues = {
+  dates: {
+    startAt: null,
+    endAt: null,
+  },
+}
+
+const config: FilterConfig<FilterValues>[] = [
+  {
+    type: 'dateRange',
+    name: 'dates',
+    label: 'Date Range',
+  },
+]
+
+const labels = {
+  clear: 'Clear',
+  clearAll: 'Clear all',
+  seeAll: 'All filters',
+  drawerHeader: 'Filters',
+  submit: 'See results',
+}
+
+describe('dateRange filter', () => {
+  beforeAll(() => {
+    // Freeze time to January 1, 2021 so the calendar always shows January 2021
+    tk.freeze(new Date(1_609_503_120_000))
+  })
+
+  afterAll(() => {
+    tk.reset()
+  })
+
+  it('should display the initialValue in the input', () => {
+    renderWithTheme(
+      <Filters
+        config={config}
+        defaultValues={defaultValues}
+        initialValues={{
+          dates: {
+            startAt: new Date(2021, 0, 15),
+            endAt: new Date(2021, 0, 27),
+          },
+        }}
+        labels={labels}
+      />,
+    )
+
+    expect(screen.getByRole('textbox', { name: 'Date Range' })).toHaveValue('15/01/2021 - 27/01/2021')
+  })
+
+  it('should call submit with the correct dates when changing the range', async () => {
+    const onSubmit = vi.fn()
+
+    renderWithTheme(<Filters config={config} defaultValues={defaultValues} labels={labels} onSubmit={onSubmit} />)
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'Date Range' }))
+
+    await userEvent.click(screen.getByText('15'))
+    await userEvent.click(screen.getByText('27'))
+
+    expect(onSubmit).toHaveBeenLastCalledWith({
+      dates: {
+        startAt: new Date(2021, 0, 15),
+        endAt: new Date(2021, 0, 27),
+      },
+    })
+  })
+
+  it('should submit with only a start date and an empty end date', async () => {
+    const onSubmit = vi.fn()
+
+    renderWithTheme(<Filters config={config} defaultValues={defaultValues} labels={labels} onSubmit={onSubmit} />)
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'Date Range' }))
+
+    await userEvent.click(screen.getByText('15'))
+
+    expect(onSubmit).toHaveBeenCalledExactlyOnceWith({
+      dates: {
+        startAt: new Date(2021, 0, 15),
+        endAt: null,
+      },
+    })
+  })
+
+  it('should allow selecting the same date as start and end date', async () => {
+    const onSubmit = vi.fn()
+
+    renderWithTheme(<Filters config={config} defaultValues={defaultValues} labels={labels} onSubmit={onSubmit} />)
+
+    await userEvent.click(screen.getByRole('textbox', { name: 'Date Range' }))
+
+    await userEvent.click(screen.getByText('15'))
+    await userEvent.click(screen.getByText('15'))
+
+    expect(onSubmit).toHaveBeenLastCalledWith({
+      dates: {
+        startAt: new Date(2021, 0, 15),
+        endAt: new Date(2021, 0, 15),
+      },
+    })
+  })
+})

--- a/packages/ui/src/compositions/Filters/__tests__/dateRange.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/dateRange.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
-import tk from 'timekeeper'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { Filters } from '..'
 import type { FilterConfig } from '../types'
@@ -39,11 +38,11 @@ const labels = {
 describe('dateRange filter', () => {
   beforeAll(() => {
     // Freeze time to January 1, 2021 so the calendar always shows January 2021
-    tk.freeze(new Date(1_609_503_120_000))
+    vi.useFakeTimers({ now: new Date(1_609_503_120_000), toFake: ['Date'] })
   })
 
   afterAll(() => {
-    tk.reset()
+    vi.useRealTimers()
   })
 
   it('should display the initialValue in the input', () => {

--- a/packages/ui/src/compositions/Filters/filterTypes/FilterDateRange.tsx
+++ b/packages/ui/src/compositions/Filters/filterTypes/FilterDateRange.tsx
@@ -1,0 +1,34 @@
+import { DateInput } from '../../../components'
+import type { FilterComponentProps, FilterConfigItemDateRange } from '../types'
+
+export type DateRangeInputValue = {
+  startAt: Date | null
+  endAt: Date | null
+}
+
+type FilterDateRangeProps = FilterComponentProps<DateRangeInputValue, FilterConfigItemDateRange>
+
+export const FilterDateRange = ({ config, hideLabel, onChange, value, size }: FilterDateRangeProps) => (
+  <DateInput
+    selectsRange
+    minDate={config.minDate}
+    maxDate={config.maxDate}
+    aria-label={hideLabel ? config.label : undefined}
+    label={hideLabel ? undefined : config.label}
+    size={size}
+    name={config.name}
+    format={config.format}
+    placeholder={config.placeholder}
+    startDate={value?.startAt}
+    endDate={value?.endAt}
+    locale={config.locale}
+    excludeDates={config.excludeDates}
+    labelDescription={config.labelDescription}
+    onChange={dates => {
+      onChange({
+        startAt: dates[0],
+        endAt: dates[1],
+      })
+    }}
+  />
+)

--- a/packages/ui/src/compositions/Filters/index.ts
+++ b/packages/ui/src/compositions/Filters/index.ts
@@ -9,6 +9,8 @@ export type {
   FilterConfigItemBase,
   FilterConfigItem,
   FilterConfigItemDatetimeRange,
+  FilterConfigItemDateRange,
+  FilterConfigItemSearch,
   FilterConfigItemMultiSelect,
   FilterConfigItemNumber,
   FilterConfigItemSelect,

--- a/packages/ui/src/compositions/Filters/parts/AbstractFilter.tsx
+++ b/packages/ui/src/compositions/Filters/parts/AbstractFilter.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react'
+import { FilterDateRange } from '../filterTypes/FilterDateRange'
 import { FilterDatetimeRange } from '../filterTypes/FilterDatetimeRange/FilterDatetimeRange'
 import { FilterMultiSelect } from '../filterTypes/FilterMultiSelect'
 import { FilterNumber } from '../filterTypes/FilterNumber'
@@ -19,6 +20,7 @@ const defaultFieldComponents = {
   multiselect: FilterMultiSelect,
   slider: FilterSlider,
   datetimeRange: FilterDatetimeRange,
+  dateRange: FilterDateRange,
   number: FilterNumber,
 }
 

--- a/packages/ui/src/compositions/Filters/types.ts
+++ b/packages/ui/src/compositions/Filters/types.ts
@@ -68,6 +68,13 @@ export type FilterConfigItemDatetimeRange = FilterConfigItemBase & {
   relativePresets: [RelativePreset, ...RelativePreset[]]
 }
 
+export type FilterConfigItemDateRange = FilterConfigItemBase & {
+  type: 'dateRange'
+} & Pick<
+    ComponentProps<typeof DateInput>,
+    'minDate' | 'maxDate' | 'format' | 'locale' | 'excludeDates' | 'labelDescription'
+  >
+
 export type FilterConfigItemNumber = FilterConfigItemBase & {
   type: 'number'
   min?: number
@@ -84,6 +91,7 @@ export type FilterConfigItem<V extends AnyObject = AnyObject> =
   | FilterConfigItemMultiSelect<V>
   | FilterConfigItemSlider
   | FilterConfigItemDatetimeRange
+  | FilterConfigItemDateRange
   | FilterConfigItemCustom
 
 export type FilterConfigGroup<V extends AnyObject = AnyObject> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,9 +391,6 @@ importers:
       svgo:
         specifier: 4.0.1
         version: 4.0.1
-      timekeeper:
-        specifier: 2.3.1
-        version: 2.3.1
       turbo:
         specifier: 2.10.4
         version: 2.10.4
@@ -5739,8 +5736,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.8.1:
-    resolution: {integrity: sha512-a8wpwOPo6HsYyRndn17C88mNzeQD6t17yhZ8qpyFWTxj5jQeWtXDj+zJfnuT8++5A4LaNeNAnKs1edVWuadNdQ==}
+  deslop-js@0.8.3:
+    resolution: {integrity: sha512-axNV/iX3Zq9xt0MYesmbBGxneeeY/HrYgXTsaM4+GOrdxXP9JyCfTdC4j8zx09bBML94oSIpFNyn9U1f0oEPqQ==}
 
   detect-file@1.0.0:
     resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
@@ -7260,8 +7257,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.8.1:
-    resolution: {integrity: sha512-ETjgoKrY0EYpK51BsbvgpWySkWaLgJ6z7yB/BfOosi+TUY4+GiDmhWfjJCeul+tpDJEFKR5MnpENjlUrmtZ5Dw==}
+  oxlint-plugin-react-doctor@0.8.3:
+    resolution: {integrity: sha512-S1Gq1H9+BpziApWcZ/sWPNYYy1FMkFmtSEGiqIJ4/Aac76LfkeutPFtSRlkJF1JlcrbYFf7LXcfcxZCJgmVBBQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.25.0:
@@ -7574,8 +7571,8 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.8.1:
-    resolution: {integrity: sha512-lP/MaS7dDMeVFpWBjh8qYp6NYcb/1TmsAwSixqkqOI50fea9kfh89fyn+UUAC3vb53FGIqwvDPZIjlJR6BgGAQ==}
+  react-doctor@0.8.3:
+    resolution: {integrity: sha512-FfG7YQKb1yv1UNk2gknZzLAPx6L3RMOhYsYbslr4MSpVMNk5xBHlu9VxjtS0br0DEBWjkZovrf/C1MrchiIzAw==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -8189,9 +8186,6 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
-  timekeeper@2.3.1:
-    resolution: {integrity: sha512-LeQRS7/4JcC0PgdSFnfUiStQEdiuySlCj/5SJ18D+T1n9BoY7PxKFfCwLulpHXoLUFr67HxBddQdEX47lDGx1g==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -13603,7 +13597,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.8.1:
+  deslop-js@0.8.3:
     dependencies:
       '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
@@ -15405,7 +15399,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.59.0
       '@oxfmt/binding-win32-x64-msvc': 0.59.0
 
-  oxlint-plugin-react-doctor@0.8.1:
+  oxlint-plugin-react-doctor@0.8.3:
     dependencies:
       '@typescript-eslint/types': 8.62.0
       eslint-scope: 9.1.2
@@ -15796,19 +15790,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.8.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0))(oxlint-tsgolint@0.25.0):
+  react-doctor@0.8.3(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0))(oxlint-tsgolint@0.25.0):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.62.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.8.1
+      deslop-js: 0.8.3
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.25.0)
-      oxlint-plugin-react-doctor: 0.8.1
+      oxlint-plugin-react-doctor: 0.8.3
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -15877,7 +15871,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.8.1(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0))(oxlint-tsgolint@0.25.0)
+      react-doctor: 0.8.3(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0))(oxlint-tsgolint@0.25.0)
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:
@@ -16585,8 +16579,6 @@ snapshots:
       - react-native-b4a
 
   through@2.3.8: {}
-
-  timekeeper@2.3.1: {}
 
   tiny-invariant@1.3.3: {}
 


### PR DESCRIPTION
## Summary

## Type

- Feature

### Summarize concisely:

#### What is expected?

Users are able to use a `dateRange` filter using a `DateInput` component

#### How to test

Check the dates range fields in the stories:
- [Filters/Playground](https://ultravioletjxvhzygy-filterdaterangestorybook.functions.fnc.fr-par.scw.cloud/?path=/story/compositions-filters--playground)
- [Filters/Dates](https://ultravioletjxvhzygy-filterdaterangestorybook.functions.fnc.fr-par.scw.cloud/?path=/story/compositions-filters--dates)

#### The following changes were made:

- add a `FilterDateRange` component
- bind it to the `dateRange` filter type
- add tests
- update the `Dates` story to display a `datetimeRange` and a `dateRange`