### PR TITLE
ci: optimise Storybook deployment job, fix CI caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: /tmp/.buildx-cache
+          path: /tmp/docs/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
@@ -176,6 +176,7 @@ jobs:
           SOURCE_DATE_EPOCH: 0
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
         with:
+          context: .
           push: true
           tags: ${{ env.IMAGE }}
           file: Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
           node-version-file: .nvmrc
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
-      - run: pnpm run build:storybook
+      - run: pnpm turbo build:storybook
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -51,6 +50,7 @@ jobs:
 
   build_examples:
     runs-on: ubuntu-24.04
+    needs: [build]
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_CACHE: 'remote:rw'
@@ -252,8 +252,10 @@ jobs:
   e2e:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
+    needs: [build]
     env:
       CI: true
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_CACHE: 'remote:rw'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm run build:storybook
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: storybook-static
+          path: storybook-static/
 
   build_examples:
     runs-on: ubuntu-24.04
@@ -115,7 +120,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-24.04
-    needs: [static-checks, build]
+    needs: [build_storybook]
     env:
       IMAGE_NAME: rg.fr-par.scw.cloud/ultraviolet/storybook
       DEPLOYMENT_NAME: 'storybook'
@@ -126,6 +131,11 @@ jobs:
       base_url: ${{ steps.deploy.outputs.url }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download Storybook build artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: storybook-static
+          path: storybook-static/
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@ef93b2ea4b6405d06fd8684fc3ff795d262ecae8 # v5.7.0
       - name: Export custom variables
@@ -239,9 +249,8 @@ jobs:
           mv /tmp/docs/.buildx-cache-new /tmp/docs/.buildx-cache
 
   e2e:
-    timeout-minutes: 20
+    timeout-minutes: 10
     runs-on: ubuntu-24.04
-    needs: [static-checks]
     env:
       CI: true
       TURBO_CACHE: 'remote:rw'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,7 @@
-FROM node:24.18.1-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS builder
-WORKDIR /build
-
-ARG TURBO_TOKEN=token
-
-ENV TURBO_TOKEN ${TURBO_TOKEN}
-
-COPY . .
-
-RUN npm install -g corepack@0.35.0
-RUN corepack enable
-RUN pnpm install --frozen-lockfile
-RUN pnpm turbo run build:storybook
-
-FROM node:24.18.1-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3 AS runner
+FROM node:24.18.1-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3
 WORKDIR /app
 
-COPY --from=builder /build/storybook-static ./storybook-static
+COPY ./storybook-static ./storybook-static
 
 EXPOSE 80/tcp
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -47,5 +47,4 @@ export default defineConfig({
     url: baseURL,
     reuseExistingServer: !isCI,
   },
-  workers: isCI ? 1 : undefined,
 })


### PR DESCRIPTION
## Summary

## Type

- Enhancement

### Summarize concisely:

#### What is expected?

CI pipeline ~25% faster

#### The following changes were made:

- reuse the storybook build from the previous job instead of rebuilding everything in the docker image
- run jobs that depend on build after the build to have a hot turbo cache
- fix broken caches (e2e, docker)
- remove the constraint of 1 worker on the playwright config

## Relevant logs and/or screenshots

| Page |   Before   |      After |
| :--- | :--------: | ---------: |
| url  | <img width="2194" height="969" alt="image" src="https://github.com/user-attachments/assets/d9a383cf-1b64-43be-99a0-51fa38bc0f9a" /> | <img width="2194" height="1209" alt="image" src="https://github.com/user-attachments/assets/a79c94d1-93c5-4fc5-9b64-33787ee8d92e" /> |
