### PR TITLE
chore(renovate): group all non-major devDependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,8 +13,7 @@
     "**/bower_components/**",
     "**/vendor/**",
     "**/__tests__/**",
-    "**/__fixtures__/**",
-    "**/examples/**"
+    "**/__fixtures__/**"
   ],
   "prConcurrentLimit": 5,
   "reviewers": ["team:console"],
@@ -24,6 +23,12 @@
     {
       "matchDepTypes": ["engines", "peerDependencies"],
       "rangeStrategy": "widen"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major devDependencies",
+      "groupSlug": "non-major-dev-deps"
     },
     {
       "matchDepTypes": ["dependencies"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
     },
     {
       "extends": ["packages:linters"],
-      "matchPackageNames": ["oxfmt", "publint", "lint-staged"],
+      "matchPackageNames": ["/oxfmt/", "/oxlint/", "publint", "lint-staged"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "non-major linters devDependencies",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,26 @@
       "groupSlug": "non-major-dev-deps"
     },
     {
+      "extends": ["packages:linters"],
+      "matchPackageNames": ["oxfmt", "publint", "lint-staged"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major linters devDependencies",
+      "groupSlug": "non-major-linters-dev-deps"
+    },
+    {
+      "extends": ["packages:jsUnitTest"],
+      "matchPackageNames": ["happy-dom", "jsdom"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major tests devDependencies",
+      "groupSlug": "non-major-tests-dev-deps"
+    },
+    {
+      "matchPackageNames": ["/storybook/"],
+      "groupName": "storybook"
+    },
+    {
       "matchDepTypes": ["dependencies"],
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
@@ -51,17 +71,15 @@
     },
     {
       "matchPackageNames": ["/^@uiw//"],
-      "groupName": "Code Editor",
-      "groupSlug": "uiw-code-editor-react"
+      "groupName": "CodeMirror",
+      "groupSlug": "codemirror"
     },
     {
       "matchPackageNames": ["/^@testing-library/"],
-      "groupName": "Testing library",
-      "groupSlug": "testing-library",
       "semanticCommitScope": "devDeps"
     },
     {
-      "matchPackageNames": ["/^prosemirror-/", "@handlewithcare/react-prosemirror"],
+      "matchPackageNames": ["/prosemirror/"],
       "groupName": "ProseMirror",
       "groupSlug": "prosemirror"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,8 @@
     {
       "matchPackageNames": ["/^@testing-library/"],
       "groupName": "Testing library",
-      "groupSlug": "testing-library"
+      "groupSlug": "testing-library",
+      "semanticCommitScope": "devDeps"
     },
     {
       "matchPackageNames": ["/^prosemirror-/", "@handlewithcare/react-prosemirror"],


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

#### What is expected?

fewer renovate PRs

#### The following changes were made:

- remove examples from ignores to avoid manypkg error with versions mismatch
- add a rule to group non-major devDependencies to have fewer PRs 