### PR TITLE
fix(Tag): add max-width

### DIFF
--- a/.changeset/wacky-mice-rule.md
+++ b/.changeset/wacky-mice-rule.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": patch
+---
+
+`Tag`: add `maxWidth` to its wrapper to improve overflow behavior

--- a/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/form/src/components/TagInputField/__tests__/__snapshots__/index.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`tagInputField > should render correctly with regex 1`] = `
             >
               <div
                 class="uv_d6zknp1 uv_toi52u0 uv_toi52u2j"
-                style="--uv_4k0ekn0: fit-content;"
+                style="--uv_4k0ekn0: fit-content; --uv_4k0ekn1: 100%;"
               >
                 <span
                   class="uv_d6zknp4 uv_d6zknp5 uv_d6zknpb uv_d6zknph uv_d6zknp8"
@@ -183,7 +183,7 @@ exports[`tagInputField > should works with defaultValues 1`] = `
             >
               <div
                 class="uv_d6zknp1 uv_toi52u0 uv_toi52u2j"
-                style="--uv_4k0ekn0: fit-content;"
+                style="--uv_4k0ekn0: fit-content; --uv_4k0ekn1: 100%;"
               >
                 <span
                   class="uv_d6zknp4 uv_d6zknp5 uv_d6zknpb uv_d6zknph uv_d6zknp8"

--- a/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/SelectInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -940,7 +940,7 @@ exports[`selectInput > renders correctly multiselect 1`] = `
             >
               <div
                 class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-                style="--_4k0ekn0: fit-content;"
+                style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
               >
                 <span
                   class="selectBar_visible__r8qe4l selectBar__r8qe4j styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"
@@ -2515,7 +2515,7 @@ exports[`selectInput > renders correctly unclosable tags when readonly 1`] = `
             >
               <div
                 class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-                style="--_4k0ekn0: fit-content;"
+                style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
               >
                 <span
                   class="selectBar_visible__r8qe4l selectBar__r8qe4j styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"

--- a/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/Tag/__tests__/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`tag > renders correctly 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -30,7 +30,7 @@ exports[`tag > renders correctly colored 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_primary__d6zknpc styles_isButton_false__d6zknph"
@@ -53,7 +53,7 @@ exports[`tag > renders correctly disabled 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_disabled_true__d6zknp7 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_9__d6zknpr"
@@ -76,7 +76,7 @@ exports[`tag > renders correctly neutral 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -99,7 +99,7 @@ exports[`tag > renders correctly with code variant 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -128,7 +128,7 @@ exports[`tag > renders correctly with copiable and copy button 1`] = `
     >
       <div
         class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-        style="--_4k0ekn0: fit-content;"
+        style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
       >
         <button
           class="styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -172,7 +172,7 @@ exports[`tag > renders correctly with icon 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -210,7 +210,7 @@ exports[`tag > renders correctly with isLoading 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -265,7 +265,7 @@ exports[`tag > renders correctly with key-value variant 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -298,7 +298,7 @@ exports[`tag > renders correctly with onClose 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"
@@ -341,7 +341,7 @@ exports[`tag > renders correctly with onClose and key-value 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"
@@ -394,7 +394,7 @@ exports[`tag > should not close with onClose and disabled 1`] = `
   >
     <div
       class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <span
         class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_disabled_true__d6zknp7 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8 styles_undefined_compound_9__d6zknpr"
@@ -438,7 +438,7 @@ exports[`tag > should not copy with copiable and disabled 1`] = `
   >
     <div
       class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-      style="--_4k0ekn0: fit-content;"
+      style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
     >
       <button
         class="styles_copiable__d6zknp3 styles__d6zknp5 styles_disabled_true__d6zknp7 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_9__d6zknpr"
@@ -467,7 +467,7 @@ exports[`tag > works correctly with copiable - number children 1`] = `
     >
       <div
         class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-        style="--_4k0ekn0: fit-content;"
+        style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
       >
         <button
           class="styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -497,7 +497,7 @@ exports[`tag > works correctly with copiable 1`] = `
     >
       <div
         class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-        style="--_4k0ekn0: fit-content;"
+        style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
       >
         <button
           class="styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -527,7 +527,7 @@ exports[`tag > works correctly with copiable and key-value 1`] = `
     >
       <div
         class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-        style="--_4k0ekn0: fit-content;"
+        style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
       >
         <button
           class="styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"

--- a/packages/ui/src/components/Tag/index.tsx
+++ b/packages/ui/src/components/Tag/index.tsx
@@ -65,7 +65,12 @@ export const Tag = ({
 
   return (
     <Tooltip text={isCopiable ? copyTextTooltip : null}>
-      <Stack direction="row" className={tagStyle.wrapper[copiable ? 'copiable' : 'notCopiable']} width="fit-content">
+      <Stack
+        direction="row"
+        className={tagStyle.wrapper[copiable ? 'copiable' : 'notCopiable']}
+        width="fit-content"
+        maxWidth="100%"
+      >
         <TagInner
           className={cn(
             className,

--- a/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagInput/__tests__/__snapshots__/index.test.tsx.snap
@@ -297,7 +297,7 @@ exports[`tagInput > should renders correctly with some tags 1`] = `
           >
             <div
               class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <span
                 class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"
@@ -331,7 +331,7 @@ exports[`tagInput > should renders correctly with some tags 1`] = `
             </div>
             <div
               class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <span
                 class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"
@@ -401,7 +401,7 @@ exports[`tagInput > should renders correctly with some tags objects 1`] = `
           >
             <div
               class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <span
                 class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"
@@ -435,7 +435,7 @@ exports[`tagInput > should renders correctly with some tags objects 1`] = `
             </div>
             <div
               class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <span
                 class="styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_closable_true__d6zknp8"

--- a/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/TagList/__tests__/__snapshots__/index.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`tagList > hide items after maxLength 1`] = `
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -32,7 +32,7 @@ exports[`tagList > hide items after maxLength 1`] = `
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -47,7 +47,7 @@ exports[`tagList > hide items after maxLength 1`] = `
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -62,7 +62,7 @@ exports[`tagList > hide items after maxLength 1`] = `
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -85,7 +85,7 @@ exports[`tagList > hide items after maxLength 1`] = `
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -100,7 +100,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -115,7 +115,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -130,7 +130,7 @@ exports[`tagList > hide items after maxLength 1`] = `
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -181,7 +181,7 @@ exports[`tagList > renders correctly 1`] = `
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -204,7 +204,7 @@ exports[`tagList > renders correctly 1`] = `
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -255,7 +255,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -270,7 +270,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -285,7 +285,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -300,7 +300,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -315,7 +315,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -338,7 +338,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -353,7 +353,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -368,7 +368,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -383,7 +383,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -398,7 +398,7 @@ exports[`tagList > renders correctly a scrollable popover with non default popov
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -456,7 +456,7 @@ exports[`tagList > renders correctly and add ellipsis to the first tag as it too
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -514,7 +514,7 @@ exports[`tagList > renders correctly and ignore custom threshold as it does not 
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -529,7 +529,7 @@ exports[`tagList > renders correctly and ignore custom threshold as it does not 
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -580,7 +580,7 @@ exports[`tagList > renders correctly when maxLength is smaller than first tag 1`
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -603,7 +603,7 @@ exports[`tagList > renders correctly when maxLength is smaller than first tag 1`
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -646,7 +646,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
         >
           <div
             class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <button
               class="styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -668,7 +668,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
         >
           <div
             class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <button
               class="ellipsed styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -698,7 +698,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
           >
             <div
               class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <button
                 class="styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -720,7 +720,7 @@ exports[`tagList > renders correctly with copiable 1`] = `
           >
             <div
               class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <button
                 class="styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -758,7 +758,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -773,7 +773,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -796,7 +796,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -811,7 +811,7 @@ exports[`tagList > renders correctly with custom threshold 1`] = `
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -848,7 +848,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -863,7 +863,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -886,7 +886,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -901,7 +901,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags 1`] = 
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -952,7 +952,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -975,7 +975,7 @@ exports[`tagList > renders correctly with custom threshold and extra tags and ma
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -1032,7 +1032,7 @@ exports[`tagList > renders correctly with icons 1`] = `
         >
           <div
             class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <button
               class="styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -1054,7 +1054,7 @@ exports[`tagList > renders correctly with icons 1`] = `
         >
           <div
             class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <button
               class="ellipsed styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -1084,7 +1084,7 @@ exports[`tagList > renders correctly with icons 1`] = `
           >
             <div
               class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <button
                 class="styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -1106,7 +1106,7 @@ exports[`tagList > renders correctly with icons 1`] = `
           >
             <div
               class="styles_copiable__d6zknp0 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <button
                 class="styles__1f9zr5y5 styles_copiable__d6zknp3 styles__d6zknp5 styles_copiable_true__d6zknp6 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph styles_undefined_compound_2__d6zknpk"
@@ -1144,7 +1144,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -1159,7 +1159,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
         </div>
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -1182,7 +1182,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -1197,7 +1197,7 @@ exports[`tagList > renders correctly with multiline 1`] = `
           </div>
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -1276,7 +1276,7 @@ exports[`tagList > renders correctly with placement 1`] = `
       >
         <div
           class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-          style="--_4k0ekn0: fit-content;"
+          style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
         >
           <span
             class="ellipsed styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -1299,7 +1299,7 @@ exports[`tagList > renders correctly with placement 1`] = `
         >
           <div
             class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-            style="--_4k0ekn0: fit-content;"
+            style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
           >
             <span
               class="styles__1f9zr5y5 styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"

--- a/packages/ui/src/compositions/Conversation/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/compositions/Conversation/__tests__/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`conversation > should work with Default 1`] = `
             </div>
             <div
               class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <span
                 class="styles__18j62h6c styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"
@@ -67,7 +67,7 @@ exports[`conversation > should work with Default 1`] = `
             </div>
             <div
               class="styles_notCopiable__d6zknp1 styles__toi52u0 styles_flexDirection_row_xxsmall__toi52u2j"
-              style="--_4k0ekn0: fit-content;"
+              style="--_4k0ekn0: fit-content; --_4k0ekn1: 100%;"
             >
               <span
                 class="styles__18j62h6c styles_notCopiable__d6zknp4 styles__d6zknp5 styles_sentiment_neutral__d6zknpb styles_isButton_false__d6zknph"


### PR DESCRIPTION
## Summary

## Type

- Bug


### Summarize concisely:

#### What is expected?

`Tag`: add `maxWidth` to its wrapper to improve overflow behavior

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| in `InfoTable`  |<img width="225" height="76" alt="before" src="https://github.com/user-attachments/assets/ff0b7b06-c658-46a5-888e-52af2485bfe8" /> |<img width="225" height="76" alt="after" src="https://github.com/user-attachments/assets/37e0098a-e367-4bc3-96f0-58466abff215" /> |

