### PR TITLE
fix(Status): missing position relative causing issue on animated Status

### DIFF
--- a/.changeset/tender-kiwis-pick.md
+++ b/.changeset/tender-kiwis-pick.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Status`: missing position relative causing issue on animated Status

--- a/packages/ui/src/components/Status/styles.css.ts
+++ b/packages/ui/src/components/Status/styles.css.ts
@@ -49,6 +49,7 @@ const status = recipe({
     display: 'flex',
     height: HEIGHT,
     width: WIDTH,
+    position: 'relative',
   },
   variants: {
     notification: {


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

The Status animated works correctly in all contexts

#### The following changes were made:

add a `position: relative` on the parent span to avoid positioning issues when the component is in a scroll container and the first parent with position != static is an ancestor of the scroll container (cf screenshot)


## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="167" height="155" alt="image" src="https://github.com/user-attachments/assets/2c974778-a3b6-47d4-b0dc-6a6b70196376" /> | <img width="144" height="120" alt="image" src="https://github.com/user-attachments/assets/26e319c2-49ae-4522-832b-1c19a7b57dbe" /> |