### PR TITLE
fix(FileInput): onChange behavior

### DIFF
--- a/.changeset/six-jars-design.md
+++ b/.changeset/six-jars-design.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`FileInput`: add more file check to ensure an `undefined` object is not added to dataTransfer (onChange behavior)

--- a/packages/ui/src/components/FileInput/index.tsx
+++ b/packages/ui/src/components/FileInput/index.tsx
@@ -138,7 +138,10 @@ const FileInputBase = ({
       }),
     )
 
-    const formattedFiles = computedMultiple ? [...files, ...formattedNewFiles] : [formattedNewFiles[0]]
+    const formattedFiles = (computedMultiple ? [...files, ...formattedNewFiles] : [formattedNewFiles[0]]).filter(
+      Boolean,
+    )
+
     setFiles(formattedFiles)
     onChangeFiles?.(formattedFiles)
 


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?

`FileInput`: add more file check to ensure an `undefined` object is not added to dataTransfer (onChange behavior).

There were instances where `[formattedNewFiles[0]` returned `[undefined]` instead of `[]` which then caused an error when doing `dataTransfer.items.add()`