### PR TITLE
fix(Modal): don't close the modal when clicking on the dialog element and releasing on the backdrop

### DIFF
--- a/.changeset/eleven-jobs-dance.md
+++ b/.changeset/eleven-jobs-dance.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Modal`: don't close the modal when clicking on the dialog element and releasing on the backdrop

--- a/packages/ui/src/components/Modal/__tests__/index.test.tsx
+++ b/packages/ui/src/components/Modal/__tests__/index.test.tsx
@@ -288,42 +288,117 @@ describe('modal', () => {
     expect(mockOnClose).not.toHaveBeenCalled()
   })
 
-  it('test hideOnClickOutside is true', async () => {
-    const mockOnClose = vi.fn(() => {})
+  it('should close when clicking on the backdrop with hideOnClickOutside', async () => {
+    const mockOnBeforeClose = vi.fn(() => {})
     renderWithTheme(
       <Modal
         ariaLabel="modal-test"
         data-testid="test"
+        disclosure={<button type="button">Open</button>}
         hideOnClickOutside
-        id="modal-test"
-        onBeforeClose={mockOnClose}
-        open
+        onBeforeClose={mockOnBeforeClose}
       >
-        <div> test</div>
+        <div>test</div>
       </Modal>,
     )
-    await userEvent.click(screen.getByRole('dialog'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    const dialog = screen.queryByRole('dialog')
+    expect(dialog).toBeVisible()
+
     await userEvent.click(screen.getByTestId('test-backdrop'))
 
-    expect(mockOnClose).toHaveBeenCalledOnce()
+    expect(dialog).not.toBeInTheDocument()
+    expect(mockOnBeforeClose).toHaveBeenCalledOnce()
   })
 
-  it('test hideOnClickOutside is false', async () => {
+  it('should not close when clicking on the backdrop with hideOnClickOutside=false', async () => {
+    const mockOnBeforeClose = vi.fn(() => {})
+    renderWithTheme(
+      <Modal
+        ariaLabel="modal-test"
+        data-testid="test"
+        disclosure={<button type="button">Open</button>}
+        hideOnClickOutside={false}
+        onBeforeClose={mockOnBeforeClose}
+      >
+        <div>test</div>
+      </Modal>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    const dialog = screen.queryByRole('dialog')
+    expect(dialog).toBeVisible()
+
+    await userEvent.click(screen.getByTestId('test-backdrop'))
+
+    expect(dialog).toBeVisible()
+    expect(mockOnBeforeClose).not.toHaveBeenCalled()
+  })
+
+  it('should not close when pointer down starts inside the dialog and releases on the backdrop', async () => {
+    const mockOnBeforeClose = vi.fn(() => {})
     const mockOnClose = vi.fn(() => {})
     renderWithTheme(
       <Modal
         ariaLabel="modal-test"
         data-testid="test"
-        hideOnClickOutside={false}
-        id="modal-test"
-        onBeforeClose={mockOnClose}
-        open
+        disclosure={<button type="button">Open</button>}
+        hideOnClickOutside
+        onBeforeClose={mockOnBeforeClose}
+        onClose={mockOnClose}
       >
-        <div> test</div>
+        <div>test</div>
       </Modal>,
     )
-    await userEvent.click(screen.getByTestId('test-backdrop'))
 
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    const backdrop = screen.getByTestId('test-backdrop')
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeVisible()
+
+    await userEvent.pointer([
+      { target: dialog, keys: '[MouseLeft>]' },
+      { target: backdrop, keys: '[/MouseLeft]' },
+    ])
+
+    expect(dialog).toBeVisible()
     expect(mockOnClose).not.toHaveBeenCalled()
+    expect(mockOnBeforeClose).not.toHaveBeenCalled()
+  })
+
+  it('should not close when pointer down starts on the backdrop and releases inside the dialog', async () => {
+    const mockOnBeforeClose = vi.fn(() => {})
+    const mockOnClose = vi.fn(() => {})
+    renderWithTheme(
+      <Modal
+        ariaLabel="modal-test"
+        data-testid="test"
+        disclosure={<button type="button">Open</button>}
+        hideOnClickOutside
+        onBeforeClose={mockOnBeforeClose}
+        onClose={mockOnClose}
+      >
+        <div>test</div>
+      </Modal>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }))
+
+    const backdrop = screen.getByTestId('test-backdrop')
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeVisible()
+
+    await userEvent.pointer([
+      { target: backdrop, keys: '[MouseLeft>]' },
+      { target: dialog, keys: '[/MouseLeft]' },
+    ])
+
+    expect(dialog).toBeVisible()
+    expect(mockOnClose).not.toHaveBeenCalled()
+    expect(mockOnBeforeClose).not.toHaveBeenCalled()
   })
 })

--- a/packages/ui/src/components/Modal/components/Dialog.tsx
+++ b/packages/ui/src/components/Modal/components/Dialog.tsx
@@ -7,7 +7,7 @@ import type {
   FocusEventHandler,
   KeyboardEvent,
   KeyboardEventHandler,
-  MouseEventHandler,
+  PointerEventHandler,
   ReactEventHandler,
 } from 'react'
 import { createPortal } from 'react-dom'
@@ -124,16 +124,20 @@ export const Dialog = ({
     [hideOnEsc],
   )
 
-  const handleClose: MouseEventHandler = useCallback(
+  const pointerDownTargetRef = useRef<HTMLElement>(null)
+
+  const handlePointerDown: PointerEventHandler = useCallback(event => {
+    pointerDownTargetRef.current = event.target as HTMLElement
+  }, [])
+
+  const handleClose: PointerEventHandler = useCallback(
     event => {
-      // if the user actually click outside of modal
-      if (
-        hideOnClickOutside &&
+      const clickedOutside =
         dialogRef.current &&
-        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-        !dialogRef.current.contains(event.target as Node) &&
-        (isDrawer || position === 0)
-      ) {
+        !dialogRef.current.contains(pointerDownTargetRef.current) &&
+        !dialogRef.current.contains(event.target as HTMLElement)
+
+      if (hideOnClickOutside && clickedOutside && (isDrawer || position === 0)) {
         onCloseRef.current()
       }
     },
@@ -204,7 +208,8 @@ export const Dialog = ({
       className={cn(backdropClassName, modalStyle.backdrop({ open: true, visible: isVisible }))}
       data-testid={dataTestId ? `${dataTestId}-backdrop` : undefined}
       data-visible={isVisible}
-      onClick={handleClose}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handleClose}
       onFocus={stopFocus}
       onKeyDown={() => {}}
     >


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

When pressing the mouse on the dialog and releasing on the backdrop, the Modal shouldn't close.

#### The following changes were made:

- save the pointer position on pointerdown event
- close the modal if the pointer position was outside the dialog when pointer down AND up
- add and update tests
