### PR TITLE
feat(Filters): add a `displayThreshold` config

### DIFF
--- a/.changeset/tall-ads-dig.md
+++ b/.changeset/tall-ads-dig.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+`Filters` add a `displayThreshold` config to choose the number of options below which the Select/MultiSelect renders as a Radio/Checkbox Group.

--- a/packages/ui/src/compositions/Filters/__stories__/Usage.mdx
+++ b/packages/ui/src/compositions/Filters/__stories__/Usage.mdx
@@ -30,6 +30,28 @@ Filters allow you to filter items based on various criteria. The component allow
 6. **Number (`number`)** : Allows filtering by a number value.
 7. **Datetime Range (`datetimeRange`)** : Allows filtering by a date range.
 
+### Select and Multi-select display
+
+When a `select` or `multiselect` filter is displayed in the drawer, the options are rendered as a `RadioGroup` or `CheckboxGroup` instead of a dropdown when their count is below a threshold. This provides a better UX for small lists.
+
+- The default threshold is **5** options. It can be overridden per filter with the `displayThreshold` config property.
+- When the options are **grouped** (provided as an object instead of an array), the dropdown is always kept regardless of the number of options.
+- When a `selectAll` config is provided on a `multiselect` filter, the dropdown is always kept so the "select all" action stays available.
+
+```typescript
+{
+  type: 'select',
+  name: 'status',
+  label: 'Status',
+  // Render as a RadioGroup in the drawer unless there are 8+ options
+  displayThreshold: 8,
+  options: [
+    { label: 'Active', value: 'active' },
+    { label: 'Inactive', value: 'inactive' },
+  ],
+}
+```
+
 ### Custom Filter Types
 
 Any string can be used for a filter type, allowing to render custom filter components that will have to be provided. See [custom field components](#custom-field-components).

--- a/packages/ui/src/compositions/Filters/__stories__/demo.config.ts
+++ b/packages/ui/src/compositions/Filters/__stories__/demo.config.ts
@@ -55,12 +55,14 @@ export const demoFilters: FilterConfig<FilterValues>[] = [
         name: 'env',
         label: 'Environment',
         placeholder: 'Select environment',
+        selectAll: {
+          label: 'All Environments',
+        },
         options: [
           { label: 'Production', value: 'prod' },
           { label: 'Development', value: 'dev' },
           { label: 'Staging', value: 'staging' },
         ],
-        searchable: true,
       },
     ],
   },

--- a/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
+++ b/packages/ui/src/compositions/Filters/__tests__/index.test.tsx
@@ -326,4 +326,132 @@ describe('filters', () => {
     expect(onSubmit).toHaveBeenCalledExactlyOnceWith(defaultValues)
     expect(screen.getByRole('textbox', { name: 'Name' })).toHaveValue('')
   })
+
+  describe('select and multiselect display threshold', () => {
+    const fiveOptions = Array.from({ length: 5 }, (_, i) => ({
+      label: `Option ${i}`,
+      value: `option-${i}`,
+    }))
+
+    const openDrawer = async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'All filters' }))
+    }
+
+    it('should render a select as a dropdown in the drawer when options reach the default threshold', async () => {
+      renderWithTheme(
+        <Filters
+          config={[
+            {
+              type: 'select',
+              name: 'status',
+              label: 'Status',
+              options: fiveOptions,
+            },
+          ]}
+          defaultValues={{ status: '' }}
+          labels={labels}
+          layout={{ mainFilters: [] }}
+        />,
+      )
+
+      await openDrawer()
+
+      expect(screen.getByTestId('select-input-status')).toBeVisible()
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+    })
+
+    it('should render a multiselect as a dropdown in the drawer when options reach the default threshold', async () => {
+      renderWithTheme(
+        <Filters
+          config={[
+            {
+              type: 'multiselect',
+              name: 'env',
+              label: 'Environment',
+              options: fiveOptions,
+            },
+          ]}
+          defaultValues={{ env: [] }}
+          labels={labels}
+          layout={{ mainFilters: [] }}
+        />,
+      )
+
+      await openDrawer()
+
+      expect(screen.getByTestId('select-input-env')).toBeVisible()
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    })
+
+    it('should render a select as a RadioGroup when below the configured displayThreshold', async () => {
+      renderWithTheme(
+        <Filters
+          config={[
+            {
+              type: 'select',
+              name: 'status',
+              label: 'Status',
+              displayThreshold: 10,
+              options: fiveOptions,
+            },
+          ]}
+          defaultValues={{ status: '' }}
+          labels={labels}
+          layout={{ mainFilters: [] }}
+        />,
+      )
+
+      await openDrawer()
+
+      expect(screen.queryByTestId('select-input-status')).not.toBeInTheDocument()
+      expect(screen.getAllByRole('radio')).toHaveLength(fiveOptions.length)
+    })
+
+    it('should always render grouped options as a dropdown regardless of the threshold', async () => {
+      renderWithTheme(
+        <Filters
+          config={[
+            {
+              type: 'multiselect',
+              name: 'env',
+              label: 'Environment',
+              options: { group: fiveOptions },
+            },
+          ]}
+          defaultValues={{ env: [] }}
+          labels={labels}
+          layout={{ mainFilters: [] }}
+        />,
+      )
+
+      await openDrawer()
+
+      expect(screen.getByTestId('select-input-env')).toBeVisible()
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    })
+
+    it('should keep the multiselect as a dropdown when a selectAll config is provided', async () => {
+      renderWithTheme(
+        <Filters
+          config={[
+            {
+              type: 'multiselect',
+              name: 'env',
+              label: 'Environment',
+              selectAll: { label: 'All Environments' },
+              options: fiveOptions,
+            },
+          ]}
+          defaultValues={{ env: [] }}
+          labels={labels}
+          layout={{ mainFilters: [] }}
+        />,
+      )
+
+      await openDrawer()
+
+      expect(screen.getByTestId('select-input-env')).toBeVisible()
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/ui/src/compositions/Filters/filterTypes/FilterMultiSelect.tsx
+++ b/packages/ui/src/compositions/Filters/filterTypes/FilterMultiSelect.tsx
@@ -26,7 +26,12 @@ export const FilterMultiSelect = <V extends AnyObject>({
     [values, configOptions],
   )
 
-  if (directionContext === 'column' && Array.isArray(options) && options.length < SELECT_DISPLAY_THRESHOLD) {
+  if (
+    directionContext === 'column' &&
+    Array.isArray(options) &&
+    !config.selectAll &&
+    options.length < (config.displayThreshold ?? SELECT_DISPLAY_THRESHOLD)
+  ) {
     return (
       <CheckboxGroup
         description={hideLabel ? undefined : <Label>{config.label}</Label>}

--- a/packages/ui/src/compositions/Filters/filterTypes/FilterSelect.tsx
+++ b/packages/ui/src/compositions/Filters/filterTypes/FilterSelect.tsx
@@ -4,7 +4,7 @@ import { RadioGroup } from '../../../components/RadioGroup'
 import { SelectInput } from '../../../components/SelectInput'
 import type { FilterConfigItemSelect, AnyObject, FilterComponentProps } from '../types'
 
-export const SELECT_DISPLAY_THRESHOLD = 10
+export const SELECT_DISPLAY_THRESHOLD = 5
 
 type FilterSelectProps<Values extends AnyObject> = FilterComponentProps<string, FilterConfigItemSelect, Values>
 
@@ -23,7 +23,11 @@ export const FilterSelect = <V extends AnyObject>({
     [values, configOptions],
   )
 
-  if (directionContext === 'column' && Array.isArray(options) && options.length < SELECT_DISPLAY_THRESHOLD) {
+  if (
+    directionContext === 'column' &&
+    Array.isArray(options) &&
+    options.length < (config.displayThreshold ?? SELECT_DISPLAY_THRESHOLD)
+  ) {
     return (
       <RadioGroup
         description={hideLabel ? undefined : <Label>{config.label}</Label>}

--- a/packages/ui/src/compositions/Filters/types.ts
+++ b/packages/ui/src/compositions/Filters/types.ts
@@ -16,7 +16,13 @@ export type FilterConfigItemBase = {
   name: string
   label: string
   placeholder?: string
+  /**
+   * When true, the filter/group will not be displayed in the Drawer. Make sure it appears in the main row.
+   */
   hideInDrawer?: boolean
+  /**
+   * Expand/collapse the filter/group in the Drawer
+   */
   expanded?: boolean
 }
 
@@ -38,6 +44,13 @@ export type FilterConfigItemSelect<V extends AnyObject = AnyObject> = FilterConf
     | ComponentProps<typeof SelectInput>['options']
     | ((values: V) => ComponentProps<typeof SelectInput>['options'])
   clearable?: boolean
+  /**
+   * When the filter is displayed in the Drawer, the
+   * options are rendered as a RadioGroup if their count is below this threshold.
+   * Grouped options always render as a Select.
+   * @default 5
+   */
+  displayThreshold?: number
 }
 
 export type FilterConfigItemMultiSelect<V extends AnyObject = AnyObject> = FilterConfigItemBase &
@@ -46,6 +59,13 @@ export type FilterConfigItemMultiSelect<V extends AnyObject = AnyObject> = Filte
     options:
       | ComponentProps<typeof SelectInput>['options']
       | ((values: V) => ComponentProps<typeof SelectInput>['options'])
+    /**
+     * When the filter is displayed in the Drawer, the
+     * options are rendered as a CheckboxGroup if their count is below this
+     * threshold. Grouped options or a `selectAll` config always render as a MultiSelect.
+     * @default 5
+     */
+    displayThreshold?: number
   }
 
 export type FilterConfigItemSlider = FilterConfigItemBase &


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:


#### What is expected?

- update the conditions to display a radio/checkbox group instead of a select / multiselect in the Filters Drawer:
  - display the radio/checkbox if there is < 5 options instead of < 10
  - if there is a selectAll (multiselect), or the options are grouped, we always keep the select / multiselect
- add a `displayThreshold` in the config to allow overriding this threshold