### PR TITLE
fix: fix error "CSS.supports is not a function" in tests

### DIFF
--- a/.changeset/gold-trains-stick.md
+++ b/.changeset/gold-trains-stick.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+fix error "CSS.supports is not a function" in tests

--- a/packages/ui/src/components/TextArea/index.tsx
+++ b/packages/ui/src/components/TextArea/index.tsx
@@ -129,7 +129,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     // native automatic resize
     useEffect(() => {
-      if (textAreaRef.current && window.CSS && CSS.supports('field-sizing', 'content')) {
+      if (textAreaRef.current && CSS?.supports?.('field-sizing', 'content')) {
         textAreaRef.current.style.fieldSizing = rows === 'auto' ? 'content' : 'fixed'
       }
     }, [rows])

--- a/utils/test/src/vitest/setup.ts
+++ b/utils/test/src/vitest/setup.ts
@@ -40,7 +40,6 @@ export const setup = () => {
 
     window.ResizeObserver = vi.fn().mockImplementation(MockResize)
     window.matchMedia = vi.fn().mockImplementation(MockMatchMedia)
-    window.CSS.supports = vi.fn().mockReturnValue(false)
 
     if (!globalThis.navigator.clipboard) {
       // @ts-expect-error mock clipboard API


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

No error in tests without having to mock CSS.supports

#### The following changes were made:

add guard to avoid error if CSS.supports is not defined