### PR TITLE
fix: avoid crashing when window.matchMedia or ResizeObserver are not defined (e.g. in tests)

### DIFF
--- a/.changeset/deep-beds-hide.md
+++ b/.changeset/deep-beds-hide.md
@@ -1,0 +1,6 @@
+---
+"@ultraviolet/animations": patch
+"@ultraviolet/ui": patch
+---
+
+avoid crashing when window.matchMedia or ResizeObserver are not defined (e.g. in tests)

--- a/packages/animations/src/hooks/usePrefersReducedMotion.ts
+++ b/packages/animations/src/hooks/usePrefersReducedMotion.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 const QUERY = '(prefers-reduced-motion: no-preference)'
 
@@ -19,11 +19,17 @@ const QUERY = '(prefers-reduced-motion: no-preference)'
  * ```
  */
 export function usePrefersReducedMotion() {
+  const supportsMatchMedia = useMemo(() => typeof window !== 'undefined' && typeof window.matchMedia === 'function', [])
+
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(
-    typeof window === 'undefined' ? true : !window.matchMedia(QUERY).matches,
+    supportsMatchMedia ? !window.matchMedia(QUERY).matches : true,
   )
 
   useEffect(() => {
+    if (!supportsMatchMedia) {
+      return
+    }
+
     const mediaQueryList = window.matchMedia(QUERY)
 
     const listener = (event: MediaQueryListEvent) => {
@@ -34,7 +40,7 @@ export function usePrefersReducedMotion() {
     return () => {
       mediaQueryList.removeEventListener('change', listener)
     }
-  }, [])
+  }, [supportsMatchMedia])
 
   return prefersReducedMotion
 }

--- a/packages/ui/src/components/PieChart/__tests__/index.test.tsx
+++ b/packages/ui/src/components/PieChart/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { renderWithTheme } from '@utils/test'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { PieChart } from '..'
 import {
   data,
@@ -11,15 +11,6 @@ import {
 } from '../__stories__/mockData'
 
 describe('pieChart', () => {
-  beforeAll(() => {
-    // Have to mock ResizeObserver as Nivo doesn't add automatically ResizeObserver polyfill anymore (v0.79.0)
-    window.ResizeObserver = vi.fn().mockReturnValue({
-      disconnect: vi.fn(),
-      observe: vi.fn(),
-      unobserve: vi.fn(),
-    })
-  })
-
   it('renders correctly with no props', () => {
     const { asFragment } = renderWithTheme(<PieChart />)
     expect(asFragment()).toMatchSnapshot()

--- a/packages/ui/src/components/Popup/index.tsx
+++ b/packages/ui/src/components/Popup/index.tsx
@@ -352,6 +352,12 @@ export const Popup = forwardRef(
 
     useLayoutEffect(() => {
       const currentRef = childrenRef.current
+
+      if (typeof ResizeObserver === 'undefined') {
+        generatePopupPositions()
+        return
+      }
+
       const mutationObserver = new MutationObserver(() => {
         generatePopupPositions()
       })

--- a/packages/ui/src/components/SwitchButton/index.tsx
+++ b/packages/ui/src/components/SwitchButton/index.tsx
@@ -76,7 +76,7 @@ export const SwitchButton = ({
 
   useEffect(() => {
     const element = getElement(localValue)
-    if (!element) {
+    if (!element || typeof ResizeObserver === 'undefined') {
       return undefined
     }
 

--- a/utils/test/src/vitest/setup.ts
+++ b/utils/test/src/vitest/setup.ts
@@ -3,27 +3,6 @@ import { cleanup } from '@testing-library/react'
 import { afterEach, beforeEach, expect, vi } from 'vitest'
 import * as axeMatchers from 'vitest-axe/matchers'
 
-const MockResize = vi.fn(function mock() {
-  return {
-    disconnect: vi.fn(),
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-  }
-})
-
-const MockMatchMedia = vi.fn(function mock(query: string): MediaQueryList {
-  return {
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }
-})
-
 // Mock InputEvent.getTargetRanges() for ProseMirror beforeinput plugin
 // jsdom doesn't implement this method, but @handlewithcare/react-prosemirror@3.2.1 requires it
 const MockGetTargetRanges = vi.fn(function mockGetTargetRanges(): StaticRange[] {
@@ -38,8 +17,8 @@ export const setup = () => {
   beforeEach(() => {
     vi.spyOn(globalThis.Math, 'random').mockReturnValue(0.415_591_366_944_480_4)
 
-    window.ResizeObserver = vi.fn().mockImplementation(MockResize)
-    window.matchMedia = vi.fn().mockImplementation(MockMatchMedia)
+    // DON'T mock global browser APIs here because it would force consumer projects to add the same mocks.
+    // Make the components more robust instead.
 
     if (!globalThis.navigator.clipboard) {
       // @ts-expect-error mock clipboard API
@@ -61,6 +40,4 @@ export const setup = () => {
 
     cleanup()
   })
-
-  vi.stubGlobal('ResizeObserver', MockResize)
 }


### PR DESCRIPTION
## Summary

## Type

- Bug

### Summarize concisely:

#### What is expected?

No need to mock ResizeObserver or window.matchMedia in consumer projects

#### The following changes were made:

- remove the mocks in vitest setup
- make the components more robust

