### PR TITLE
feat(VisuallyHidden): new component

### DIFF
--- a/.changeset/long-readers-like.md
+++ b/.changeset/long-readers-like.md
@@ -1,0 +1,5 @@
+---
+"@ultraviolet/ui": minor
+---
+
+New component `VisuallyHidden`: use this component to visually hide content while leaving it available to screen readers. It is preferred to `aria-label` for accessible labels.

--- a/packages/ui/src/components/VisuallyHidden/__stories__/A11y.mdx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/A11y.mdx
@@ -1,0 +1,42 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="UI/Other/VisuallyHidden/A11y" />
+
+# VisuallyHidden - Accessibility
+
+## Description
+
+A utility component that hides content visually while keeping it accessible to screen readers. Uses CSS positioning and clipping to hide elements from sighted users while maintaining their presence in the accessibility tree. Commonly used for accessible labels, skip links, and providing context to icon-only elements.
+
+## Summary
+
+1. ✅ **Perceivable**: Content remains available to assistive technologies while visually hidden
+2. ✅ **Operable**: Focus states make content visible when focused or active, supporting keyboard navigation
+3. ✅ **Understandable**: Content structure and relationships are preserved in the accessibility tree
+4. ✅ **Robust**: Uses standard HTML elements and CSS, compatible with all assistive technologies
+
+## ARIA Pattern
+
+No specific ARIA pattern for this utility component. It supports implementation of various ARIA patterns by providing accessible hidden text.
+
+## Rules
+
+Enforced by the component:
+
+- ✅ [WCAG 1.1.1 - Non-text Content (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html) - Provides text alternatives for non-text content (icons, images)
+- ✅ [WCAG 1.3.1 - Info and Relationships (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) - Preserves information structure for assistive technologies
+- ✅ [WCAG 2.4.3 - Focus Order (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html) - Maintains logical focus order; content becomes visible on focus
+- ✅ [WCAG 4.1.2 - Name, Role, Value (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html) - Does not interfere with accessible name computation
+
+To apply when using the component:
+
+- [WCAG 2.4.1 - Bypass Blocks (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html) - When used for skip links, ensure proper placement at page top
+- [WCAG 1.4.1 - Use of Color (Level A)](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html) - Ensure information is not conveyed by color alone when visible on focus
+
+## Accessibility issues
+
+None
+
+## Dependencies
+
+None

--- a/packages/ui/src/components/VisuallyHidden/__stories__/Example.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/Example.stories.tsx
@@ -1,0 +1,28 @@
+import type { StoryFn } from '@storybook/react-vite'
+import { PlusIcon } from '@ultraviolet/icons'
+import { VisuallyHidden } from '..'
+import { Button } from '../../Button'
+import { Stack } from '../../Stack'
+import { TextInput } from '../../TextInput'
+
+export const Example: StoryFn<typeof VisuallyHidden> = props => (
+  <Stack gap={2} width="fit-content">
+    <Button>
+      <PlusIcon aria-hidden />
+      <VisuallyHidden>Add to cart</VisuallyHidden>
+    </Button>
+    <TextInput placeholder="John Doe" aria-labelledby="hc_ex_uv" />
+    <VisuallyHidden {...props} id="hc_ex_uv">
+      Full Name
+    </VisuallyHidden>
+  </Stack>
+)
+
+Example.parameters = {
+  docs: {
+    description: {
+      story:
+        'This component can be use to correctly label elements without a clear label: icon-only buttons, inputs without label (do not forget to add `aria-labelledBy`), etc.',
+    },
+  },
+}

--- a/packages/ui/src/components/VisuallyHidden/__stories__/FocusableChildren.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/FocusableChildren.stories.tsx
@@ -5,7 +5,7 @@ import { Stack } from '../../Stack'
 
 export const FocusableChildren: StoryFn<typeof VisuallyHidden> = props => (
   <Stack gap={2} width="fit-content">
-    Tab to to focus on VisuallyHidden content
+    Tab to focus on VisuallyHidden content
     <VisuallyHidden {...props} as="p">
       With a link in child:
       <Link href="www.scaleway.com">scaleway.com</Link>

--- a/packages/ui/src/components/VisuallyHidden/__stories__/FocusableChildren.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/FocusableChildren.stories.tsx
@@ -1,0 +1,29 @@
+import type { StoryFn } from '@storybook/react-vite'
+import { VisuallyHidden } from '..'
+import { Link } from '../../Link'
+import { Stack } from '../../Stack'
+
+export const FocusableChildren: StoryFn<typeof VisuallyHidden> = props => (
+  <Stack gap={2} width="fit-content">
+    Tab to to focus on VisuallyHidden content
+    <VisuallyHidden {...props} as="p">
+      With a link in child:
+      <Link href="www.scaleway.com">scaleway.com</Link>
+    </VisuallyHidden>
+    <VisuallyHidden {...props} tabIndex={0}>
+      With tabIndex. It can be used for skip links.
+    </VisuallyHidden>
+    <VisuallyHidden {...props} as="button" onClick={() => alert('clicked')}>
+      As a focusable element. It can also be used for skip links.
+    </VisuallyHidden>
+  </Stack>
+)
+
+FocusableChildren.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the `as` prop is a focusable element (e.g., `a`, `button`) or when `tabIndex` is set, the VisuallyHidden content becomes visible on focus. This is useful for "skip links" or other accessibility patterns where content should only appear when focused.',
+    },
+  },
+}

--- a/packages/ui/src/components/VisuallyHidden/__stories__/Playground.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/Playground.stories.tsx
@@ -1,0 +1,7 @@
+import { Template } from './Template.stories'
+
+export const Playground = Template.bind({})
+
+Playground.args = {
+  children: 'Hidden text',
+}

--- a/packages/ui/src/components/VisuallyHidden/__stories__/Role.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/Role.stories.tsx
@@ -1,0 +1,17 @@
+import { Template } from './Template.stories'
+
+export const As = Template.bind({})
+
+As.args = {
+  children: 'Hidden text',
+  as: 'div',
+}
+
+As.parameters = {
+  docs: {
+    description: {
+      story:
+        'You can change the element type using prop `as`. Do not use any interactive element, as the element is not visible.',
+    },
+  },
+}

--- a/packages/ui/src/components/VisuallyHidden/__stories__/Role.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/Role.stories.tsx
@@ -11,7 +11,7 @@ As.parameters = {
   docs: {
     description: {
       story:
-        'You can change the element type using prop `as`. Do not use any interactive element, as the element is not visible.',
+        'You can change the element type using prop `as`. Be careful when using interactive elements (button, a, etc.), as the element is not visible unless focused (via Tab).',
     },
   },
 }

--- a/packages/ui/src/components/VisuallyHidden/__stories__/Template.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/Template.stories.tsx
@@ -1,0 +1,12 @@
+import type { StoryFn } from '@storybook/react-vite'
+import { VisuallyHidden } from '..'
+
+export const Template: StoryFn<typeof VisuallyHidden> = props => (
+  <>
+    Visually hidden content: <VisuallyHidden {...props} />
+  </>
+)
+
+Template.args = {
+  children: 'Hidden text',
+}

--- a/packages/ui/src/components/VisuallyHidden/__stories__/index.stories.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__stories__/index.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta } from '@storybook/react-vite'
+import { VisuallyHidden } from '..'
+
+export default {
+  component: VisuallyHidden,
+  title: 'UI/Other/VisuallyHidden',
+  parameters: {
+    a11yStatus: {
+      perceivable: true,
+      operable: true,
+      understandable: true,
+      robust: true,
+    },
+  },
+} as Meta
+
+export { Playground } from './Playground.stories'
+export { As } from './Role.stories.tsx'
+export { Example } from './Example.stories.tsx'
+export { FocusableChildren } from './FocusableChildren.stories.tsx'

--- a/packages/ui/src/components/VisuallyHidden/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/VisuallyHidden/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,141 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`visuallyHidden > render correct html element 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <button
+      class="styles__u0p5n50"
+    >
+      hidden
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`visuallyHidden > renders correctly with default props 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <span
+      class="styles__u0p5n50"
+    >
+      hidden
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`visuallyHidden > should be visible when focusable (tabIndex) 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <span
+      class="styles__u0p5n50"
+      tabindex="0"
+    >
+      hidden
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`visuallyHidden > should be visible when it is a focusable element 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <button
+      class="styles__u0p5n50"
+    >
+      hidden
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`visuallyHidden > should be visible when it is has focusable element 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <span
+      class="styles__u0p5n50"
+    >
+      <button
+        type="button"
+      >
+        click
+      </button>
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`visuallyHidden > should not be visible 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <span
+      class="styles__u0p5n50"
+    >
+      hidden
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`visuallyHidden > should work to label and describe elements 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="testing"
+  >
+    <button
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="uv_icons_1sbwqkz0 uv_icons_1sbwqkz1 uv_icons_1sbwqkz3 uv_icons_1sbwqkzg uv_icons_1sbwqkz1n"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <title>
+          DownloadIcon
+        </title>
+        <path
+          d="M8.75 2.75a.75.75 0 0 0-1.5 0v5.69L5.03 6.22a.75.75 0 0 0-1.06 1.06l3.5 3.5a.75.75 0 0 0 1.06 0l3.5-3.5a.75.75 0 0 0-1.06-1.06L8.75 8.44z"
+        />
+        <path
+          d="M3.5 9.75a.75.75 0 0 0-1.5 0v1.5A2.75 2.75 0 0 0 4.75 14h6.5A2.75 2.75 0 0 0 14 11.25v-1.5a.75.75 0 0 0-1.5 0v1.5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25z"
+        />
+      </svg>
+      <span
+        class="styles__u0p5n50"
+      >
+        download
+      </span>
+    </button>
+    <input
+      aria-describedby="example_desc"
+      aria-labelledby="example_label"
+    />
+    <span
+      class="styles__u0p5n50"
+      id="example_label"
+    >
+      label
+    </span>
+    <span
+      class="styles__u0p5n50"
+      id="example_desc"
+    >
+      desc
+    </span>
+  </div>
+</DocumentFragment>
+`;

--- a/packages/ui/src/components/VisuallyHidden/__tests__/__snapshots__/index.test.tsx.snap
+++ b/packages/ui/src/components/VisuallyHidden/__tests__/__snapshots__/index.test.tsx.snap
@@ -28,21 +28,6 @@ exports[`visuallyHidden > renders correctly with default props 1`] = `
 </DocumentFragment>
 `;
 
-exports[`visuallyHidden > should be visible when focusable (tabIndex) 1`] = `
-<DocumentFragment>
-  <div
-    data-testid="testing"
-  >
-    <span
-      class="styles__u0p5n50"
-      tabindex="0"
-    >
-      hidden
-    </span>
-  </div>
-</DocumentFragment>
-`;
-
 exports[`visuallyHidden > should be visible when it is a focusable element 1`] = `
 <DocumentFragment>
   <div

--- a/packages/ui/src/components/VisuallyHidden/__tests__/index.test.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__tests__/index.test.tsx
@@ -1,0 +1,135 @@
+import { screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { DownloadIcon } from '@ultraviolet/icons'
+import { renderWithTheme } from '@utils/test'
+import { describe, expect, it, vi } from 'vitest'
+import { VisuallyHidden } from '..'
+
+type TestElement = HTMLElement | SVGElement
+
+/**
+ * Can't use `.toBeVisible` since it checks if it:
+ * - Is present in the DOM;
+ * - Doesn’t have the display CSS property set to none;
+ * - Doesn’t have the opacity CSS property set to 0;
+ * - Doesn’t have the visibility CSS property set to hidden/collapse;
+ * -Doesn’t have the aria-hidden attribute set to true;
+ *
+ * None of this is true in `VisuallyHidden`. So we check if the style is correctly applied instead.
+ *
+ * For visibility, after focus we assert the element receives focus; CSS :focus rules
+ * are not reliably reflected in jsdom computed styles, so testing focus is simpler
+ */
+const expectVisuallyHidden = (element: TestElement) => {
+  const style = window.getComputedStyle(element)
+
+  expect(style.position).toBe('absolute')
+  expect(style.width).toBe('1px')
+  expect(style.height).toBe('1px')
+  expect(style.overflow).toBe('hidden')
+  expect(style.whiteSpace).toBe('nowrap')
+  expect(style.borderTopWidth).toBe('0px')
+  expect(style.paddingTop).toBe('0px')
+}
+
+describe('visuallyHidden', () => {
+  it('renders correctly with default props', () => {
+    const { asFragment } = renderWithTheme(<VisuallyHidden>hidden</VisuallyHidden>)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should not be visible', () => {
+    const { asFragment } = renderWithTheme(<VisuallyHidden>hidden</VisuallyHidden>)
+
+    const element = screen.getByText('hidden', { selector: 'span' })
+    expectVisuallyHidden(element)
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('render correct html element', () => {
+    const { asFragment } = renderWithTheme(<VisuallyHidden as="button">hidden</VisuallyHidden>)
+
+    const element = screen.getByRole('button', { name: 'hidden' })
+
+    expect(element).toBeInTheDocument()
+    expectVisuallyHidden(element)
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should be visible when focusable (tabIndex)', async () => {
+    const { asFragment } = renderWithTheme(<VisuallyHidden tabIndex={0}>hidden</VisuallyHidden>)
+
+    const element = screen.getByText('hidden', { selector: 'span' })
+    expectVisuallyHidden(element)
+
+    await userEvent.tab()
+    await waitFor(() => expect(element).toHaveFocus())
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should be visible when it is a focusable element', async () => {
+    const onClick = vi.fn()
+
+    const { asFragment } = renderWithTheme(
+      <VisuallyHidden as="button" onClick={onClick}>
+        hidden
+      </VisuallyHidden>,
+    )
+
+    const button = screen.getByRole('button', { name: 'hidden' })
+    expectVisuallyHidden(button)
+
+    await userEvent.tab()
+    await waitFor(() => expect(button).toHaveFocus())
+
+    await userEvent.click(button)
+    expect(onClick).toHaveBeenCalledOnce()
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should be visible when it is has focusable element', async () => {
+    const { asFragment } = renderWithTheme(
+      <VisuallyHidden>
+        <button type="button">click</button>
+      </VisuallyHidden>,
+    )
+
+    const button = screen.getByRole('button', { name: 'click' })
+    const wrapper = button.closest('span')
+
+    expect(wrapper).toBeInstanceOf(HTMLSpanElement)
+    expectVisuallyHidden(wrapper as HTMLSpanElement)
+
+    await userEvent.tab()
+    await waitFor(() => expect(button).toHaveFocus())
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('should work to label and describe elements', async () => {
+    const { asFragment } = renderWithTheme(
+      <>
+        <button type="button">
+          <DownloadIcon aria-hidden />
+          <VisuallyHidden>download</VisuallyHidden>
+        </button>
+        <input aria-labelledby="example_label" aria-describedby="example_desc" />
+        <VisuallyHidden id="example_label">label</VisuallyHidden>
+        <VisuallyHidden id="example_desc">desc</VisuallyHidden>
+      </>,
+    )
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveAccessibleName('download')
+
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveAccessibleName('label')
+    expect(input).toHaveAccessibleDescription('desc')
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/packages/ui/src/components/VisuallyHidden/__tests__/index.test.tsx
+++ b/packages/ui/src/components/VisuallyHidden/__tests__/index.test.tsx
@@ -58,18 +58,6 @@ describe('visuallyHidden', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('should be visible when focusable (tabIndex)', async () => {
-    const { asFragment } = renderWithTheme(<VisuallyHidden tabIndex={0}>hidden</VisuallyHidden>)
-
-    const element = screen.getByText('hidden', { selector: 'span' })
-    expectVisuallyHidden(element)
-
-    await userEvent.tab()
-    await waitFor(() => expect(element).toHaveFocus())
-
-    expect(asFragment()).toMatchSnapshot()
-  })
-
   it('should be visible when it is a focusable element', async () => {
     const onClick = vi.fn()
 

--- a/packages/ui/src/components/VisuallyHidden/index.tsx
+++ b/packages/ui/src/components/VisuallyHidden/index.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { cn } from '@ultraviolet/utils'
+import type { ComponentProps, ElementType } from 'react'
+import { visuallyHiddenStyle } from './styles.css'
+
+type VisuallyHiddenProps<T extends ElementType = 'span'> = Omit<ComponentProps<T>, 'as'> & {
+  /**
+   * The element type for the container. By default `span`.
+   * Any focusable element will be displayed when focused
+   */
+  as?: T
+}
+
+export const VisuallyHidden = <T extends ElementType = 'span'>({
+  children,
+  className,
+  as: Component,
+  ...props
+}: VisuallyHiddenProps<T>) => {
+  const ComponentElement = (Component ?? 'span') as ElementType
+  const componentProps = props as ComponentProps<T>
+
+  return (
+    <ComponentElement className={cn(className, visuallyHiddenStyle.visuallyHidden)} {...componentProps}>
+      {children}
+    </ComponentElement>
+  )
+}
+
+VisuallyHidden.displayName = 'VisuallyHidden'

--- a/packages/ui/src/components/VisuallyHidden/index.tsx
+++ b/packages/ui/src/components/VisuallyHidden/index.tsx
@@ -1,31 +1,33 @@
 'use client'
 
 import { cn } from '@ultraviolet/utils'
-import type { ComponentProps, ElementType } from 'react'
+import type { ComponentProps, ElementType, ForwardedRef } from 'react'
+import { createElement, forwardRef } from 'react'
 import { visuallyHiddenStyle } from './styles.css'
 
-type VisuallyHiddenProps<T extends ElementType = 'span'> = Omit<ComponentProps<T>, 'as'> & {
+type VisuallyHiddenProps<T extends ElementType = 'span'> = {
   /**
    * The element type for the container. By default `span`.
    * Any focusable element will be displayed when focused
    */
   as?: T
-}
+} & Omit<ComponentProps<T>, 'as'>
 
-export const VisuallyHidden = <T extends ElementType = 'span'>({
-  children,
-  className,
-  as: Component,
-  ...props
-}: VisuallyHiddenProps<T>) => {
-  const ComponentElement = (Component ?? 'span') as ElementType
-  const componentProps = props as ComponentProps<T>
-
-  return (
-    <ComponentElement className={cn(className, visuallyHiddenStyle.visuallyHidden)} {...componentProps}>
-      {children}
-    </ComponentElement>
-  )
-}
+export const VisuallyHidden = forwardRef(
+  <T extends ElementType = 'span'>(
+    { children, className, as = 'span' as T, ...props }: VisuallyHiddenProps<T>,
+    ref: ForwardedRef<ComponentProps<T>>,
+  ) => {
+    return createElement(
+      as,
+      {
+        className: cn(className, visuallyHiddenStyle.visuallyHidden),
+        ...props,
+        ref,
+      },
+      children,
+    )
+  },
+)
 
 VisuallyHidden.displayName = 'VisuallyHidden'

--- a/packages/ui/src/components/VisuallyHidden/styles.css.ts
+++ b/packages/ui/src/components/VisuallyHidden/styles.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css'
+
+const visuallyHidden = style({
+  selectors: {
+    '&:not(:focus):not(:active):not(:focus-within)': {
+      position: 'absolute',
+      width: 1,
+      height: 1,
+      overflow: 'hidden',
+      clip: 'rect(0 0 0 0)',
+      clipPath: 'inset(50%)',
+      whiteSpace: 'nowrap',
+      border: 0,
+      padding: 0,
+    },
+  },
+})
+
+export const visuallyHiddenStyle = { visuallyHidden }

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -76,5 +76,6 @@ export { Tooltip } from './Tooltip'
 export { TreeMapChart } from './TreeMapChart'
 export { UnitInput } from './UnitInput'
 export { VerificationCode } from './VerificationCode'
+export { VisuallyHidden } from './VisuallyHidden'
 
 export type { OptionType, DataType } from './SelectInput/types'


### PR DESCRIPTION
## Summary

## Type


- Feature

### Summarize concisely:

#### What is expected?
New component `VisuallyHidden`: use this component to visually hide content while leaving it available to screen readers. It is preferred to `aria-label` for accessible labels.
<img width="750" height="312" alt="Capture d’écran 2026-08-06 à 16 56 03" src="https://github.com/user-attachments/assets/b2bb2078-b8d5-4f59-863a-4465f33d481f" />
<img width="272" height="102" alt="Capture d’écran 2026-08-06 à 16 56 09" src="https://github.com/user-attachments/assets/f6244673-da73-4c9b-875e-cb273c9e356a" />
